### PR TITLE
Update retry logic in BasePromptDriver

### DIFF
--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -6,8 +6,6 @@ from griptape.artifacts import TextArtifact
 
 @define
 class MockFailingPromptDriver(BasePromptDriver):
-    min_retry_delay: int
-    max_retry_delay: int
     max_failures: int = 2
     current_attempt: int = 0
     model: str = "test-model"

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -11,7 +11,7 @@ class MockFailingPromptDriver(BasePromptDriver):
     model: str = "test-model"
     tokenizer: BaseTokenizer = TiktokenTokenizer()
 
-    def try_run(self, **kwargs) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         if self.current_attempt < self.max_failures:
             self.current_attempt += 1
 

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -7,7 +7,7 @@ from griptape.artifacts import TextArtifact
 @define
 class MockFailingPromptDriver(BasePromptDriver):
     min_retry_delay: int
-    min_retry_delay: int
+    max_retry_delay: int
     max_failures: int = 2
     current_attempt: int = 0
     model: str = "test-model"

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -6,7 +6,9 @@ from griptape.artifacts import TextArtifact
 
 @define
 class MockFailingPromptDriver(BasePromptDriver):
-    max_failures: int
+    min_retry_delay: int
+    min_retry_delay: int
+    max_failures: int = 2
     current_attempt: int = 0
     model: str = "test-model"
     tokenizer: BaseTokenizer = TiktokenTokenizer()

--- a/tests/mocks/mock_value_prompt_driver.py
+++ b/tests/mocks/mock_value_prompt_driver.py
@@ -10,5 +10,5 @@ class MockValuePromptDriver(BasePromptDriver):
     model: str = "test-model"
     tokenizer: BaseTokenizer = TiktokenTokenizer()
 
-    def try_run(self, **kwargs) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         return TextArtifact(value=self.value)

--- a/tests/unit/drivers/prompt/test_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_prompt_driver.py
@@ -7,7 +7,7 @@ from griptape.structures import Pipeline
 
 class TestPromptDriver:
     def test_run_retries_success(self):
-        driver = MockPromptDriver(min_retry_delay=2, max_retry_delay=10)
+        driver = MockPromptDriver()
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(
@@ -17,7 +17,7 @@ class TestPromptDriver:
         assert isinstance(pipeline.run().output, TextArtifact)
 
     def test_run_retries_failure(self):
-        driver = MockFailingPromptDriver(min_retry_delay=2, max_retry_delay=10)
+        driver = MockFailingPromptDriver()
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(

--- a/tests/unit/drivers/prompt/test_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_prompt_driver.py
@@ -7,7 +7,7 @@ from griptape.structures import Pipeline
 
 class TestPromptDriver:
     def test_run_retries_success(self):
-        driver = MockPromptDriver(max_retries=1, retry_delay=0.01)
+        driver = MockPromptDriver(min_retry_delay=2, max_retry_delay=10)
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(
@@ -17,7 +17,7 @@ class TestPromptDriver:
         assert isinstance(pipeline.run().output, TextArtifact)
 
     def test_run_retries_failure(self):
-        driver = MockFailingPromptDriver(max_failures=2, max_retries=1, retry_delay=0.01)
+        driver = MockFailingPromptDriver(min_retry_delay=2, max_retry_delay=10)
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(


### PR DESCRIPTION
Using tenacity, updated the BasePromptDriver retry logic.

Tag: [Issue 51](https://github.com/griptape-ai/griptape/issues/51)