### PR TITLE
Extract rate limit metadata from OpenAI API response headers

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -140,9 +140,9 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             return "user"
 
     def _extract_ratelimit_metadata(self, response, *args, **kwargs):
-        # The timeparse utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
-        # If the API returns, for example, "13ms", timeparse returns None. In this case, we will set the time value
-        # to the current time plus a one second buffer.
+        # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
+        # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
+        # the time value to the current time plus a one second buffer.
         self.__ratelimit_requests_reset_at = dateparser.parse(
             response.headers["x-ratelimit-reset-requests"],
             settings={"PREFER_DATES_FROM": "future"},

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -26,6 +26,12 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         organization: OpenAI organization.
         tokenizer: Custom `OpenAiTokenizer`.
         user: OpenAI user.
+        _ratelimit_request_limit: The maximum number of requests allowed in the current rate limit window.
+        _ratelimit_requests_remaining: The number of requests remaining in the current rate limit window.
+        _ratelimit_requests_reset_at: The time at which the current rate limit window resets.
+        _ratelimit_token_limit: The maximum number of tokens allowed in the current rate limit window.
+        _ratelimit_tokens_remaining: The number of tokens remaining in the current rate limit window.
+        _ratelimit_tokens_reset_at: The time at which the current rate limit window resets.
     """
 
     api_type: str = field(default=openai.api_type, kw_only=True)

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -48,12 +48,11 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         print("reset tokens in:", response.headers["x-ratelimit-reset-tokens"])
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
-        s = requests.Session()
-        s.hooks = {
+        openai.requestssession = requests.Session()
+        openai.requestssession.hooks = {
             "response": self.__print_headers
         }
 
-        openai.requestssession = s
         result = openai.ChatCompletion.create(**self._base_params(prompt_stack))
 
         if len(result.choices) == 1:

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -41,12 +41,12 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     ignored_exception_types: Tuple[Type[Exception], ...] = field(
         default=Factory(lambda: openai.InvalidRequestError), kw_only=True
     )
-    __ratelimit_request_limit: Optional[int] = field(init=False, default=None)
-    __ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
-    __ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
-    __ratelimit_token_limit: Optional[int] = field(init=False, default=None)
-    __ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
-    __ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
+    _ratelimit_request_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
+    _ratelimit_token_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         # Define a hook to pull rate limit metadata from the OpenAI API response header.
@@ -68,42 +68,42 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         """Returns the maximum number of requests allowed before the reset time.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_request_limit
+        return self._ratelimit_request_limit
 
     @property
     def ratelimit_requests_remaining(self) -> Optional[int]:
         """Returns the remaining number of requests allowed before the reset time.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_requests_remaining
+        return self._ratelimit_requests_remaining
 
     @property
     def ratelimit_requests_reset_at(self) -> Optional[datetime]:
         """Returns the time at which the request limit will be reset.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_requests_reset_at
+        return self._ratelimit_requests_reset_at
 
     @property
     def ratelimit_token_limit(self) -> Optional[int]:
         """Returns the maximum number of tokens that may be consumed before the reset time.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_token_limit
+        return self._ratelimit_token_limit
 
     @property
     def ratelimit_tokens_remaining(self) -> Optional[int]:
         """Returns the remaining number of tokens that may be consumed before the reset time.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_tokens_remaining
+        return self._ratelimit_tokens_remaining
 
     @property
     def ratelimit_tokens_reset_at(self) -> Optional[datetime]:
         """Returns the time at which the token limit will be reset.
         This value is None until the first request is made.
         """
-        return self.__ratelimit_tokens_reset_at
+        return self._ratelimit_tokens_reset_at
 
     def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:
         return [{"role": self.__to_openai_role(i), "content": i.content} for i in prompt_stack.inputs]
@@ -143,21 +143,21 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
         # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
         # the time value to the current time plus a one second buffer.
-        self.__ratelimit_requests_reset_at = dateparser.parse(
+        self._ratelimit_requests_reset_at = dateparser.parse(
             response.headers["x-ratelimit-reset-requests"],
             settings={"PREFER_DATES_FROM": "future"},
         )
-        if self.__ratelimit_requests_reset_at is None:
-            self.__ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
+        if self._ratelimit_requests_reset_at is None:
+            self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self.__ratelimit_tokens_reset_at = dateparser.parse(
+        self._ratelimit_tokens_reset_at = dateparser.parse(
             response.headers["x-ratelimit-reset-tokens"],
             settings={"PREFER_DATES_FROM": "future"},
         )
-        if self.__ratelimit_tokens_reset_at is None:
-            self.__ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
+        if self._ratelimit_tokens_reset_at is None:
+            self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self.__ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
-        self.__ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
-        self.__ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
-        self.__ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]
+        self._ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
+        self._ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
+        self._ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
+        self._ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -41,12 +41,12 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     ignored_exception_types: Tuple[Type[Exception], ...] = field(
         default=Factory(lambda: openai.InvalidRequestError), kw_only=True
     )
-    __ratelimit_request_limit: Optional[int] = field(init=False, default=None)
-    __ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
-    __ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
-    __ratelimit_token_limit: Optional[int] = field(init=False, default=None)
-    __ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
-    __ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
+    _ratelimit_request_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
+    _ratelimit_token_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         # Define a hook to pull rate limit metadata from the OpenAI API response header.
@@ -62,48 +62,6 @@ class OpenAiChatPromptDriver(BasePromptDriver):
 
     def token_count(self, prompt_stack: PromptStack) -> int:
         return self.tokenizer.token_count(self._prompt_stack_to_messages(prompt_stack))
-
-    @property
-    def ratelimit_request_limit(self) -> Optional[int]:
-        """Returns the maximum number of requests allowed before the reset time.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_request_limit
-
-    @property
-    def ratelimit_requests_remaining(self) -> Optional[int]:
-        """Returns the remaining number of requests allowed before the reset time.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_requests_remaining
-
-    @property
-    def ratelimit_requests_reset_at(self) -> Optional[datetime]:
-        """Returns the time at which the request limit will be reset.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_requests_reset_at
-
-    @property
-    def ratelimit_token_limit(self) -> Optional[int]:
-        """Returns the maximum number of tokens that may be consumed before the reset time.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_token_limit
-
-    @property
-    def ratelimit_tokens_remaining(self) -> Optional[int]:
-        """Returns the remaining number of tokens that may be consumed before the reset time.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_tokens_remaining
-
-    @property
-    def ratelimit_tokens_reset_at(self) -> Optional[datetime]:
-        """Returns the time at which the token limit will be reset.
-        This value is None until the first request is made.
-        """
-        return self.__ratelimit_tokens_reset_at
 
     def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:
         return [{"role": self.__to_openai_role(i), "content": i.content} for i in prompt_stack.inputs]
@@ -143,21 +101,21 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
         # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
         # the time value to the current time plus a one second buffer.
-        self.__ratelimit_requests_reset_at = dateparser.parse(
+        self._ratelimit_requests_reset_at = dateparser.parse(
             response.headers["x-ratelimit-reset-requests"],
             settings={"PREFER_DATES_FROM": "future"},
         )
-        if self.__ratelimit_requests_reset_at is None:
-            self.__ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
+        if self._ratelimit_requests_reset_at is None:
+            self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self.__ratelimit_tokens_reset_at = dateparser.parse(
+        self._ratelimit_tokens_reset_at = dateparser.parse(
             response.headers["x-ratelimit-reset-tokens"],
             settings={"PREFER_DATES_FROM": "future"},
         )
-        if self.__ratelimit_tokens_reset_at is None:
-            self.__ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
+        if self._ratelimit_tokens_reset_at is None:
+            self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self.__ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
-        self.__ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
-        self.__ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
-        self.__ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]
+        self._ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
+        self._ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
+        self._ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
+        self._ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -7,6 +7,8 @@ from griptape.utils import PromptStack
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import OpenAiTokenizer
 from typing import Tuple, Type
+from pytimeparse.timeparse import timeparse
+from datetime import datetime, timedelta
 import requests
 
 
@@ -15,7 +17,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     """
     Attributes:
         api_type: Can be changed to use OpenAI models on Azure.
-        api_version: API version. 
+        api_version: API version.
         api_base: API URL.
         api_key: API key to pass directly; by default uses `OPENAI_API_KEY_PATH` environment variable.
         max_tokens: Optional maximum return tokens. If not specified, no value will be passed to the API. If set, the
@@ -23,8 +25,9 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         model: OpenAI model name. Uses `gpt-4` by default.
         organization: OpenAI organization.
         tokenizer: Custom `OpenAiTokenizer`.
-        user: OpenAI user. 	
+        user: OpenAI user.
     """
+
     api_type: str = field(default=openai.api_type, kw_only=True)
     api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     api_base: str = field(default=openai.api_base, kw_only=True)
@@ -32,49 +35,77 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     organization: Optional[str] = field(default=openai.organization, kw_only=True)
     model: str = field(kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True),
-        kw_only=True
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
     user: str = field(default="", kw_only=True)
-    ignored_exception_types: Tuple[Type[Exception], ...] = field(default=Factory(lambda: (openai.InvalidRequestError)), kw_only=True)
+    ignored_exception_types: Tuple[Type[Exception], ...] = field(
+        default=Factory(lambda: (openai.InvalidRequestError)), kw_only=True
+    )
+    __ratelimit_request_limit: int = field(default=Factory(lambda: 0))
+    __ratelimit_requests_remaining: int = field(default=Factory(lambda: 0))
+    __ratelimit_requests_reset_at: datetime = field(default=Factory(lambda: datetime.now()))
+    __ratelimit_token_limit: int = field(default=Factory(lambda: 0))
+    __ratelimit_tokens_remaining: int = field(default=Factory(lambda: 0))
+    __ratelimit_tokens_reset_at: datetime = field(default=Factory(lambda: datetime.now()))
 
-    @staticmethod
-    def __print_headers(response, *args, **kwargs):
-        print("request limit:", response.headers['x-ratelimit-limit-requests'])
-        print("request remaining:", response.headers['x-ratelimit-remaining-requests'])
-        print("reset requests in:", response.headers["x-ratelimit-reset-requests"])
-        print("token limit:", response.headers['x-ratelimit-limit-tokens'])
-        print("remaining tokens:", response.headers['x-ratelimit-remaining-tokens'])
-        print("reset tokens in:", response.headers["x-ratelimit-reset-tokens"])
+    @property
+    def ratelimit_request_limit(self) -> int:
+        """Returns the maximum number of requests allowed before the reset time."""
+        return self.__ratelimit_request_limit
+
+    @property
+    def ratelimit_requests_remaining(self) -> int:
+        """Returns the remaining number of requests allowed before the reset time."""
+        return self.__ratelimit_requests_remaining
+
+    @property
+    def ratelimit_requests_reset_at(self) -> datetime:
+        """Returns the time at which the request limit will be reset."""
+        return self.__ratelimit_requests_reset_at
+
+    @property
+    def ratelimit_token_limit(self) -> int:
+        """Returns the maximum number of tokens that may be consumed before the reset time."""
+        return self.__ratelimit_token_limit
+
+    @property
+    def ratelimit_tokens_remaining(self) -> int:
+        """Returns the remaining number of tokens that may be consumed before the reset time."""
+        return self.__ratelimit_tokens_remaining
+
+    @property
+    def ratelimit_tokens_reset_at(self) -> datetime:
+        """Returns the time at which the token limit will be reset."""
+        return self.__ratelimit_tokens_reset_at
+
+    def __extract_ratelimit_metadata(self, response, *args, **kwargs):
+        reset_requests_duration_sec = timeparse(response.headers["x-ratelimit-reset-requests-in"])
+        self.__ratelimit_request_reset_at = datetime.now() + timedelta(seconds=reset_requests_duration_sec)
+        self.__ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
+        self.__ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
+
+        reset_token_duration_sec = timeparse(response.headers["x-ratelimit-reset-tokens-in"])
+        self.__ratelimit_token_reset_at = datetime.now() + timedelta(seconds=reset_token_duration_sec)
+        self.__ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
+        self.__ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
+        # Define a hook to pull rate limit metadata from the OpenAI API response header.
         openai.requestssession = requests.Session()
-        openai.requestssession.hooks = {
-            "response": self.__print_headers
-        }
+        openai.requestssession.hooks = {"response": self.__extract_ratelimit_metadata}
 
         result = openai.ChatCompletion.create(**self._base_params(prompt_stack))
 
         if len(result.choices) == 1:
-            return TextArtifact(
-                value=result.choices[0]["message"]["content"].strip()
-            )
+            return TextArtifact(value=result.choices[0]["message"]["content"].strip())
         else:
             raise Exception("Completion with more than one choice is not supported yet.")
 
     def token_count(self, prompt_stack: PromptStack) -> int:
-        return self.tokenizer.token_count(
-            self._prompt_stack_to_messages(prompt_stack)
-        )
+        return self.tokenizer.token_count(self._prompt_stack_to_messages(prompt_stack))
 
     def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:
-        return [
-            {
-                "role": self.__to_openai_role(i),
-                "content": i.content
-            } for i in prompt_stack.inputs
-        ]
-
+        return [{"role": self.__to_openai_role(i), "content": i.content} for i in prompt_stack.inputs]
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         messages = self._prompt_stack_to_messages(prompt_stack)
@@ -89,7 +120,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             "api_version": self.api_version,
             "api_base": self.api_base,
             "api_type": self.api_type,
-            "messages": messages
+            "messages": messages,
         }
 
         # A max_tokens parameter is not required, but if it is specified by the caller, bound it to

--- a/poetry.lock
+++ b/poetry.lock
@@ -4135,4 +4135,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "52c257b58234d6f43ba11d6f89eace0d85001eeb4972a7871ed316ba2c9c9149"
+content-hash = "d21e59f66404b086f9ec179f7dd9de0ec27725fffda234489bc36d99c9a7e14b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pgvector = "^0.2.3"
 psycopg2-binary = "^2.9.9"
 snowflake-connector-python = "^3.2"
 cryptography = "^41.0.4"
+dateparser = "^1.1.8"
 
 
 [tool.poetry.group.test.dependencies]

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -1,3 +1,5 @@
+import datetime
+
 from griptape.drivers import OpenAiChatPromptDriver
 from griptape.utils import PromptStack
 from griptape.tokenizers import OpenAiTokenizer
@@ -29,6 +31,39 @@ class TestOpenAiChatPromptDriverFixtureMixin:
             {"role": "user", "content": "user-input"},
             {"role": "assistant", "content": "assistant-input"},
         ]
+
+
+class OpenAiApiResponseWithHeaders:
+    def __init__(
+        self,
+        reset_requests_in=5,
+        reset_requests_in_unit="s",
+        reset_tokens_in=10,
+        reset_tokens_in_unit="s",
+        remaining_requests=123,
+        remaining_tokens=234,
+        limit_requests=345,
+        limit_tokens=456,
+    ):
+        self.reset_requests_in = reset_requests_in
+        self.reset_requests_in_unit = reset_requests_in_unit
+        self.reset_tokens_in = reset_tokens_in
+        self.reset_tokens_in_unit = reset_tokens_in_unit
+        self.remaining_requests = remaining_requests
+        self.remaining_tokens = remaining_tokens
+        self.limit_requests = limit_requests
+        self.limit_tokens = limit_tokens
+
+    @property
+    def headers(self):
+        return {
+            "x-ratelimit-reset-requests": f"{self.reset_requests_in}{self.reset_requests_in_unit}",
+            "x-ratelimit-reset-tokens": f"{self.reset_tokens_in}{self.reset_tokens_in_unit}",
+            "x-ratelimit-limit-requests": self.limit_requests,
+            "x-ratelimit-remaining-requests": self.remaining_requests,
+            "x-ratelimit-limit-tokens": self.limit_tokens,
+            "x-ratelimit-remaining-tokens": self.remaining_tokens,
+        }
 
 
 class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
@@ -167,6 +202,48 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert max_output_tokens == 42
 
     def test_max_output_tokens_with_max_tokens(self, messages):
-        OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, max_tokens=42).max_output_tokens(
-            messages
-        ) == 42
+        max_tokens = OpenAiChatPromptDriver(
+            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
+            max_tokens=42,
+        ).max_output_tokens(messages)
+
+        assert max_tokens == 42
+
+    def test_extract_ratelimit_metadata(self):
+        response_with_headers = OpenAiApiResponseWithHeaders()
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+        driver._extract_ratelimit_metadata(response_with_headers)
+
+        assert driver.ratelimit_requests_remaining == response_with_headers.remaining_requests
+        assert driver.ratelimit_tokens_remaining == response_with_headers.remaining_tokens
+        assert driver.ratelimit_request_limit == response_with_headers.limit_requests
+        assert driver.ratelimit_token_limit == response_with_headers.limit_tokens
+
+        # Assert that the reset times are within one second of the expected value.
+        expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(
+            seconds=response_with_headers.reset_requests_in
+        )
+        expected_token_reset_time = datetime.datetime.now() + datetime.timedelta(
+            seconds=response_with_headers.reset_tokens_in
+        )
+
+        assert abs(driver.ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver.ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
+
+    def test_extract_ratelimit_metadata_with_subsecond_reset_times(self):
+        response_with_headers = OpenAiApiResponseWithHeaders(
+            reset_requests_in=1,
+            reset_requests_in_unit="ms",
+            reset_tokens_in=10,
+            reset_tokens_in_unit="ms",
+        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+        driver._extract_ratelimit_metadata(response_with_headers)
+
+        # Assert that the reset times are within one second of the expected value. With a sub-second reset time,
+        # this is rounded up to one second in the future.
+        expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
+        expected_token_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
+
+        assert abs(driver.ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver.ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -214,10 +214,10 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         driver._extract_ratelimit_metadata(response_with_headers)
 
-        assert driver.ratelimit_requests_remaining == response_with_headers.remaining_requests
-        assert driver.ratelimit_tokens_remaining == response_with_headers.remaining_tokens
-        assert driver.ratelimit_request_limit == response_with_headers.limit_requests
-        assert driver.ratelimit_token_limit == response_with_headers.limit_tokens
+        assert driver._ratelimit_requests_remaining == response_with_headers.remaining_requests
+        assert driver._ratelimit_tokens_remaining == response_with_headers.remaining_tokens
+        assert driver._ratelimit_request_limit == response_with_headers.limit_requests
+        assert driver._ratelimit_token_limit == response_with_headers.limit_tokens
 
         # Assert that the reset times are within one second of the expected value.
         expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(
@@ -227,8 +227,8 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             seconds=response_with_headers.reset_tokens_in
         )
 
-        assert abs(driver.ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
-        assert abs(driver.ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
 
     def test_extract_ratelimit_metadata_with_subsecond_reset_times(self):
         response_with_headers = OpenAiApiResponseWithHeaders(
@@ -245,5 +245,5 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
         expected_token_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
 
-        assert abs(driver.ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
-        assert abs(driver.ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)


### PR DESCRIPTION
Adds dormant functionality to parse OpenAI API response headers for ratelimit-related information. In the future, we can use this information to more intelligently implement backoff or calculate token requests.

New tests ensure functionality of header parsing functionality.

Related to #309.