### PR TITLE
Improve prompt drivers coverage

### DIFF
--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -8,7 +8,7 @@ from griptape.tokenizers import BaseTokenizer
 
 @define(frozen=True)
 class OpenAiTokenizer(BaseTokenizer):
-    DEFAULT_OPENAI_GPT_3_COMPLETION_MODEL = "davinci"
+    DEFAULT_OPENAI_GPT_3_COMPLETION_MODEL = "text-davinci-003"
     DEFAULT_OPENAI_GPT_3_CHAT_MODEL = "gpt-3.5-turbo"
     DEFAULT_OPENAI_GPT_4_MODEL = "gpt-4"
     DEFAULT_ENCODING = "cl100k_base"

--- a/tests/unit/drivers/prompt/test_amazon_sagemaker_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_sagemaker_prompt_driver.py
@@ -1,27 +1,87 @@
-import boto3
-from griptape.drivers import AmazonSageMakerPromptDriver
-from griptape.drivers import SageMakerLlamaPromptModelDriver
-from griptape.tokenizers import OpenAiTokenizer, HuggingFaceTokenizer
-
+from botocore.response import StreamingBody
+from griptape.artifacts import TextArtifact
+from griptape.drivers import AmazonSageMakerPromptDriver, SageMakerLlamaPromptModelDriver
+from griptape.tokenizers import HuggingFaceTokenizer, OpenAiTokenizer
+from io import BytesIO
+from unittest.mock import Mock
+import json
+import pytest
 
 class TestAmazonSageMakerPromptDriver:
+    @pytest.fixture
+    def mock_model_driver(self):
+        mock_model_driver = Mock()
+        mock_model_driver.prompt_stack_to_model_input.return_value = 'model-inputs'
+        mock_model_driver.prompt_stack_to_model_params.return_value = 'model-params'
+        mock_model_driver.process_output.return_value = TextArtifact('model-output')
+        return mock_model_driver
+
+    @pytest.fixture(autouse=True)
+    def mock_client(self, mocker):
+        return mocker.patch('boto3.Session').return_value.client.return_value
+
     def test_init(self):
         assert AmazonSageMakerPromptDriver(
             model="foo",
-            session=boto3.Session(region_name="us-east-1"),
             prompt_model_driver=SageMakerLlamaPromptModelDriver()
         )
 
     def test_custom_tokenizer(self):
         assert isinstance(AmazonSageMakerPromptDriver(
             model="foo",
-            session=boto3.Session(region_name="us-east-1"),
             prompt_model_driver=SageMakerLlamaPromptModelDriver()
         ).tokenizer, HuggingFaceTokenizer)
 
         assert isinstance(AmazonSageMakerPromptDriver(
             model="foo",
-            session=boto3.Session(region_name="us-east-1"),
             tokenizer=OpenAiTokenizer(),
             prompt_model_driver=SageMakerLlamaPromptModelDriver()
         ).tokenizer, OpenAiTokenizer)
+
+    def test_try_run(self, mock_model_driver, mock_client):
+        # Given
+        driver = AmazonSageMakerPromptDriver(
+            model='model',
+            prompt_model_driver=mock_model_driver
+        )
+        prompt_stack = 'prompt-stack'
+        response_body = 'invoke-endpoint-response-body'
+        mock_client.invoke_endpoint.return_value = { 'Body': to_streaming_body(response_body) }
+        
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_model_driver.prompt_stack_to_model_input.assert_called_once_with(prompt_stack)
+        mock_model_driver.prompt_stack_to_model_params.assert_called_once_with(prompt_stack)
+        mock_client.invoke_endpoint.assert_called_once_with(
+            EndpointName=driver.model,
+            ContentType='application/json',
+            Body=json.dumps({
+                'inputs': mock_model_driver.prompt_stack_to_model_input.return_value,
+                'parameters': mock_model_driver.prompt_stack_to_model_params.return_value
+            }),
+            CustomAttributes='accept_eula=true',
+        )
+        mock_model_driver.process_output.assert_called_once_with(response_body)
+        assert text_artifact == mock_model_driver.process_output.return_value
+
+    def test_try_run_throws_on_empty_response(self, mock_model_driver, mock_client):
+        # Given
+        driver = AmazonSageMakerPromptDriver(
+            model='model',
+            prompt_model_driver=mock_model_driver
+        )
+        mock_client.invoke_endpoint.return_value = { 'Body': to_streaming_body('') }
+        
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run('prompt-stack')
+
+        # Then
+        assert e.value.args[0] == 'model response is empty'
+
+
+def to_streaming_body(text: str) -> StreamingBody:
+    bytes = json.dumps(text).encode('utf-8')
+    return StreamingBody(BytesIO(bytes), len(bytes))

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -1,6 +1,57 @@
 from griptape.drivers import AnthropicPromptDriver
