### PR TITLE
Add customization to Chat util output

### DIFF
--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from attr import define, field
 
 if TYPE_CHECKING:
@@ -9,16 +9,24 @@ if TYPE_CHECKING:
 @define(frozen=True)
 class Chat:
     structure: Structure = field()
+    exit_keywords: list[str] = field(default=["exit"], kw_only=True)
+    exiting_text: str = field(default='exiting...', kw_only=True)
+    processing_text: str = field(default='processing...', kw_only=True)
+    intro_text: Optional[str] = field(default=None, kw_only=True)
+    prompt_prefix: str = field(default='Q: ', kw_only=True)
+    response_prefix: str = field(default='A: ', kw_only=True)
 
     def start(self) -> None:
+        if self.intro_text:
+            print(self.intro_text)
         while True:
-            question = input("Q: ")
+            question = input(self.prompt_prefix)
 
-            if question.lower() == "exit":
-                print("exiting...")
+            if question.lower() in self.exit_keywords:
+                print(self.exiting_text)
 
                 break
             else:
-                print("processing...")
+                print(self.processing_text)
 
-            print(f"A: {self.structure.run(question).output.to_text()}")
+            print(f"{self.response_prefix}{self.structure.run(question).output.to_text()}")

--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
-from attr import define, field
+from typing import TYPE_CHECKING, Optional, Callable
+from attr import define, field, Factory
 
 if TYPE_CHECKING:
     from griptape.structures import Structure
@@ -10,23 +10,24 @@ if TYPE_CHECKING:
 class Chat:
     structure: Structure = field()
     exit_keywords: list[str] = field(default=["exit"], kw_only=True)
-    exiting_text: str = field(default='exiting...', kw_only=True)
-    processing_text: str = field(default='processing...', kw_only=True)
+    exiting_text: str = field(default="exiting...", kw_only=True)
+    processing_text: str = field(default="processing...", kw_only=True)
     intro_text: Optional[str] = field(default=None, kw_only=True)
-    prompt_prefix: str = field(default='Q: ', kw_only=True)
-    response_prefix: str = field(default='A: ', kw_only=True)
+    prompt_prefix: str = field(default="Q: ", kw_only=True)
+    response_prefix: str = field(default="A: ", kw_only=True)
+    output_fn: Callable[[str], None] = field(default=Factory(lambda: print), kw_only=True)
 
     def start(self) -> None:
         if self.intro_text:
-            print(self.intro_text)
+            self.output_fn(self.intro_text)
         while True:
             question = input(self.prompt_prefix)
 
             if question.lower() in self.exit_keywords:
-                print(self.exiting_text)
+                self.output_fn(self.exiting_text)
 
                 break
             else:
-                print(self.processing_text)
+                self.output_fn(self.processing_text)
 
-            print(f"{self.response_prefix}{self.structure.run(question).output.to_text()}")
+            self.output_fn(f"{self.response_prefix}{self.structure.run(question).output.to_text()}")

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -6,6 +6,7 @@ from tests.mocks.mock_prompt_driver import MockPromptDriver
 
 class TestConversation:
     def test_init(self):
+        import logging
         agent = Agent(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         chat = Chat(
@@ -15,7 +16,8 @@ class TestConversation:
             processing_text="bar...",
             intro_text="hello...",
             prompt_prefix="Question: ",
-            response_prefix="Answer: "
+            response_prefix="Answer: ",
+            output_fn=logging.info
         )
         assert chat.structure == agent
         assert chat.exiting_text == "foo..."
@@ -23,3 +25,4 @@ class TestConversation:
         assert chat.intro_text == "hello..."
         assert chat.prompt_prefix == "Question: "
         assert chat.response_prefix == "Answer: "
+        assert callable(chat.output_fn)

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -8,4 +8,18 @@ class TestConversation:
     def test_init(self):
         agent = Agent(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
-        assert Chat(agent).structure == agent
+        chat = Chat(
+            agent,
+            exit_keywords=["exit", "bye"],
+            exiting_text="foo...",
+            processing_text="bar...",
+            intro_text="hello...",
+            prompt_prefix="Question: ",
+            response_prefix="Answer: "
+        )
+        assert chat.structure == agent
+        assert chat.exiting_text == "foo..."
+        assert chat.processing_text == "bar..."
+        assert chat.intro_text == "hello..."
+        assert chat.prompt_prefix == "Question: "
+        assert chat.response_prefix == "Answer: "


### PR DESCRIPTION
Addresses https://github.com/griptape-ai/griptape/issues/66.

Enables use cases like:
```python
import logging
from griptape.structures import Agent
from griptape.rules import Ruleset, Rule
from griptape.utils import Chat

pirate_agent = Agent(
    rulesets=[
        Ruleset(
            name="Pirate",
            rules=[
                Rule("You are a pirate"),
                Rule("You are worried about people stealing your gold"),
            ],
        )
    ]
)

Chat(
    pirate_agent,
    exit_keywords=["exit", "arr!"],
    processing_text="Arr, processing...",
    exiting_text="Arr, catch ye later...",
    intro_text="Arr - I be a pirate. Please chat with me!",
    prompt_prefix= "Hey: ",
    response_prefix= "Arr: ",
    output_fn=logging.error
).start()
```

```
ERROR:root:Arr - I be a pirate. Please chat with me!
Hey: Where is your treasure?
ERROR:root:Arr, processing...
[09/14/23 12:53:41] INFO     PromptTask 28d526294fbf4e54ac3c6e989a79c3ba
                             Input: Where is your treasure?
[09/14/23 12:53:48] INFO     PromptTask 28d526294fbf4e54ac3c6e989a79c3ba
                             Output: Arr matey, ye be a sly one, askin' about me treasure! I can't be revealin' the whereabouts of me precious gold, for fear of it bein'
                             plundered. Ye understand, don't ye? Always keepin' a weather eye open, I am.
ERROR:root:Arr: Arr matey, ye be a sly one, askin' about me treasure! I can't be revealin' the whereabouts of me precious gold, for fear of it bein' plundered. Ye understand, don't ye? Always keepin' a weather eye open, I am.
Hey: arr!
ERROR:root:Arr, catch ye later...

```