### PR TITLE
Fix TiktokenTokenizer is_chat

### DIFF
--- a/griptape/tokenizers/tiktoken_tokenizer.py
+++ b/griptape/tokenizers/tiktoken_tokenizer.py
@@ -59,4 +59,4 @@ class TiktokenTokenizer(BaseTokenizer):
         return self.encoding.decode(tokens)
 
     def is_chat(self) -> bool:
-        return next(p for p in self.CHAT_API_PREFIXES if self.model.startswith(p)) is not None
+        return any(self.model.startswith(p) for p in self.CHAT_API_PREFIXES)


### PR DESCRIPTION
Current code throws an error when trying to run non-chat model prompt:

```py
driver = OpenAiPromptDriver(model="text-davinci-003", api_key=os.environ["OPENAI_API_KEY"])
debug(driver.run(value="Hello!"))
```

```
Traceback (most recent call last):
  File "/[REDACTED]/main.py", line 10, in <module>
    debug(driver.run(value="Hello!"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/[REDACTED]/.venv/lib/python3.11/site-packages/griptape/drivers/prompt/base_prompt_driver.py", line 31, in run
    raise e
  File "/[REDACTED]/.venv/lib/python3.11/site-packages/griptape/drivers/prompt/base_prompt_driver.py", line 24, in run
    return self.try_run(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/[REDACTED]/.venv/lib/python3.11/site-packages/griptape/drivers/prompt/openai_prompt_driver.py", line 32, in try_run
    devtools.debug(self.tokenizer.is_chat())
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/[REDACTED]/.venv/lib/python3.11/site-packages/griptape/tokenizers/tiktoken_tokenizer.py", line 62, in is_chat
    return next(p for p in self.CHAT_API_PREFIXES if self.model.startswith(p)) is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration
```