### PR TITLE
Adding Amazon Redshift SQL Driver

### DIFF
--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -22,6 +22,7 @@ from .vector.local_vector_store_driver import LocalVectorStoreDriver
 from .vector.pinecone_vector_store_driver import PineconeVectorStoreDriver
 
 from .sql.base_sql_driver import BaseSqlDriver
+from .sql.amazon_redshift_sql_driver import AmazonRedshiftSqlDriver
 from .sql.sql_driver import SqlDriver
 
 
@@ -50,5 +51,6 @@ __all__ = [
     "PineconeVectorStoreDriver",
 
     "BaseSqlDriver",
+    "AmazonRedshiftSqlDriver",
     "SqlDriver"
 ]

--- a/griptape/drivers/sql/amazon_redshift_sql_driver.py
+++ b/griptape/drivers/sql/amazon_redshift_sql_driver.py
@@ -13,7 +13,7 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
     workgroup_name: Optional[str] = field(default=None, kw_only=True)
     db_user: Optional[str] = field(default=None, kw_only=True)
     database_credentials_secret_arn: Optional[str] = field(default=None, kw_only=True)
-    wait_for_query_completion_sec: Optional[float] = field(default=0.3, kw_only=True)
+    wait_for_query_completion_sec: float = field(default=0.3, kw_only=True)
     client: boto3.client = field(
         default=Factory(
             lambda self: self.session.client("redshift-data"), takes_self=True
@@ -27,7 +27,7 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
             raise ValueError(
                 "Provide a value for one of `cluster_identifier` or `workgroup_name`"
             )
-        if self.cluster_identifier and self.workgroup_name:
+        elif self.cluster_identifier and self.workgroup_name:
             raise ValueError(
                 "Provide a value for either `cluster_identifier` or `workgroup_name`, but not both"
             )

--- a/griptape/drivers/sql/amazon_redshift_sql_driver.py
+++ b/griptape/drivers/sql/amazon_redshift_sql_driver.py
@@ -1,0 +1,106 @@
+import time
+from typing import Optional
+import boto3
+from griptape.drivers import BaseSqlDriver
+from attr import define, field
+
+
+@define
+class AmazonRedshiftSqlDriver(BaseSqlDriver):
+    database: str = field(kw_only=True)
+    cluster_identifier: str = field(default=None, kw_only=True)
+    workgroup_name: str = field(default=None, kw_only=True)
+    db_user: str = field(default=None, kw_only=True)
+    secret_arn: str = field(default=None, kw_only=True)
+    region_name: str = field(default="us-east-1", kw_only=True)
+    wait_sec: float = field(default=0.3, kw_only=True)
+    client = field(default=None, kw_only=True)
+
+    def __attrs_post_init__(self):
+        if self.client == None:
+            session = boto3.Session(region_name=self.region_name)
+            self.client = session.client("redshift-data")
+
+    @staticmethod
+    def _process_rows_from_records(records) -> list[list]:
+        rows = []
+        for r in records:
+            tmp = [c[list(c.keys())[0]] for c in r]
+            rows.append(tmp)
+        return rows
+
+    @staticmethod
+    def _process_cells_from_rows_and_columns(
+        columns: list, rows: list[list]
+    ) -> list[dict[str, any]]:
+        return [{column: r[idx] for idx, column in enumerate(columns)} for r in rows]
+
+    @staticmethod
+    def _process_columns_from_column_metadata(meta) -> list:
+        return [k["name"] for k in meta]
+
+    @staticmethod
+    def _post_process(meta, records) -> list[dict[str, any]]:
+        columns = AmazonRedshiftSqlDriver._process_columns_from_column_metadata(meta)
+        rows = AmazonRedshiftSqlDriver._process_rows_from_records(records)
+        return AmazonRedshiftSqlDriver._process_cells_from_rows_and_columns(
+            columns, rows
+        )
+
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
+        rows = self.execute_query_raw(query)
+        return [BaseSqlDriver.RowResult(row) for row in rows]
+
+    def execute_query_raw(self, query: str) -> Optional[list[dict[str, any]]]:
+        function_kwargs = {"Sql": query, "Database": self.database}
+        if self.workgroup_name:
+            function_kwargs["WorkgroupName"] = self.workgroup_name
+        if self.cluster_identifier:
+            function_kwargs["ClusterIdentifier"] = self.cluster_identifier
+        if self.db_user:
+            function_kwargs["DbUser"] = self.db_user
+        if self.secret_arn:
+            function_kwargs["SecretArn"] = self.secret_arn
+
+        response = self.client.execute_statement(**function_kwargs)
+        response_id = response["Id"]
+
+        statement = self.client.describe_statement(Id=response_id)
+
+        while statement["Status"] in ["SUBMITTED", "PICKED", "STARTED"]:
+            time.sleep(self.wait_sec)
+            statement = self.client.describe_statement(Id=response_id)
+
+        if statement["Status"] == "FINISHED":
+            statement_result = self.client.get_statement_result(Id=response_id)
+            results = statement_result.get("Records", [])
+
+            while "NextToken" in statement_result:
+                statement_result = self.client.get_statement_result(
+                    Id=response_id, NextToken=statement_result["NextToken"]
+                )
+                results = results + response.get("Records", [])
+
+            return AmazonRedshiftSqlDriver._post_process(
+                statement_result["ColumnMetadata"], results
+            )
+
+        if statement["Status"] in ["FAILED", "ABORTED"]:
+            return None
+
+    def get_table_schema(
+        self, table: str, schema: Optional[str] = None
+    ) -> Optional[str]:
+        function_kwargs = {"Database": self.database, "Table": table}
+        if schema:
+            function_kwargs["Schema"] = schema
+        if self.workgroup_name:
+            function_kwargs["WorkgroupName"] = self.workgroup_name
+        if self.cluster_identifier:
+            function_kwargs["ClusterIdentifier"] = self.cluster_identifier
+        if self.db_user:
+            function_kwargs["DbUser"] = self.db_user
+        if self.secret_arn:
+            function_kwargs["SecretArn"] = self.secret_arn
+        response = self.client.describe_table(**function_kwargs)
+        return [col["name"] for col in response["ColumnList"]]

--- a/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
+++ b/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
@@ -43,7 +43,7 @@ class TestAmazonRedshiftSqlDriver:
 
     @pytest.fixture
     def statement_driver(self):
-        client = boto3.client("redshift-data")
+        client = boto3.client("redshift-data", region_name="us-east-1")
         stubber = Stubber(client)
         expected_params = {"Sql": "query", "Database": "dev", "WorkgroupName": "dev"}
         response = {"Id": "responseId"}
@@ -109,7 +109,7 @@ class TestAmazonRedshiftSqlDriver:
 
     @pytest.fixture
     def describe_table_driver(self):
-        client = boto3.client("redshift-data")
+        client = boto3.client("redshift-data", region_name="us-east-1")
         stubber = Stubber(client)
         describe_table_response = {
             "ColumnList": TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA

--- a/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
+++ b/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
@@ -1,0 +1,163 @@
+import pytest
+import boto3
+from botocore.stub import Stubber
+from griptape.drivers import BaseSqlDriver, AmazonRedshiftSqlDriver
+
+
+class TestAmazonRedshiftSqlDriver:
+    TEST_RECORDS = [
+        [{"stringValue": "Bob"}, {"stringValue": "Ross"}],
+        [{"stringValue": "Tony"}, {"stringValue": "Hawk"}],
+    ]
+
+    TEST_COLUMN_METADATA = [
+        {
+            "isCaseSensitive": True,
+            "isCurrency": False,
+            "isSigned": False,
+            "label": "first_name",
+            "length": 0,
+            "name": "first_name",
+            "nullable": 1,
+            "precision": 256,
+            "scale": 0,
+            "schemaName": "public",
+            "tableName": "revenue_contacts",
+            "typeName": "varchar",
+        },
+        {
+            "isCaseSensitive": True,
+            "isCurrency": False,
+            "isSigned": False,
+            "label": "last_name",
+            "length": 0,
+            "name": "last_name",
+            "nullable": 1,
+            "precision": 256,
+            "scale": 0,
+            "schemaName": "public",
+            "tableName": "revenue_contacts",
+            "typeName": "varchar",
+        },
+    ]
+
+    @pytest.fixture
+    def statement_driver(self):
+        client = boto3.client("redshift-data")
+        stubber = Stubber(client)
+        expected_params = {"Sql": "query", "Database": "dev", "WorkgroupName": "dev"}
+        response = {"Id": "responseId"}
+        stubber.add_response("execute_statement", response, expected_params)
+
+        expected_params = {"Id": "responseId"}
+        response = {"Id": "responseId", "Status": "FINISHED"}
+        stubber.add_response("describe_statement", response, expected_params)
+
+        expected_params = {"Id": "responseId"}
+        response = {
+            "ColumnMetadata": [
+                {
+                    "isCaseSensitive": True,
+                    "isCurrency": False,
+                    "isSigned": False,
+                    "label": "first_name",
+                    "length": 0,
+                    "name": "first_name",
+                    "nullable": 1,
+                    "precision": 256,
+                    "scale": 0,
+                    "schemaName": "public",
+                    "tableName": "revenue_contacts",
+                    "typeName": "varchar",
+                },
+                {
+                    "isCaseSensitive": True,
+                    "isCurrency": False,
+                    "isSigned": False,
+                    "label": "last_name",
+                    "length": 0,
+                    "name": "last_name",
+                    "nullable": 1,
+                    "precision": 256,
+                    "scale": 0,
+                    "schemaName": "public",
+                    "tableName": "revenue_contacts",
+                    "typeName": "varchar",
+                },
+            ],
+            "Records": [
+                [{"stringValue": "Bob"}, {"stringValue": "Ross"}],
+                [{"stringValue": "Tony"}, {"stringValue": "Hawk"}],
+            ],
+            "TotalNumRows": 2,
+            "ResponseMetadata": {
+                "RequestId": "50033523-70b1-422b-98d7-e91045f55f8a",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "x-amzn-requestid": "50033523-70b1-422b-98d7-e91045f55f8a",
+                    "content-type": "application/x-amz-json-1.1",
+                    "content-length": "551",
+                    "date": "Fri, 07 Jul 2023 20:38:26 GMT",
+                },
+                "RetryAttempts": 0,
+            },
+        }
+        stubber.add_response("get_statement_result", response, expected_params)
+        stubber.activate()
+
+        return AmazonRedshiftSqlDriver(database="dev", workgroup_name="dev", client=client)
+
+    @pytest.fixture
+    def describe_table_driver(self):
+        client = boto3.client("redshift-data")
+        stubber = Stubber(client)
+        describe_table_response = {
+            "ColumnList": TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA
+        }
+        expected_params = {"Database": "dev", "WorkgroupName": "dev", "Table": "dev"}
+        stubber.add_response("describe_table", describe_table_response, expected_params)
+
+        stubber.activate()
+
+        return AmazonRedshiftSqlDriver(database="dev", workgroup_name="dev", client=client)
+
+    def test_process_rows_from_records(self):
+        assert AmazonRedshiftSqlDriver._process_rows_from_records(
+            TestAmazonRedshiftSqlDriver.TEST_RECORDS
+        ) == [["Bob", "Ross"], ["Tony", "Hawk"]]
+
+    def test_process_columns_from_column_metadata(self):
+        assert AmazonRedshiftSqlDriver._process_columns_from_column_metadata(
+            TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA
+        ) == ["first_name", "last_name"]
+
+    def test_post_process(self):
+        assert AmazonRedshiftSqlDriver._post_process(
+            TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA,
+            TestAmazonRedshiftSqlDriver.TEST_RECORDS,
+        ) == [
+            {"first_name": "Bob", "last_name": "Ross"},
+            {"first_name": "Tony", "last_name": "Hawk"},
+        ]
+
+    def test_execute_query_raw(self, statement_driver):
+        rows = [
+            {"first_name": "Bob", "last_name": "Ross"},
+            {"first_name": "Tony", "last_name": "Hawk"},
+        ]
+        assert statement_driver.execute_query_raw("query") == rows
+
+    def test_execute_query(self, statement_driver):
+        rows = [
+            {"first_name": "Bob", "last_name": "Ross"},
+            {"first_name": "Tony", "last_name": "Hawk"},
+        ]
+        assert statement_driver.execute_query("query") == [
+            BaseSqlDriver.RowResult(row) for row in rows
+        ]
+
+    def test_get_table_schema(self, describe_table_driver):
+        assert describe_table_driver.get_table_schema("dev") == [
+            "first_name",
+            "last_name",
+        ]


### PR DESCRIPTION
### Description

Adding an Amazon Redshift SQL Driver for use with the SqlClient tool.

Example with a Redshift Serverless workgroup:

```
sql_driver=AmazonRedshiftSqlDriver(
            database="dev",
            workgroup_name="dev"
)
```