### PR TITLE
Fix missing header for json requests

### DIFF
--- a/griptape/tools/rest_api_client/tool.py
+++ b/griptape/tools/rest_api_client/tool.py
@@ -75,7 +75,7 @@ class RestApiClient(BaseTool):
         url = self._build_url(base_url, path=path)
 
         try:
-            response = put(url, data=body, timeout=30)
+            response = put(url, json=body, timeout=30)
 
             return TextArtifact(response.text)
         except exceptions.RequestException as err:
@@ -113,7 +113,7 @@ class RestApiClient(BaseTool):
         url = self._build_url(base_url, path=path, path_params=path_params)
 
         try:
-            response = patch(url, data=body, timeout=30)
+            response = patch(url, json=body, timeout=30)
             return TextArtifact(response.text)
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
@@ -145,7 +145,7 @@ class RestApiClient(BaseTool):
         body = values["body"]
 
         try:
-            response = post(url, data=body, timeout=30)
+            response = post(url, json=body, timeout=30)
             return TextArtifact(response.text)
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))


### PR DESCRIPTION
Fixes #345
Replaced `data` with `json` so that requests will automatically add the Content-Type header. https://requests.readthedocs.io/en/latest/user/quickstart/#more-complicated-post-requests