+from griptape.utils import PromptStack
+from unittest.mock import ANY
+import pytest
 
 
 class TestAnthropicPromptDriver:
+    @pytest.fixture(autouse=True)
+    def mock_completion_create(self, mocker):
+        mock_completion_create = mocker.patch("anthropic.Anthropic").return_value.completions.create
+        mock_completion_create.return_value.completion = 'model-output'
+        return mock_completion_create
+
     def test_init(self):
         assert AnthropicPromptDriver(api_key='1234')
+
+    def test_try_run(self, mock_completion_create):
+        # Given
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        driver = AnthropicPromptDriver(api_key='api-key')
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_completion_create.assert_called_once_with(
+            prompt=''.join([
+                '\n\n',
+                'Human: generic-input\n\n',
+                'Human: system-input\n\n',
+                'Human: user-input\n\n',
+                'Assistant: assistant-input\n\n',
+                'Assistant:'
+            ]),
+            stop_sequences=ANY,
+            model=driver.model,
+            max_tokens_to_sample=ANY,
+            temperature=ANY,
+        )
+        assert text_artifact.value == 'model-output'
+
+    def test_try_run_throws_when_prompt_stack_is_string(self):
+        # Given
+        prompt_stack = 'prompt-stack'
+        driver = AnthropicPromptDriver(api_key='api-key')
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        assert e.value.args[0] == "'str' object has no attribute 'inputs'"
+

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -1,10 +1,39 @@
 from griptape.drivers import AzureOpenAiChatPromptDriver
+from tests.unit.drivers.prompt.test_openai_chat_prompt_driver import TestOpenAiChatPromptDriverFixtureMixin
+from unittest.mock import ANY
 
-
-class TestAzureOpenAiChatPromptDriver:
+class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_init(self):
         assert AzureOpenAiChatPromptDriver(
             api_base="foobar",
             deployment_id="foobar",
             model="gpt-4"
         )
+
+    def test_try_run(self, mock_chat_completion_create, prompt_stack, messages):
+        # Given
+        driver = AzureOpenAiChatPromptDriver(
+            api_base='api-base',
+            deployment_id='deployment-id',
+            model='gpt-4'
+        )
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_chat_completion_create.assert_called_once_with(
+            model=driver.model,
+            max_tokens=ANY,
+            temperature=driver.temperature,
+            stop=driver.tokenizer.stop_sequences,
+            user=driver.user,
+            api_key=driver.api_key,
+            organization=driver.organization,
+            api_version=driver.api_version,
+            api_base=driver.api_base,
+            api_type=driver.api_type,
+            messages=messages,
+            deployment_id='deployment-id'
+        )
+        assert text_artifact.value == 'model-output'

--- a/tests/unit/drivers/prompt/test_azure_openai_completion_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_completion_prompt_driver.py
@@ -1,10 +1,40 @@
 from griptape.drivers import AzureOpenAiCompletionPromptDriver
+from tests.unit.drivers.prompt.test_openai_completion_prompt_driver import TestOpenAiCompletionPromptDriverFixtureMixin
+from unittest.mock import ANY
 
 
-class TestAzureOpenAiCompletionPromptDriver:
+class TestAzureOpenAiCompletionPromptDriver(TestOpenAiCompletionPromptDriverFixtureMixin):
     def test_init(self):
         assert AzureOpenAiCompletionPromptDriver(
             api_base="foobar",
             deployment_id="foobar",
-            model="davinci"
+            model="text-davinci-003",
         )
+
+    def test_try_run(self, mock_completion_create, prompt_stack, prompt):
+        # Given
+        driver = AzureOpenAiCompletionPromptDriver(
+            api_base='api-base',
+            deployment_id='deployment-id',
+            model='text-davinci-003',
+        )
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_completion_create.assert_called_once_with(
+            model=driver.model,
+            max_tokens=ANY,
+            temperature=driver.temperature,
+            stop=driver.tokenizer.stop_sequences,
+            user=driver.user,
+            api_key=driver.api_key,
+            organization=driver.organization,
+            api_version=driver.api_version,
+            api_base=driver.api_base,
+            api_type=driver.api_type,
+            prompt=prompt,
+            deployment_id='deployment-id',
+        )
+        assert text_artifact.value == 'model-output'

