### PR TITLE
Hotfix: Remove Event Listeners after streaming

### DIFF
--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -157,14 +157,18 @@ class Structure(ABC):
         return [self.add_task(s) for s in tasks]
 
     def add_event_listener(
-        self,
-        handler: Callable[[BaseEvent], Any],
-        event_types: Optional[list[Type[BaseEvent]]] = None,
-    ) -> None:
-        event_listener = EventListener(handler, event_types=event_types)
-
+        self, event_listener: EventListener
+    ) -> EventListener:
         if event_listener not in self.event_listeners:
             self.event_listeners.append(event_listener)
+
+        return event_listener
+
+    def remove_event_listener(self, event_listener: EventListener) -> None:
+        if event_listener in self.event_listeners:
+            self.event_listeners.remove(event_listener)
+        else:
+            raise ValueError(f"Event Listener not found.")
 
     def publish_event(self, event: BaseEvent) -> None:
         for event_listener in self.event_listeners:

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -103,18 +103,31 @@ class TestEventListener:
         finish_structure_run_event_handler.assert_called_once()
         completion_chunk_handler.assert_called_once()
 
-    def test_add_event_listener(self, pipeline):
+    def test_add_remove_event_listener(self, pipeline):
         pipeline.event_listeners = []
         mock1 = Mock()
         mock2 = Mock()
         # duplicate event listeners will only get added once
-        pipeline.add_event_listener(mock1, [StartPromptEvent])
-        pipeline.add_event_listener(mock1, [StartPromptEvent])
+        event_listener_1 = pipeline.add_event_listener(
+            EventListener(mock1, event_types=[StartPromptEvent])
+        )
+        pipeline.add_event_listener(
+            EventListener(mock1, event_types=[StartPromptEvent])
+        )
 
-        # uniqueness is based off of the handler + event type
-        pipeline.add_event_listener(mock1, [FinishPromptEvent])
-        pipeline.add_event_listener(mock2, [StartPromptEvent])
+        event_listener_3 = pipeline.add_event_listener(
+            EventListener(mock1, event_types=[FinishPromptEvent])
+        )
+        event_listener_4 = pipeline.add_event_listener(
+            EventListener(mock2, event_types=[StartPromptEvent])
+        )
 
-        pipeline.add_event_listener(mock2)
+        event_listener_5 = pipeline.add_event_listener(EventListener(mock2))
 
         assert len(pipeline.event_listeners) == 4
+
+        pipeline.remove_event_listener(event_listener_1)
+        pipeline.remove_event_listener(event_listener_3)
+        pipeline.remove_event_listener(event_listener_4)
+        pipeline.remove_event_listener(event_listener_5)
+        assert len(pipeline.event_listeners) == 0


### PR DESCRIPTION
Fixes #408.

- Clean up Event Listeners after Streaming
- Don't block on streaming thread.