### PR TITLE
Add trailing Assistant: to default prompt stack converter

### DIFF
--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -75,6 +75,8 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
             else:
                 prompt_lines.append(i.content)
 
+        prompt_lines.append("Assistant:")
+
         return "\n\n".join(prompt_lines)
 
     @abstractmethod

--- a/tests/unit/drivers/prompt/test_base_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_base_prompt_driver.py
@@ -30,7 +30,7 @@ class TestBasePromptDriver:
     def test_token_count(self):
         assert MockPromptDriver().token_count(
             PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)])
-        ) == 4
+        ) == 7
 
     def test_max_output_tokens(self):
         assert MockPromptDriver().max_output_tokens("foobar") == 4087
@@ -40,7 +40,7 @@ class TestBasePromptDriver:
     def test_prompt_stack_to_string(self):
         assert MockPromptDriver().prompt_stack_to_string(
             PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)])
-        ) == "User: foobar"
+        ) == "User: foobar\n\nAssistant:"
 
     def test_custom_prompt_stack_to_string(self):
         assert MockPromptDriver(

--- a/tests/unit/drivers/prompt_models/test_sagemaker_falcon_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_sagemaker_falcon_prompt_model_driver.py
@@ -30,7 +30,7 @@ class TestSageMakerFalconPromptModelDriver:
         assert model_input.startswith("foo\n\nUser: bar")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 594
+        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 590
         assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):

--- a/tests/unit/drivers/prompt_models/test_sagemaker_llama_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_sagemaker_llama_prompt_model_driver.py
@@ -34,7 +34,7 @@ class TestSageMakerLlamaPromptModelDriver:
         assert model_input[0][1]["content"] == "bar"
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 593
+        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 588
         assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):


### PR DESCRIPTION
Tests will fail until #262 is merged because the Prompt Model Drivers have an incorrect dependency on `default_prompt_stack_to_string_converter`