### PR TITLE
Fix OpenAI rate limit headers parsing

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -122,15 +122,18 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             return "user"
 
     def _extract_ratelimit_metadata(self, response, *args, **kwargs):
-        # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
-        # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
-        # the time value to the current time plus a one second buffer.
+        # The OpenAI SDK's requestssession variable is global, so this hook will fire for all API requests.
+        # The following headers are not reliably returned in every API call, so we check for the presence of the
+        # headers before reading and parsing their values to prevent other SDK users from encountering KeyErrors.
         if "x-ratelimit-reset-requests" in response.headers:
             self._ratelimit_requests_reset_at = dateparser.parse(
                 response.headers["x-ratelimit-reset-requests"],
                 settings={"PREFER_DATES_FROM": "future"},
             )
 
+            # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
+            # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
+            # the time value to the current time plus a one second buffer.
             if self._ratelimit_requests_reset_at is None:
                 self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -125,9 +125,10 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         # The OpenAI SDK's requestssession variable is global, so this hook will fire for all API requests.
         # The following headers are not reliably returned in every API call, so we check for the presence of the
         # headers before reading and parsing their values to prevent other SDK users from encountering KeyErrors.
-        if "x-ratelimit-reset-requests" in response.headers:
+        requests_reset_at_header = "x-ratelimit-reset-requests"
+        if requests_reset_at_header in response.headers:
             self._ratelimit_requests_reset_at = dateparser.parse(
-                response.headers["x-ratelimit-reset-requests"],
+                response.headers[requests_reset_at_header],
                 settings={"PREFER_DATES_FROM": "future"},
             )
 
@@ -137,23 +138,28 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             if self._ratelimit_requests_reset_at is None:
                 self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
-        if "x-ratelimit-reset-tokens" in response.headers:
+        tokens_reset_at_header = "x-ratelimit-reset-tokens"
+        if tokens_reset_at_header in response.headers:
             self._ratelimit_tokens_reset_at = dateparser.parse(
-                response.headers["x-ratelimit-reset-tokens"],
+                response.headers[tokens_reset_at_header],
                 settings={"PREFER_DATES_FROM": "future"},
             )
 
             if self._ratelimit_tokens_reset_at is None:
                 self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
 
-        if "x-ratelimit-limit-requests" in response.headers:
-            self._ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
+        request_limit_header = "x-ratelimit-limit-requests"
+        if request_limit_header in response.headers:
+            self._ratelimit_request_limit = response.headers[request_limit_header]
 
-        if "x-ratelimit-remaining-requests" in response.headers:
-            self._ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
+        requests_remaining_header = "x-ratelimit-remaining-requests"
+        if requests_remaining_header in response.headers:
+            self._ratelimit_requests_remaining = response.headers[requests_remaining_header]
 
-        if "x-ratelimit-limit-tokens" in response.headers:
-            self._ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
+        token_limit_header = "x-ratelimit-limit-tokens"
+        if token_limit_header in response.headers:
+            self._ratelimit_token_limit = response.headers[token_limit_header]
 
-        if "x-ratelimit-remaining-tokens" in response.headers:
-            self._ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]
+        tokens_remaining_header = "x-ratelimit-remaining-tokens"
+        if tokens_remaining_header in response.headers:
+            self._ratelimit_tokens_remaining = response.headers[tokens_remaining_header]

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -125,10 +125,10 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         # The OpenAI SDK's requestssession variable is global, so this hook will fire for all API requests.
         # The following headers are not reliably returned in every API call, so we check for the presence of the
         # headers before reading and parsing their values to prevent other SDK users from encountering KeyErrors.
-        requests_reset_at_header = "x-ratelimit-reset-requests"
-        if requests_reset_at_header in response.headers:
+        reset_requests_at = response.headers.get("x-ratelimit-reset-requests")
+        if reset_requests_at is not None:
             self._ratelimit_requests_reset_at = dateparser.parse(
-                response.headers[requests_reset_at_header],
+                reset_requests_at,
                 settings={"PREFER_DATES_FROM": "future"},
             )
 
@@ -138,28 +138,17 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             if self._ratelimit_requests_reset_at is None:
                 self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
-        tokens_reset_at_header = "x-ratelimit-reset-tokens"
-        if tokens_reset_at_header in response.headers:
+        reset_tokens_at = response.headers.get("x-ratelimit-reset-tokens")
+        if reset_tokens_at is not None:
             self._ratelimit_tokens_reset_at = dateparser.parse(
-                response.headers[tokens_reset_at_header],
+                reset_tokens_at,
                 settings={"PREFER_DATES_FROM": "future"},
             )
 
             if self._ratelimit_tokens_reset_at is None:
                 self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
 