--- a/tests/unit/drivers/prompt/test_base_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_base_prompt_driver.py
@@ -1,3 +1,4 @@
+from griptape.events import FinishPromptEvent, StartPromptEvent
 from griptape.utils import PromptStack
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 from tests.mocks.mock_failing_prompt_driver import MockFailingPromptDriver
@@ -7,7 +8,7 @@ from griptape.structures import Pipeline
 
 
 class TestBasePromptDriver:
-    def test_run_retries_success(self):
+    def test_run_via_pipeline_retries_success(self):
         driver = MockPromptDriver(max_attempts=1)
         pipeline = Pipeline(prompt_driver=driver)
 
@@ -17,7 +18,7 @@ class TestBasePromptDriver:
 
         assert isinstance(pipeline.run().output, TextArtifact)
 
-    def test_run_retries_failure(self):
+    def test_run_via_pipeline_retries_failure(self):
         driver = MockFailingPromptDriver(max_failures=2, max_attempts=1)
         pipeline = Pipeline(prompt_driver=driver)
 
@@ -26,6 +27,23 @@ class TestBasePromptDriver:
         )
 
         assert isinstance(pipeline.run().output, ErrorArtifact)
+
+    def test_run_via_pipeline_publishes_events(self, mocker):
+        mock_publish_event = mocker.patch.object(Pipeline, 'publish_event')
+        driver = MockPromptDriver()
+        pipeline = Pipeline(prompt_driver=driver)
+        pipeline.add_task(PromptTask("test"))
+
+        pipeline.run()
+
+        events = [call_args[0][0] for call_args in mock_publish_event.call_args_list]
+        assert instance_count(events, StartPromptEvent) == 1
+        assert instance_count(events, FinishPromptEvent) == 1
+
+
+    def test_run(self):
+        assert isinstance(MockPromptDriver().run('prompt-stack'), TextArtifact)
+
 
     def test_token_count(self):
         assert MockPromptDriver().token_count(
@@ -48,3 +66,6 @@ class TestBasePromptDriver:
         ).prompt_stack_to_string(
             PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)])
         ) == "Foo: foobar"
+
+def instance_count(instances, clazz):
+    return len([instance for instance in instances if isinstance(instance, clazz)])

--- a/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
@@ -1,6 +1,52 @@
 from griptape.drivers import CoherePromptDriver
+from griptape.utils import PromptStack
+from unittest.mock import Mock
+import pytest
 
 
 class TestCoherePromptDriver:
+    @pytest.fixture(autouse=True)
+    def mock_client(self, mocker):
+        mock_client = mocker.patch('cohere.Client').return_value
+        mock_client.generate.return_value.generations = [Mock()]
+        mock_client.generate.return_value.generations[0].text = 'model-output'
+        return mock_client
+    
+    @pytest.fixture(autouse=True)
+    def mock_tokenizer(self, mocker):
+        return mocker.patch('griptape.tokenizers.CohereTokenizer').return_value
+    
+    @pytest.fixture
+    def prompt_stack(self):
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        return prompt_stack
+
     def test_init(self):
         assert CoherePromptDriver(api_key="foobar")
+
+    def test_try_run(self, prompt_stack):
+        # Given
+        driver = CoherePromptDriver(api_key='api-key')
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        assert text_artifact.value == 'model-output'
+
+    @pytest.mark.parametrize('choices', [[], [1, 2]])
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_client, prompt_stack):
+        # Given
+        driver = CoherePromptDriver(api_key='api-key')
+        mock_client.generate.return_value.generations = choices
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        e.value.args[0] == 'Completion with more than one choice is not supported yet.'

--- a/tests/unit/drivers/prompt/test_hugging_face_hub_pipeline_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_hub_pipeline_driver.py
@@ -1,6 +1,0 @@
-from griptape.drivers import HuggingFacePipelinePromptDriver
-
-
-class TestHuggingFacePipelinePromptDriver:
-    def test_init(self):
-        assert HuggingFacePipelinePromptDriver(model="gpt2")

--- a/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
@@ -1,6 +1,65 @@
 from griptape.drivers import HuggingFaceHubPromptDriver
+from griptape.utils import PromptStack
+import pytest
 
 
 class TestHuggingFaceHubPromptDriver:
