### PR TITLE
Suppress transformers pytorch warning

### DIFF
--- a/griptape/__init__.py
+++ b/griptape/__init__.py
@@ -1,1 +1,3 @@
+from os import environ
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+environ["TRANSFORMERS_VERBOSITY"] = "error"


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape/issues/37

This warning happens in [__init__](https://github.com/huggingface/transformers/blob/f49a3453caa6fe606bb31c571423f72264152fce/src/transformers/__init__.py#L7046) so even importing the logging module (to set verbosity) triggers it. Setting the environment variable seems like the best alternative.