### PR TITLE
feat: add & shift operators for Workflows & Tasks

### DIFF
--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -22,6 +22,9 @@ class Pipeline(StructureWithMemory):
     def finished_tasks(self) -> list[BaseTask]:
         return [s for s in self.tasks if s.is_finished()]
 
+    def __add__(self, other: BaseTask) -> BaseTask:
+        return [self.add_task(o) for o in other] if isinstance(other, list) else self + [other]
+
     def add_task(self, task: BaseTask) -> BaseTask:
         if self.last_task():
             self.last_task().add_child(task)

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -13,6 +13,9 @@ from griptape.utils import J2
 class Workflow(Structure):
     executor: futures.Executor = field(default=futures.ThreadPoolExecutor(), kw_only=True)
 
+    def __add__(self, other: BaseTask) -> BaseTask:
+        return [self.add_task(o) for o in other] if isinstance(other, list) else self + [other]
+
     def add_task(self, task: BaseTask) -> BaseTask:
         task.structure = self
 

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -40,6 +40,12 @@ class BaseTask(ABC):
     def children(self) -> list[BaseTask]:
         return [self.structure.find_task(child_id) for child_id in self.child_ids]
 
+    def __rshift__(self, child: BaseTask) -> BaseTask:
+        return self.add_child(child)
+
+    def __lshift__(self, child: BaseTask) -> BaseTask:
+        return self.add_parent(child)
+
     def add_child(self, child: BaseTask) -> BaseTask:
         if self.structure:
             child.structure = self.structure

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -32,7 +32,7 @@ class TestPipeline:
             memory=Memory()
         )
 
-        pipeline.add_tasks(first_task, second_task, third_task)
+        pipeline + [first_task, second_task, third_task]
 
         assert pipeline.memory is not None
         assert len(pipeline.memory.runs) == 0
@@ -52,9 +52,9 @@ class TestPipeline:
             prompt_driver=MockDriver()
         )
 
-        pipeline.add_task(first_task)
-        pipeline.add_task(second_task)
-        pipeline.add_task(third_task)
+        pipeline + first_task
+        pipeline + second_task
+        pipeline + third_task
 
         assert pipeline.first_task().id is first_task.id
         assert pipeline.tasks[1].id is second_task.id
@@ -69,8 +69,8 @@ class TestPipeline:
             prompt_driver=MockDriver()
         )
 
-        pipeline.add_task(first_task)
-        pipeline.add_task(second_task)
+        pipeline + first_task
+        pipeline + second_task
 
         assert len(pipeline.tasks) == 2
         assert first_task in pipeline.tasks
@@ -90,7 +90,7 @@ class TestPipeline:
             prompt_driver=MockDriver()
         )
 
-        pipeline.add_tasks(first_task, second_task)
+        pipeline + [first_task, second_task]
 
         assert len(pipeline.tasks) == 2
         assert first_task in pipeline.tasks
@@ -110,14 +110,14 @@ class TestPipeline:
         task1 = PromptTask("test")
         task2 = PromptTask("test")
 
-        pipeline.add_task(task1)
+        pipeline + [task1]
 
         # context and first input
         assert len(pipeline.prompt_stack(task1)) == 2
 
         pipeline.run()
 
-        pipeline.add_task(task2)
+        pipeline + [task2]
 
         # context and second input
         assert len(pipeline.prompt_stack(task2)) == 2
@@ -131,14 +131,14 @@ class TestPipeline:
         task1 = PromptTask("test")
         task2 = PromptTask("test")
 
-        pipeline.add_task(task1)
+        pipeline + [task1]
 
         # context and first input
         assert len(pipeline.prompt_stack(task1)) == 2
 
         pipeline.run()
 
-        pipeline.add_task(task2)
+        pipeline + task2
 
         # context, memory, and second input
         assert len(pipeline.prompt_stack(task2)) == 3
@@ -150,7 +150,7 @@ class TestPipeline:
 
         task = PromptTask("test")
 
-        pipeline.add_task(task)
+        pipeline + task
 
         pipeline.run()
 
@@ -164,7 +164,7 @@ class TestPipeline:
     def test_run(self):
         task = PromptTask("test")
         pipeline = Pipeline(prompt_driver=MockDriver())
-        pipeline.add_task(task)
+        pipeline + task
 
         assert task.state == BaseTask.State.PENDING
 
@@ -176,7 +176,7 @@ class TestPipeline:
     def test_run_with_args(self):
         task = PromptTask("{{ args[0] }}-{{ args[1] }}")
         pipeline = Pipeline(prompt_driver=MockDriver())