+    @pytest.fixture(autouse=True)
+    def mock_client(self, mocker):
+        mock_client = mocker.patch('griptape.drivers.prompt.hugging_face_hub_prompt_driver.InferenceApi').return_value
+        mock_client.task = 'text-generation'
+        mock_client.return_value = [{'generated_text': 'model-output'}]
+        return mock_client
+    
+    @pytest.fixture
+    def prompt_stack(self):
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        return prompt_stack
+
+    @pytest.fixture(autouse=True)
+    def mock_autotokenizer(self, mocker):
+        mock_autotokenizer = mocker.patch("transformers.AutoTokenizer.from_pretrained").return_value
+        mock_autotokenizer.model_max_length = 42
+        return mock_autotokenizer
+
     def test_init(self):
         assert HuggingFaceHubPromptDriver(api_token="foobar", repo_id="gpt2")
+
+    def test_try_run(self, prompt_stack):
+        # Given
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", repo_id="repo-id")
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        assert text_artifact.value == 'model-output'
+
+    @pytest.mark.parametrize('choices', [[], [1, 2]])
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_client, prompt_stack):
+        # Given
+        driver = HuggingFaceHubPromptDriver(api_token='api-token', repo_id='repo-id')
+        mock_client.return_value = choices
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        e.value.args[0] == 'Completion with more than one choice is not supported yet.'
+
+    def test_try_run_throws_when_unsupported_task_returned(self, prompt_stack, mock_client):
+        # Given
+        driver = HuggingFaceHubPromptDriver(api_token='api-token', repo_id='repo-id')
+        mock_client.task = 'obviously-an-unsupported-task'
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        assert e.value.args[0].startswith('Only models with the following tasks are supported: ')

--- a/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
@@ -1,0 +1,69 @@
+from griptape.drivers import HuggingFacePipelinePromptDriver
+from griptape.utils import PromptStack
+import pytest
+
+class TestHuggingFacePipelinePromptDriver:
+    @pytest.fixture(autouse=True)
+    def mock_pipeline(self, mocker):
+        mock_pipeline = mocker.patch('griptape.drivers.prompt.hugging_face_pipeline_prompt_driver.pipeline')
+        return mock_pipeline
+
+    @pytest.fixture(autouse=True)
+    def mock_generator(self, mock_pipeline):
+        mock_generator = mock_pipeline.return_value
+        mock_generator.task = 'text-generation'
+        mock_generator.return_value = [{'generated_text': 'model-output'}]
+        return mock_generator
+
+    @pytest.fixture(autouse=True)
+    def mock_autotokenizer(self, mocker):
+        mock_autotokenizer = mocker.patch('transformers.AutoTokenizer.from_pretrained').return_value
+        mock_autotokenizer.model_max_length = 42
+        return mock_autotokenizer
+
+    @pytest.fixture
+    def prompt_stack(self):
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        return prompt_stack
+
+    def test_init(self):
+        assert HuggingFacePipelinePromptDriver(model="gpt2")
+
+    def test_try_run(self, prompt_stack):
+        # Given
+        driver = HuggingFacePipelinePromptDriver(model="foo")
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        assert text_artifact.value == 'model-output'
+
+    @pytest.mark.parametrize('choices', [[], [1, 2]])
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_generator, prompt_stack):
+        # Given
+        driver = HuggingFacePipelinePromptDriver(model='foo')
+        mock_generator.return_value = choices
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        e.value.args[0] == 'Completion with more than one choice is not supported yet.'
+
+    def test_try_run_throws_when_unsupported_task_returned(self, prompt_stack, mock_generator):
+        # Given
+        driver = HuggingFacePipelinePromptDriver(model='foo')
+        mock_generator.task = 'obviously-an-unsupported-task'
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        assert e.value.args[0].startswith('Only models with the following tasks are supported: ')

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -1,8 +1,113 @@
 from griptape.drivers import OpenAiChatPromptDriver
+from griptape.utils import PromptStack
+from unittest.mock import ANY, Mock
+import pytest
 
+class TestOpenAiChatPromptDriverFixtureMixin:
+    @pytest.fixture(autouse=True)
+    def mock_chat_completion_create(self, mocker):
+        mock_chat_create = mocker.patch('openai.ChatCompletion').create
+        mock_chat_create.return_value.choices = [ 
+            {'message': {'content': 'model-output'}}
+        ]
+        return mock_chat_create
+    
+    @pytest.fixture
+    def prompt_stack(self):
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        return prompt_stack
+    
+    @pytest.fixture
+    def messages(self):
+        return [
+            {'role': 'user', 'content': 'generic-input'},
+            {'role': 'system', 'content': 'system-input'},
+            {'role': 'user', 'content': 'user-input'},
+            {'role': 'assistant', 'content': 'assistant-input'},
+        ]
 