-        request_limit_header = "x-ratelimit-limit-requests"
-        if request_limit_header in response.headers:
-            self._ratelimit_request_limit = response.headers[request_limit_header]
-
-        requests_remaining_header = "x-ratelimit-remaining-requests"
-        if requests_remaining_header in response.headers:
-            self._ratelimit_requests_remaining = response.headers[requests_remaining_header]
-
-        token_limit_header = "x-ratelimit-limit-tokens"
-        if token_limit_header in response.headers:
-            self._ratelimit_token_limit = response.headers[token_limit_header]
-
-        tokens_remaining_header = "x-ratelimit-remaining-tokens"
-        if tokens_remaining_header in response.headers:
-            self._ratelimit_tokens_remaining = response.headers[tokens_remaining_header]
+        self._ratelimit_request_limit = response.headers.get("x-ratelimit-limit-requests")
+        self._ratelimit_requests_remaining = response.headers.get("x-ratelimit-remaining-requests")
+        self._ratelimit_token_limit = response.headers.get("x-ratelimit-limit-tokens")
+        self._ratelimit_tokens_remaining = response.headers.get("x-ratelimit-remaining-tokens")

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -125,21 +125,32 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         # The dateparser utility doesn't handle sub-second durations as are sometimes returned by OpenAI's API.
         # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
         # the time value to the current time plus a one second buffer.
-        self._ratelimit_requests_reset_at = dateparser.parse(
-            response.headers["x-ratelimit-reset-requests"],
-            settings={"PREFER_DATES_FROM": "future"},
-        )
-        if self._ratelimit_requests_reset_at is None:
-            self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
+        if "x-ratelimit-reset-requests" in response.headers:
+            self._ratelimit_requests_reset_at = dateparser.parse(
+                response.headers["x-ratelimit-reset-requests"],
+                settings={"PREFER_DATES_FROM": "future"},
+            )
 
-        self._ratelimit_tokens_reset_at = dateparser.parse(
-            response.headers["x-ratelimit-reset-tokens"],
-            settings={"PREFER_DATES_FROM": "future"},
-        )
-        if self._ratelimit_tokens_reset_at is None:
-            self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
+            if self._ratelimit_requests_reset_at is None:
+                self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self._ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
-        self._ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
-        self._ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
-        self._ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]
+        if "x-ratelimit-reset-tokens" in response.headers:
+            self._ratelimit_tokens_reset_at = dateparser.parse(
+                response.headers["x-ratelimit-reset-tokens"],
+                settings={"PREFER_DATES_FROM": "future"},
+            )
+
+            if self._ratelimit_tokens_reset_at is None:
+                self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
+
+        if "x-ratelimit-limit-requests" in response.headers:
+            self._ratelimit_request_limit = response.headers["x-ratelimit-limit-requests"]
+
+        if "x-ratelimit-remaining-requests" in response.headers:
+            self._ratelimit_requests_remaining = response.headers["x-ratelimit-remaining-requests"]
+
+        if "x-ratelimit-limit-tokens" in response.headers:
+            self._ratelimit_token_limit = response.headers["x-ratelimit-limit-tokens"]
+
+        if "x-ratelimit-remaining-tokens" in response.headers:
+            self._ratelimit_tokens_remaining = response.headers["x-ratelimit-remaining-tokens"]

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -278,3 +278,21 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
         assert abs(driver._ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
         assert abs(driver._ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
+
+    def test_extract_ratelimit_metadata_missing_headers(self):
+        class OpenAiApiResponseNoHeaders:
+            @property
+            def headers(self):
+                return {}
+
+        response_without_headers = OpenAiApiResponseNoHeaders()
+
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+        driver._extract_ratelimit_metadata(response_without_headers)
+
+        assert driver._ratelimit_request_limit is None
+        assert driver._ratelimit_requests_remaining is None
+        assert driver._ratelimit_requests_reset_at is None
+        assert driver._ratelimit_token_limit is None
+        assert driver._ratelimit_tokens_remaining is None
+        assert driver._ratelimit_tokens_reset_at is None


### PR DESCRIPTION
#384 describes a bug where an unrelated OpenAI tool encounters a KeyError due to headers parsing hooks registered by the OpenAiChatPromptDriver. Because the optional OpenAI `requestssession` variable is global, registering hooks in OpenAiChatPromptDriver leads to the hooks executing when interacting with the other SDK APIs (e.g. image creation), which do not reliably return the same headers. 

This PR updates the way we parse OpenAI's response headers to avoid a KeyError if they are not present.

Resolves #384 