### PR TITLE
Remove prompt driver/tokenizer model defaults

### DIFF
--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -11,11 +11,11 @@ class AnthropicPromptDriver(BasePromptDriver):
     """
     Attributes:
         api_key: Anthropic API key.
-        model: Anthropic model name. Defaults to `claude-2`.
+        model: Anthropic model name.
         tokenizer: Custom `AnthropicTokenizer`.
     """
     api_key: str = field(kw_only=True)
-    model: str = field(default=AnthropicTokenizer.DEFAULT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
     tokenizer: AnthropicTokenizer = field(
         default=Factory(
             lambda self: AnthropicTokenizer(model=self.model), takes_self=True

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -11,12 +11,12 @@ class CoherePromptDriver(BasePromptDriver):
     """
     Attributes: 
         api_key: Cohere API key.
-        model: 	Cohere model name. Defaults to `xlarge`.
+        model: 	Cohere model name.
         client: Custom `cohere.Client`.
         tokenizer: Custom `CohereTokenizer`.
     """
     api_key: str = field(kw_only=True)
-    model: str = field(default=CohereTokenizer.DEFAULT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
     client: cohere.Client = field(
         default=Factory(lambda self: cohere.Client(self.api_key), takes_self=True), kw_only=True
     )

--- a/griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py
@@ -16,7 +16,7 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
     """
     Attributes:
         params: Custom model run parameters. 
-        model: Hugging Face Hub model name. Defaults to `repo_id`.
+        model: Hugging Face Hub model name.
         tokenizer: Custom `HuggingFaceTokenizer`.
         
     """

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -27,7 +27,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     api_base: str = field(default=openai.api_base, kw_only=True)
     api_key: Optional[str] = field(default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True)
     organization: Optional[str] = field(default=openai.organization, kw_only=True)
-    model: str = field(default=TiktokenTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
     tokenizer: TiktokenTokenizer = field(
         default=Factory(lambda self: TiktokenTokenizer(model=self.model), takes_self=True),
         kw_only=True

--- a/griptape/drivers/prompt/openai_completion_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_completion_prompt_driver.py
@@ -27,7 +27,7 @@ class OpenAiCompletionPromptDriver(BasePromptDriver):
     api_base: str = field(default=openai.api_base, kw_only=True)
     api_key: Optional[str] = field(default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True)
     organization: Optional[str] = field(default=openai.organization, kw_only=True)
-    model: str = field(default=TiktokenTokenizer.DEFAULT_OPENAI_GPT_3_COMPLETION_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
     tokenizer: TiktokenTokenizer = field(
         default=Factory(lambda self: TiktokenTokenizer(model=self.model), takes_self=True),
         kw_only=True

--- a/griptape/tokenizers/anthropic_tokenizer.py
+++ b/griptape/tokenizers/anthropic_tokenizer.py
@@ -5,10 +5,9 @@ from griptape.tokenizers import BaseTokenizer
 
 @define(frozen=True)
 class AnthropicTokenizer(BaseTokenizer):
-    DEFAULT_MODEL = "claude-2"
     DEFAULT_MAX_TOKENS = 100000
 
-    model: str = field(default=DEFAULT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
 
     @property
     def max_tokens(self) -> int:

--- a/griptape/tokenizers/cohere_tokenizer.py
+++ b/griptape/tokenizers/cohere_tokenizer.py
@@ -5,10 +5,9 @@ from griptape.tokenizers import BaseTokenizer
 
 @define(frozen=True)
 class CohereTokenizer(BaseTokenizer):
-    DEFAULT_MODEL = "command"
     MAX_TOKENS = 2048
 
-    model: str = field(default=DEFAULT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
     client: cohere.Client = field(kw_only=True)
 
     @property

--- a/griptape/tokenizers/tiktoken_tokenizer.py
+++ b/griptape/tokenizers/tiktoken_tokenizer.py
@@ -33,7 +33,7 @@ class TiktokenTokenizer(BaseTokenizer):
         "text-embedding-ada-001"
     ]
 
-    model: str = field(default=DEFAULT_OPENAI_GPT_3_CHAT_MODEL, kw_only=True)
+    model: str = field(kw_only=True)
 
     @property
     def encoding(self) -> tiktoken.Encoding:


### PR DESCRIPTION
Removed Prompt Driver `model` defaults as sometimes the default value was unclear. If a user goes out of their way to create a `PromptDriver`, they must explicitly set a model. `Structure`s will still provide default `model` values.