-        pipeline.add_tasks(task)
+        pipeline + [task]
 
         pipeline._execution_args = ("test1", "test2")
 
@@ -192,7 +192,7 @@ class TestPipeline:
         child = PromptTask("child")
         pipeline = Pipeline(prompt_driver=MockDriver())
 
-        pipeline.add_tasks(parent, task, child)
+        pipeline + [parent, task, child]
 
         context = pipeline.context(task)
 

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -26,8 +26,8 @@ class TestWorkflow:
             prompt_driver=MockDriver()
         )
 
-        workflow.add_task(first_task)
-        workflow.add_task(second_task)
+        workflow + first_task
+        workflow + second_task
 
         assert len(workflow.tasks) == 2
         assert first_task in workflow.tasks
@@ -47,7 +47,7 @@ class TestWorkflow:
             prompt_driver=MockDriver()
         )
 
-        workflow.add_tasks(first_task, second_task)
+        workflow + [first_task, second_task]
 
         assert len(workflow.tasks) == 2
         assert first_task in workflow.tasks
@@ -63,7 +63,7 @@ class TestWorkflow:
         task1 = PromptTask("test")
         task2 = PromptTask("test")
         workflow = Workflow(prompt_driver=MockDriver())
-        workflow.add_tasks(task1, task2)
+        workflow + [task1, task2]
 
         assert task1.state == BaseTask.State.PENDING
         assert task2.state == BaseTask.State.PENDING
@@ -76,7 +76,7 @@ class TestWorkflow:
     def test_run_with_args(self):
         task = PromptTask("{{ args[0] }}-{{ args[1] }}")
         workflow = Workflow(prompt_driver=MockDriver())
-        workflow.add_tasks(task)
+        workflow + task
 
         workflow._execution_args = ("test1", "test2")
 
@@ -93,9 +93,9 @@ class TestWorkflow:
         workflow = Workflow(prompt_driver=MockDriver())
 
         # task1 splits into task2 and task3
-        workflow.add_task(task1)
-        task1.add_child(task2)
-        task3.add_parent(task1)
+        workflow + task1
+        task1 >> task2
+        task3 << task1
 
         workflow.run()
 
@@ -110,9 +110,9 @@ class TestWorkflow:
         workflow = Workflow(prompt_driver=MockDriver())
 
         # task1 and task2 converge into task3
-        workflow.add_tasks(task1, task2)
-        task1.add_child(task3)
-        task3.add_parent(task2)
+        workflow + [task1, task2]
+        task1 >> task3
+        task3 << task2
 
         workflow.run()
 
@@ -126,9 +126,9 @@ class TestWorkflow:
         task3 = PromptTask("prompt3")
         workflow = Workflow(prompt_driver=MockDriver())
 
-        workflow.add_task(task1)
-        task1.add_child(task2)
-        task3.add_parent(task1)
+        workflow + task1
+        task1 >> task2
+        task3 << task1
 
         assert len(workflow.output_tasks()) == 2
         assert task2 in workflow.output_tasks()
@@ -140,9 +140,9 @@ class TestWorkflow:
         task3 = PromptTask("prompt3", id="task3")
         workflow = Workflow(prompt_driver=MockDriver())
 
-        workflow.add_task(task1)
-        task1.add_child(task2)
-        task3.add_parent(task1)
+        workflow + task1
+        task1 >> task2
+        task3 << task1
 
         graph = workflow.to_graph()
 
@@ -155,9 +155,9 @@ class TestWorkflow:
         task3 = PromptTask("prompt3")
         workflow = Workflow(prompt_driver=MockDriver())
 
-        workflow.add_task(task1)
-        task1.add_child(task2)
-        task3.add_parent(task1)
+        workflow + task1
+        task1 >> task2
+        task3 << task1
 
         ordered_tasks = workflow.order_tasks()
 
@@ -171,10 +171,10 @@ class TestWorkflow:
         child = PromptTask("child")
         workflow = Workflow(prompt_driver=MockDriver())
 
-        workflow.add_task(parent)
+        workflow + parent
 
-        parent.add_child(task)
-        task.add_child(child)
+        parent >> task
+        task >> child
 
         context = workflow.context(task)
 


### PR DESCRIPTION
Having used DAG-based Python libraries for very large workflows such as Hera & Argo Workflows I thought the following would be neat to add to griptape.

This PR adds support for `+` for `Worklfows`:

```python
workflow + task == workflow.add_task(task)
```

 and `>>` and `<<` for assembling child/parent task relationships:

```python
task1 >> task2 == task.add_child(task2)
task3 << task4 == task4.add_parent(task3)
```

Lists are also supported for workflow `+`.