-class TestOpenAiChatPromptDriver:
+class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_init(self):
         assert OpenAiChatPromptDriver(
             model="gpt-4"
         )
+
+    def test_try_run(self, mock_chat_completion_create, prompt_stack, messages):
+        # Given
+        driver = OpenAiChatPromptDriver()
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_chat_completion_create.assert_called_once_with(
+            model=driver.model,
+            max_tokens=ANY,
+            temperature=driver.temperature,
+            stop=driver.tokenizer.stop_sequences,
+            user=driver.user,
+            api_key=driver.api_key,
+            organization=driver.organization,
+            api_version=driver.api_version,
+            api_base=driver.api_base,
+            api_type=driver.api_type,
+            messages=messages
+        )
+        assert text_artifact.value == 'model-output'
+
+    def test_try_run_throws_when_prompt_stack_is_string(self):
+        # Given
+        driver = OpenAiChatPromptDriver()
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run('prompt-stack')
+
+        # Then
+        assert e.value.args[0] == "'str' object has no attribute 'inputs'"
+
+    @pytest.mark.parametrize('choices', [[], [1, 2]])
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_chat_completion_create, prompt_stack):
+        # Given
+        driver = OpenAiChatPromptDriver()
+        mock_chat_completion_create.return_value.choices = choices
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        e.value.args[0] == 'Completion with more than one choice is not supported yet.'
+
+    def test_token_count(self, prompt_stack, messages):
+        # Given
+        mock_tokenizer = Mock()
+        mock_tokenizer.token_count.return_value = 42
+        driver = OpenAiChatPromptDriver(tokenizer=mock_tokenizer)
+        
+        # When
+        token_count = driver.token_count(prompt_stack)
+
+        # Then
+        mock_tokenizer.token_count.assert_called_once_with(messages)
+        assert token_count == 42
+
+    def test_max_output_tokens(self, messages):
+        # Given
+        mock_tokenizer = Mock()
+        mock_tokenizer.tokens_left.return_value = 42
+        driver = OpenAiChatPromptDriver(tokenizer=mock_tokenizer)
+        
+        # When
+        max_output_tokens = driver.max_output_tokens(messages)
+
+        # Then
+        mock_tokenizer.tokens_left.assert_called_once_with(messages)
+        assert max_output_tokens == 42
+
+    def test_max_output_tokens_with_max_tokens(self, messages):
+        OpenAiChatPromptDriver(max_tokens=42).max_output_tokens(messages) == 42

--- a/tests/unit/drivers/prompt/test_openai_completion_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_completion_prompt_driver.py
@@ -1,8 +1,82 @@
 from griptape.drivers import OpenAiCompletionPromptDriver
+from griptape.utils import PromptStack
+from unittest.mock import ANY, Mock
+import pytest
 
+class TestOpenAiCompletionPromptDriverFixtureMixin:
+    @pytest.fixture(autouse=True)
+    def mock_completion_create(self, mocker):
+        mock_chat_create = mocker.patch('openai.Completion').create
+        mock_chat_create.return_value.choices = [  Mock() ]
+        mock_chat_create.return_value.choices[0].text = 'model-output'
+        return mock_chat_create
 
-class TestAzureOpenAiCompletionPromptDriver:
+    @pytest.fixture
+    def prompt_stack(self):
+        prompt_stack = PromptStack()
+        prompt_stack.add_generic_input('generic-input')
+        prompt_stack.add_system_input('system-input')
+        prompt_stack.add_user_input('user-input')
+        prompt_stack.add_assistant_input('assistant-input')
+        return prompt_stack
+
+    @pytest.fixture
+    def prompt(self):
+        return ''.join([
+            'generic-input\n\n',
+            'system-input\n\n',
+            'User: user-input\n\n',
+            'Assistant: assistant-input\n\n',
+            'Assistant:'
+        ])
+
+class TestOpenAiCompletionPromptDriver(TestOpenAiCompletionPromptDriverFixtureMixin):
     def test_init(self):
