### PR TITLE
Freeze BaseTokenizer

### DIFF
--- a/griptape/tokenizers/base_tokenizer.py
+++ b/griptape/tokenizers/base_tokenizer.py
@@ -5,7 +5,7 @@ from typing import Generator
 from attr import define, field, Factory
 
 
-@define
+@define(frozen=True)
 class BaseTokenizer(ABC):
     DEFAULT_STOP_SEQUENCES = ["Observation:"]
 


### PR DESCRIPTION
Fixes Pyright error:
A frozen class cannot inherit from a class that is not frozen [reportGeneralTypeIssues]