### PR TITLE
Add relative datetime activity

### DIFF
--- a/griptape/tools/date_time/requirements.txt
+++ b/griptape/tools/date_time/requirements.txt
@@ -1,0 +1,1 @@
+dateparser

--- a/griptape/tools/date_time/tool.py
+++ b/griptape/tools/date_time/tool.py
@@ -24,8 +24,8 @@ class DateTime(BaseTool):
         "description": "Can be used to return a relative date and time.",
         "schema": Schema({
             Literal(
-                description="A string representing date and/or time in a recognizably valid format."
                 "relative_date_string",
+                description='Relative date in English. For example, "now EST", "20 minutes ago", or "yesterday at 2pm"'
             ): str
         })
     })

--- a/griptape/tools/date_time/tool.py
+++ b/griptape/tools/date_time/tool.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from dateparser import parse
+from schema import Schema, Literal
 from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
@@ -7,13 +9,31 @@ from griptape.utils.decorators import activity
 class DateTime(BaseTool):
     @activity(config={
         "uses_default_memory": False,
-        "description": "Can be used to return current date and time. Always use it when you need to know what the "
-                       "current date or time is."
+        "description": "Can be used to return current date and time."
     })
     def get_current_datetime(self, _: dict) -> BaseArtifact:
         try:
             current_datetime = datetime.now()
 
             return TextArtifact(str(current_datetime))
+        except Exception as e:
+            return ErrorArtifact(f"error getting current datetime: {e}")
+    
+    @activity(config={
+        "uses_default_memory": False,
+        "description": "Can be used to return a relative date and time.",
+        "schema": Schema({
+            Literal(
+                "date_string",
+                description="A string representing date and/or time in a recognizably valid format."
+            ): str
+        })
+    })
+    def get_relative_datetime(self, params: dict) -> BaseArtifact:
+        try:
+            date_string = params["values"]["date_string"]
+            relative_datetime = parse(date_string)
+
+            return TextArtifact(str(relative_datetime))
         except Exception as e:
             return ErrorArtifact(f"error getting current datetime: {e}")

--- a/griptape/tools/date_time/tool.py
+++ b/griptape/tools/date_time/tool.py
@@ -24,14 +24,14 @@ class DateTime(BaseTool):
         "description": "Can be used to return a relative date and time.",
         "schema": Schema({
             Literal(
-                "date_string",
                 description="A string representing date and/or time in a recognizably valid format."
+                "relative_date_string",
             ): str
         })
     })
     def get_relative_datetime(self, params: dict) -> BaseArtifact:
         try:
-            date_string = params["values"]["date_string"]
+            date_string = params["values"]["relative_date_string"]
             relative_datetime = parse(date_string)
 
             return TextArtifact(str(relative_datetime))

--- a/tests/unit/tools/test_date_time.py
+++ b/tests/unit/tools/test_date_time.py
@@ -7,3 +7,8 @@ class TestDateTime:
         result = DateTime().get_current_datetime({})
         time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
         assert abs(time_delta.total_seconds()) <= 1000
+        
+    def test_get_relative_datetime(self):
+        result = DateTime().get_relative_datetime({"values": {"relative_date_string": "5 min ago"}})
+        time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
+        assert abs(time_delta.total_seconds()) <= 1000


### PR DESCRIPTION
#168 Adds relative date activity, enabling use-cases like this:
```python
from griptape.structures import Agent
from griptape.tools import DateTime

agent = Agent(tools=[DateTime()])
agent.run("What time was it 3 months, 1 week and 1 day ago") # relative functionality
agent.run("What is the current time?") # existing functionality
```