-        assert OpenAiCompletionPromptDriver(
-            model="davinci"
+        assert OpenAiCompletionPromptDriver()
+
+    def test_try_run(self, mock_completion_create, prompt_stack, prompt):
+        # Given
+        driver = OpenAiCompletionPromptDriver()
+
+        # When
+        text_artifact = driver.try_run(prompt_stack)
+
+        # Then
+        mock_completion_create.assert_called_once_with(
+            model=driver.model,
+            max_tokens=ANY,
+            temperature=driver.temperature,
+            stop=driver.tokenizer.stop_sequences,
+            user=driver.user,
+            api_key=driver.api_key,
+            organization=driver.organization,
+            api_version=driver.api_version,
+            api_base=driver.api_base,
+            api_type=driver.api_type,
+            prompt=prompt
         )
+        assert text_artifact.value == 'model-output'
+
+    def test_try_run_throws_when_prompt_stack_is_string(self):
+        # Given
+        driver = OpenAiCompletionPromptDriver()
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run('prompt-stack')
+
+        # Then
+        assert e.value.args[0] == "'str' object has no attribute 'inputs'"
+
+    @pytest.mark.parametrize('choices', [[], [1, 2]])
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_completion_create, prompt_stack):
+        # Given
+        driver = OpenAiCompletionPromptDriver()
+        mock_completion_create.return_value.choices = choices
+
+        # When
+        with pytest.raises(Exception) as e:
+            driver.try_run(prompt_stack)
+
+        # Then
+        e.value.args[0] == 'Completion with more than one choice is not supported yet.'


### PR DESCRIPTION
### Notes

Partially resolves #130:
- Increase the unit testing coverage of the prompt drivers to 100%
- Changed the `OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_COMPLETION_MODEL` from `davinci` to `text-davinci-003` since  the `max_tokens` method requires the model to start with a value that exists in `OpenAiTokenizer.MODEL_PREFIXES_TO_MAX_TOKENS`.
- Fixed file name of the hugging face pipeline prompt driver to follow convention.

Also: This PR includes the commit from https://github.com/griptape-ai/griptape/pull/253. When that is merged, I'll rebase and update this PR. If you have an alternative workflow suggestion, lmk.

### Testing

Command used to check coverage (from poetry shell):
```
pytest tests/unit/drivers/prompt --cov=griptape/drivers/prompt
```

Coverage before commit:
```
Name                                                               Stmts   Miss  Cover
--------------------------------------------------------------------------------------
griptape/drivers/prompt/__init__.py                                    0      0   100%
griptape/drivers/prompt/amazon_bedrock_prompt_driver.py               23     10    57%
griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py             21      7    67%
griptape/drivers/prompt/anthropic_prompt_driver.py                    23     10    57%
griptape/drivers/prompt/azure_openai_chat_prompt_driver.py            14      1    93%
griptape/drivers/prompt/azure_openai_completion_prompt_driver.py      14      1    93%
griptape/drivers/prompt/base_multi_model_prompt_driver.py             17      2    88%
griptape/drivers/prompt/base_prompt_driver.py                         48      4    92%
griptape/drivers/prompt/cohere_prompt_driver.py                       19      6    68%
griptape/drivers/prompt/hugging_face_hub_prompt_driver.py             29      7    76%
griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py        25      9    64%
griptape/drivers/prompt/openai_chat_prompt_driver.py                  42     16    62%
griptape/drivers/prompt/openai_completion_prompt_driver.py            28      6    79%
--------------------------------------------------------------------------------------
TOTAL                                                                303     79    74%
```

Coverage after commit:
```
Name                                                               Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------------------------------------
griptape/drivers/prompt/__init__.py                                    0      0      0      0   100%
griptape/drivers/prompt/amazon_bedrock_prompt_driver.py               21      0     10      0   100%
griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py             19      0      8      0   100%
griptape/drivers/prompt/anthropic_prompt_driver.py                    23      0      8      0   100%
griptape/drivers/prompt/azure_openai_chat_prompt_driver.py            14      0      4      0   100%
griptape/drivers/prompt/azure_openai_completion_prompt_driver.py      14      0      4      0   100%
griptape/drivers/prompt/base_multi_model_prompt_driver.py             14      0      4      0   100%
griptape/drivers/prompt/base_prompt_driver.py                         42      0     20      0   100%
griptape/drivers/prompt/cohere_prompt_driver.py                       19      0      8      0   100%
griptape/drivers/prompt/hugging_face_hub_prompt_driver.py             29      0     12      0   100%
griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py        25      0      8      0   100%
griptape/drivers/prompt/openai_chat_prompt_driver.py                  42      0     18      0   100%
griptape/drivers/prompt/openai_completion_prompt_driver.py            28      0     10      0   100%
----------------------------------------------------------------------------------------------------
TOTAL                                                                290      0    114      0   100%
```