### PR TITLE
Use prompt model input instead of default prompt driver converter

### DIFF
--- a/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
@@ -36,7 +36,7 @@ class BedrockClaudePromptModelDriver(BasePromptModelDriver):
         return { "prompt": prompt }
 
     def prompt_stack_to_model_params(self, prompt_stack: PromptStack) -> dict:
-        prompt = self.prompt_driver.prompt_stack_to_string(prompt_stack)
+        prompt = self.prompt_stack_to_model_input(prompt_stack)["prompt"]
 
         return {
             "max_tokens_to_sample": self.prompt_driver.max_output_tokens(prompt),

--- a/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
@@ -32,7 +32,7 @@ class BedrockJurassicPromptModelDriver(BasePromptModelDriver):
         return { "prompt": prompt }
 
     def prompt_stack_to_model_params(self, prompt_stack: PromptStack) -> dict:
-        prompt = self.prompt_driver.prompt_stack_to_string(prompt_stack)
+        prompt = self.prompt_stack_to_model_input(prompt_stack)["prompt"]
 
         return {
             "maxTokens": self.prompt_driver.max_output_tokens(prompt),

--- a/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
@@ -35,7 +35,7 @@ class BedrockTitanPromptModelDriver(BasePromptModelDriver):
         return { "inputText": prompt }
 
     def prompt_stack_to_model_params(self, prompt_stack: PromptStack) -> dict:
-        prompt = self.prompt_driver.prompt_stack_to_string(prompt_stack)
+        prompt = self.prompt_stack_to_model_input(prompt_stack)["inputText"]
 
         return {
             "textGenerationConfig": {

--- a/griptape/drivers/prompt_model/sagemaker_falcon_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/sagemaker_falcon_prompt_model_driver.py
@@ -22,7 +22,7 @@ class SageMakerFalconPromptModelDriver(BasePromptModelDriver):
         return self.prompt_driver.prompt_stack_to_string(prompt_stack)
 
     def prompt_stack_to_model_params(self, prompt_stack: PromptStack) -> dict:
-        prompt = self.prompt_driver.prompt_stack_to_string(prompt_stack)
+        prompt = self.prompt_stack_to_model_input(prompt_stack)
         stop_sequences = self.prompt_driver.tokenizer.stop_sequences
 
         return {

--- a/tests/unit/drivers/prompt_models/test_bedrock_claude_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_claude_prompt_model_driver.py
@@ -41,7 +41,7 @@ class TestBedrockClaudePromptModelDriver:
         assert model_input['prompt'].startswith("\nInstructions: foo\n\nHuman: bar\n\nAssistant:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert driver.prompt_stack_to_model_params(stack)["max_tokens_to_sample"] == 8186
+        assert driver.prompt_stack_to_model_params(stack)["max_tokens_to_sample"] == 8178
         assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):


### PR DESCRIPTION
We should be using `prompt_stack_to_model_input` instead of `default_prompt_stack_to_string_converter` because there are discrepancies in the prompt that gets built.

Unsure how to handle `SageMakerLlamaPromptModelDriver` because we don't know how its' [prompt_stack_to_model_input](https://github.com/griptape-ai/griptape/blob/main/griptape/drivers/prompt_model/sagemaker_llama_prompt_model_driver.py#L23C9-L23C36) gets tokenized. Could #261 further contribute to the problem here?