### PR TITLE
Fix docstring causing docs build failure

### DIFF
--- a/griptape/utils/prompt_stack.py
+++ b/griptape/utils/prompt_stack.py
@@ -61,7 +61,7 @@ class PromptStack:
         as possible without exceeding the token limit.
 
         Args:
-            stack: The Prompt Stack to add the Conversation Memory runs to.
+            memory: The Conversation Memory to add the Prompt Stack to.
             index: Optional index to insert the Conversation Memory runs at.
                    Defaults to appending to the end of the Prompt Stack.
         """


### PR DESCRIPTION
Fix doc build error:

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/docs/checkouts/readthedocs.org/user_builds/griptape/checkouts/latest/_readthedocs/html
WARNING -  griffe: griptape/griptape/utils/prompt_stack.py:64: No type or annotation for parameter 'stack'
WARNING -  griffe: griptape/griptape/utils/prompt_stack.py:64: Parameter 'stack' does not appear in the function signature

Aborted with 2 warnings in strict mode!
```