### PR TITLE
Add pre-commit configuration to apply Black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 23.7.0
+    hooks:
+    - id: black
+#      language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: 23.7.0
     hooks:
     - id: black
-#      language_version: python3.9

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ We welcome and encourage pull requests. To streamline the process, please follow
 
 4. **Documentation:** Every pull request must include a corresponding pull request in the [docs repository](https://github.com/griptape-ai/griptape-docs) or explicitly explain why a documentation update is not required. Documentation is crucial for maintaining a comprehensive and user-friendly project.
 
+5. **Formatting:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. In your local repository, simply run `poetry run pre-commit install` and Black will reformat files as they are committed.
+
 ## License
 
 Griptape is available under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,21 @@ We welcome and encourage pull requests. To streamline the process, please follow
 
 4. **Documentation:** Every pull request must include a corresponding pull request in the [docs repository](https://github.com/griptape-ai/griptape-docs) or explicitly explain why a documentation update is not required. Documentation is crucial for maintaining a comprehensive and user-friendly project.
 
-5. **Formatting:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. In your local repository, simply run `poetry run pre-commit install` and Black will reformat files as they are committed.
+5. **Code Style:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. See [Tools](#tools-) for information on how to configure this and other dev tools.
+
+### Tools
+
+Install dev dependencies with Poetry:
+
+```shell
+poetry install --with dev
+```
+
+Configure pre-commit to ensure that your code is formatted correctly and passes all checks:
+
+```shell
+poetry run pre-commit install
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ We welcome and encourage pull requests. To streamline the process, please follow
 
 4. **Documentation:** Every pull request must include a corresponding pull request in the [docs repository](https://github.com/griptape-ai/griptape-docs) or explicitly explain why a documentation update is not required. Documentation is crucial for maintaining a comprehensive and user-friendly project.
 
-5. **Code Style:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. See [Tools](#tools-) for information on how to configure this and other dev tools.
+5. **Code Style:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. See [Tools](#tools) for information on how to configure this and other dev tools.
 
 ### Tools
 

--- a/griptape/artifacts/base_artifact.py
+++ b/griptape/artifacts/base_artifact.py
@@ -10,14 +10,9 @@ from marshmallow.exceptions import RegistryError
 @define
 class BaseArtifact(ABC):
     id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True)
-    name: str = field(
-        default=Factory(lambda self: self.id, takes_self=True), kw_only=True
-    )
+    name: str = field(default=Factory(lambda self: self.id, takes_self=True), kw_only=True)
     value: any = field()
-    type: str = field(
-        default=Factory(lambda self: self.__class__.__name__, takes_self=True),
-        kw_only=True,
-    )
+    type: str = field(default=Factory(lambda self: self.__class__.__name__, takes_self=True), kw_only=True)
 
     @classmethod
     def value_to_bytes(cls, value: any) -> bytes:
@@ -54,9 +49,7 @@ class BaseArtifact(ABC):
         class_registry.register("ListArtifact", ListArtifactSchema)
 
         try:
-            return class_registry.get_class(artifact_dict["type"])().load(
-                artifact_dict
-            )
+            return class_registry.get_class(artifact_dict["type"])().load(artifact_dict)
         except RegistryError:
             raise ValueError("Unsupported artifact type")
 

--- a/griptape/artifacts/blob_artifact.py
+++ b/griptape/artifacts/blob_artifact.py
@@ -17,16 +17,10 @@ class BlobArtifact(BaseArtifact):
 
     @property
     def full_path(self) -> str:
-        return (
-            os.path.join(self.dir_name, self.name)
-            if self.dir_name
-            else self.name
-        )
+        return os.path.join(self.dir_name, self.name) if self.dir_name else self.name
 
     def to_text(self) -> str:
-        return self.value.decode(
-            encoding=self.encoding, errors=self.encoding_error_handler
-        )
+        return self.value.decode(encoding=self.encoding, errors=self.encoding_error_handler)
 
     def to_dict(self) -> dict:
         from griptape.schemas import BlobArtifactSchema

--- a/griptape/artifacts/csv_row_artifact.py
+++ b/griptape/artifacts/csv_row_artifact.py
@@ -16,10 +16,7 @@ class CsvRowArtifact(TextArtifact):
     def to_text(self) -> str:
         with io.StringIO() as csvfile:
             writer = csv.DictWriter(
-                csvfile,
-                fieldnames=self.value.keys(),
-                quoting=csv.QUOTE_MINIMAL,
-                delimiter=self.delimiter,
+                csvfile, fieldnames=self.value.keys(), quoting=csv.QUOTE_MINIMAL, delimiter=self.delimiter
             )
 
             writer.writerow(self.value)

--- a/griptape/artifacts/list_artifact.py
+++ b/griptape/artifacts/list_artifact.py
@@ -14,9 +14,7 @@ class ListArtifact(BaseArtifact):
             first_type = type(value[0])
 
             if not all(isinstance(v, first_type) for v in value):
-                raise ValueError(
-                    f"list elements in 'value' are not the same type"
-                )
+                raise ValueError(f"list elements in 'value' are not the same type")
 
     @property
     def child_type(self) -> Optional[type]:

--- a/griptape/chunkers/__init__.py
+++ b/griptape/chunkers/__init__.py
@@ -5,10 +5,4 @@ from .pdf_chunker import PdfChunker
 from .markdown_chunker import MarkdownChunker
 
 
-__all__ = [
-    "ChunkSeparator",
-    "BaseChunker",
-    "TextChunker",
-    "PdfChunker",
-    "MarkdownChunker",
-]
+__all__ = ["ChunkSeparator", "BaseChunker", "TextChunker", "PdfChunker", "MarkdownChunker"]

--- a/griptape/chunkers/base_chunker.py
+++ b/griptape/chunkers/base_chunker.py
@@ -12,32 +12,19 @@ class BaseChunker(ABC):
     DEFAULT_SEPARATORS = [ChunkSeparator(" ")]
 
     separators: list[ChunkSeparator] = field(
-        default=Factory(lambda self: self.DEFAULT_SEPARATORS, takes_self=True),
-        kw_only=True,
+        default=Factory(lambda self: self.DEFAULT_SEPARATORS, takes_self=True), kw_only=True
     )
     tokenizer: BaseTokenizer = field(
-        default=Factory(
-            lambda: OpenAiTokenizer(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
-        kw_only=True,
+        default=Factory(lambda: OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)), kw_only=True
     )
-    max_tokens: int = field(
-        default=Factory(
-            lambda self: self.tokenizer.max_tokens, takes_self=True
-        ),
-        kw_only=True,
-    )
+    max_tokens: int = field(default=Factory(lambda self: self.tokenizer.max_tokens, takes_self=True), kw_only=True)
 
     def chunk(self, text: TextArtifact | str) -> list[TextArtifact]:
         text = text.value if isinstance(text, TextArtifact) else text
 
         return [TextArtifact(c) for c in self._chunk_recursively(text)]
 
-    def _chunk_recursively(
-        self, chunk: str, current_separator: Optional[ChunkSeparator] = None
-    ) -> list[str]:
+    def _chunk_recursively(self, chunk: str, current_separator: Optional[ChunkSeparator] = None) -> list[str]:
         token_count = self.tokenizer.count_tokens(chunk)
 
         if token_count <= self.max_tokens:
@@ -50,9 +37,7 @@ class BaseChunker(ABC):
 
             # If a separator is provided, only use separators after it.
             if current_separator:
-                separators = self.separators[
-                    self.separators.index(current_separator) :
-                ]
+                separators = self.separators[self.separators.index(current_separator) :]
             else:
                 separators = self.separators
 
@@ -81,32 +66,16 @@ class BaseChunker(ABC):
                     # Create the two subchunks based on the best separator.
                     if separator.is_prefix:
                         # If the separator is a prefix, append it before this subchunk.
-                        first_subchunk = separator.value + separator.value.join(
-                            subchunks[: balance_index + 1]
-                        )
-                        second_subchunk = (
-                            separator.value
-                            + separator.value.join(
-                                subchunks[balance_index + 1 :]
-                            )
-                        )
+                        first_subchunk = separator.value + separator.value.join(subchunks[: balance_index + 1])
+                        second_subchunk = separator.value + separator.value.join(subchunks[balance_index + 1 :])
                     else:
                         # If the separator is not a prefix, append it after this subchunk.
-                        first_subchunk = (
-                            separator.value.join(subchunks[: balance_index + 1])
-                            + separator.value
-                        )
-                        second_subchunk = separator.value.join(
-                            subchunks[balance_index + 1 :]
-                        )
+                        first_subchunk = separator.value.join(subchunks[: balance_index + 1]) + separator.value
+                        second_subchunk = separator.value.join(subchunks[balance_index + 1 :])
 
                     # Continue recursively chunking the subchunks.
-                    first_subchunk_rec = self._chunk_recursively(
-                        first_subchunk.strip(), separator
-                    )
-                    second_subchunk_rec = self._chunk_recursively(
-                        second_subchunk.strip(), separator
-                    )
+                    first_subchunk_rec = self._chunk_recursively(first_subchunk.strip(), separator)
+                    second_subchunk_rec = self._chunk_recursively(second_subchunk.strip(), separator)
 
                     # Return the concatenated results of the subchunks if both are non-empty.
                     if first_subchunk_rec and second_subchunk_rec:
@@ -120,6 +89,4 @@ class BaseChunker(ABC):
                         return []
             # If none of the separators result in a balanced split, split the chunk in half.
             midpoint = len(chunk) // 2
-            return self._chunk_recursively(
-                chunk[:midpoint]
-            ) + self._chunk_recursively(chunk[midpoint:])
+            return self._chunk_recursively(chunk[:midpoint]) + self._chunk_recursively(chunk[midpoint:])

--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -2,35 +2,23 @@ from .prompt.base_prompt_driver import BasePromptDriver
 from .prompt.openai_chat_prompt_driver import OpenAiChatPromptDriver
 from .prompt.openai_completion_prompt_driver import OpenAiCompletionPromptDriver
 from .prompt.azure_openai_chat_prompt_driver import AzureOpenAiChatPromptDriver
-from .prompt.azure_openai_completion_prompt_driver import (
-    AzureOpenAiCompletionPromptDriver,
-)
+from .prompt.azure_openai_completion_prompt_driver import AzureOpenAiCompletionPromptDriver
 from .prompt.cohere_prompt_driver import CoherePromptDriver
-from .prompt.hugging_face_pipeline_prompt_driver import (
-    HuggingFacePipelinePromptDriver,
-)
+from .prompt.hugging_face_pipeline_prompt_driver import HuggingFacePipelinePromptDriver
 from .prompt.hugging_face_hub_prompt_driver import HuggingFaceHubPromptDriver
 from .prompt.anthropic_prompt_driver import AnthropicPromptDriver
 from .prompt.amazon_sagemaker_prompt_driver import AmazonSageMakerPromptDriver
 from .prompt.amazon_bedrock_prompt_driver import AmazonBedrockPromptDriver
 from .prompt.base_multi_model_prompt_driver import BaseMultiModelPromptDriver
 
-from .memory.conversation.base_conversation_memory_driver import (
-    BaseConversationMemoryDriver,
-)
-from .memory.conversation.local_conversation_memory_driver import (
-    LocalConversationMemoryDriver,
-)
-from .memory.conversation.amazon_dynamodb_conversation_memory_driver import (
-    AmazonDynamoDbConversationMemoryDriver,
-)
+from .memory.conversation.base_conversation_memory_driver import BaseConversationMemoryDriver
+from .memory.conversation.local_conversation_memory_driver import LocalConversationMemoryDriver
+from .memory.conversation.amazon_dynamodb_conversation_memory_driver import AmazonDynamoDbConversationMemoryDriver
 
 from .embedding.base_embedding_driver import BaseEmbeddingDriver
 from .embedding.openai_embedding_driver import OpenAiEmbeddingDriver
 from .embedding.azure_openai_embedding_driver import AzureOpenAiEmbeddingDriver
-from .embedding.bedrock_titan_embedding_driver import (
-    BedrockTitanEmbeddingDriver,
-)
+from .embedding.bedrock_titan_embedding_driver import BedrockTitanEmbeddingDriver
 
 from .vector.base_vector_store_driver import BaseVectorStoreDriver
 from .vector.local_vector_store_driver import LocalVectorStoreDriver
@@ -39,9 +27,7 @@ from .vector.marqo_vector_store_driver import MarqoVectorStoreDriver
 from .vector.mongodb_vector_store_driver import MongoDbAtlasVectorStoreDriver
 from .vector.redis_vector_store_driver import RedisVectorStoreDriver
 from .vector.opensearch_vector_store_driver import OpenSearchVectorStoreDriver
-from .vector.amazon_opensearch_vector_store_driver import (
-    AmazonOpenSearchVectorStoreDriver,
-)
+from .vector.amazon_opensearch_vector_store_driver import AmazonOpenSearchVectorStoreDriver
 from .vector.pgvector_vector_store_driver import PgVectorVectorStoreDriver
 
 from .sql.base_sql_driver import BaseSqlDriver
@@ -50,21 +36,11 @@ from .sql.snowflake_sql_driver import SnowflakeSqlDriver
 from .sql.sql_driver import SqlDriver
 
 from .prompt_model.base_prompt_model_driver import BasePromptModelDriver
-from .prompt_model.sagemaker_llama_prompt_model_driver import (
-    SageMakerLlamaPromptModelDriver,
-)
-from .prompt_model.sagemaker_falcon_prompt_model_driver import (
-    SageMakerFalconPromptModelDriver,
-)
-from .prompt_model.bedrock_titan_prompt_model_driver import (
-    BedrockTitanPromptModelDriver,
-)
-from .prompt_model.bedrock_claude_prompt_model_driver import (
-    BedrockClaudePromptModelDriver,
-)
-from .prompt_model.bedrock_jurassic_prompt_model_driver import (
-    BedrockJurassicPromptModelDriver,
-)
+from .prompt_model.sagemaker_llama_prompt_model_driver import SageMakerLlamaPromptModelDriver
+from .prompt_model.sagemaker_falcon_prompt_model_driver import SageMakerFalconPromptModelDriver
+from .prompt_model.bedrock_titan_prompt_model_driver import BedrockTitanPromptModelDriver
+from .prompt_model.bedrock_claude_prompt_model_driver import BedrockClaudePromptModelDriver
+from .prompt_model.bedrock_jurassic_prompt_model_driver import BedrockJurassicPromptModelDriver
 
 
 __all__ = [

--- a/griptape/drivers/embedding/azure_openai_embedding_driver.py
+++ b/griptape/drivers/embedding/azure_openai_embedding_driver.py
@@ -23,10 +23,7 @@ class AzureOpenAiEmbeddingDriver(OpenAiEmbeddingDriver):
     api_type: str = field(default="azure", kw_only=True)
     api_version: str = field(default="2023-05-15", kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
     def _params(self, chunk: list[int] | str) -> dict:

--- a/griptape/drivers/embedding/base_embedding_driver.py
+++ b/griptape/drivers/embedding/base_embedding_driver.py
@@ -28,10 +28,7 @@ class BaseEmbeddingDriver(ExponentialBackoffMixin, ABC):
     def embed_string(self, string: str) -> list[float]:
         for attempt in self.retrying():
             with attempt:
-                if (
-                    self.tokenizer.count_tokens(string)
-                    > self.tokenizer.max_tokens
-                ):
+                if self.tokenizer.count_tokens(string) > self.tokenizer.max_tokens:
                     return self._embed_long_string(string)
                 else:
                     return self.try_embed_chunk(string)
@@ -57,9 +54,7 @@ class BaseEmbeddingDriver(ExponentialBackoffMixin, ABC):
             length_chunks.append(len(chunk))
 
         # generate weighted averages
-        embedding_chunks = np.average(
-            embedding_chunks, axis=0, weights=length_chunks
-        )
+        embedding_chunks = np.average(embedding_chunks, axis=0, weights=length_chunks)
 
         # normalize length to 1
         embedding_chunks = embedding_chunks / np.linalg.norm(embedding_chunks)

--- a/griptape/drivers/embedding/bedrock_titan_embedding_driver.py
+++ b/griptape/drivers/embedding/bedrock_titan_embedding_driver.py
@@ -26,34 +26,20 @@ class BedrockTitanEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(default=DEFAULT_MODEL, kw_only=True)
     dimensions: int = field(default=DEFAULT_MAX_TOKENS, kw_only=True)
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     tokenizer: BedrockTitanTokenizer = field(
-        default=Factory(
-            lambda self: BedrockTitanTokenizer(
-                model=self.model, session=self.session
-            ),
-            takes_self=True,
-        ),
+        default=Factory(lambda self: BedrockTitanTokenizer(model=self.model, session=self.session), takes_self=True),
         kw_only=True,
     )
     bedrock_client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("bedrock-runtime"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True
     )
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         payload = {"inputText": chunk}
 
         response = self.bedrock_client.invoke_model(
-            body=json.dumps(payload),
-            modelId=self.model,
-            accept="application/json",
-            contentType="application/json",
+            body=json.dumps(payload), modelId=self.model, accept="application/json", contentType="application/json"
         )
         response_body = json.loads(response.get("body").read())
 

--- a/griptape/drivers/embedding/openai_embedding_driver.py
+++ b/griptape/drivers/embedding/openai_embedding_driver.py
@@ -29,17 +29,10 @@ class OpenAiEmbeddingDriver(BaseEmbeddingDriver):
     api_type: str = field(default=openai.api_type, kw_only=True)
     api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     api_base: str = field(default=openai.api_base, kw_only=True)
-    api_key: Optional[str] = field(
-        default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True
-    )
-    organization: Optional[str] = field(
-        default=openai.organization, kw_only=True
-    )
+    api_key: Optional[str] = field(default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True)
+    organization: Optional[str] = field(default=openai.organization, kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
     def __attrs_post_init__(self) -> None:
@@ -54,9 +47,7 @@ class OpenAiEmbeddingDriver(BaseEmbeddingDriver):
         # https://github.com/openai/openai-python/issues/418#issuecomment-1525939500
         if self.model.endswith("001"):
             chunk = chunk.replace("\n", " ")
-        return openai.Embedding.create(**self._params(chunk))["data"][0][
-            "embedding"
-        ]
+        return openai.Embedding.create(**self._params(chunk))["data"][0]["embedding"]
 
     def _params(self, chunk: str) -> dict:
         return {

--- a/griptape/drivers/memory/conversation/amazon_dynamodb_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/amazon_dynamodb_conversation_memory_driver.py
@@ -11,10 +11,7 @@ if TYPE_CHECKING:
 
 @define
 class AmazonDynamoDbConversationMemoryDriver(BaseConversationMemoryDriver):
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     table_name: str = field(kw_only=True)
     partition_key: str = field(kw_only=True)
     value_attribute_key: str = field(kw_only=True)
@@ -36,9 +33,7 @@ class AmazonDynamoDbConversationMemoryDriver(BaseConversationMemoryDriver):
         )
 
     def load(self) -> Optional[ConversationMemory]:
-        response = self.table.get_item(
-            Key={self.partition_key: self.partition_key_value}
-        )
+        response = self.table.get_item(Key={self.partition_key: self.partition_key_value})
 
         if "Item" in response and self.value_attribute_key in response["Item"]:
             memory_value = response["Item"][self.value_attribute_key]

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -13,34 +13,19 @@ if TYPE_CHECKING:
 
 @define
 class AmazonBedrockPromptDriver(BaseMultiModelPromptDriver):
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     bedrock_client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("bedrock-runtime"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True
     )
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
-        model_input = self.prompt_model_driver.prompt_stack_to_model_input(
-            prompt_stack
-        )
-        payload = {
-            **self.prompt_model_driver.prompt_stack_to_model_params(
-                prompt_stack
-            )
-        }
+        model_input = self.prompt_model_driver.prompt_stack_to_model_input(prompt_stack)
+        payload = {**self.prompt_model_driver.prompt_stack_to_model_params(prompt_stack)}
         if isinstance(model_input, dict):
             payload.update(model_input)
 
         response = self.bedrock_client.invoke_model(
-            modelId=self.model,
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(payload),
+            modelId=self.model, contentType="application/json", accept="application/json", body=json.dumps(payload)
         )
 
         response_body = response["body"].read()
@@ -51,22 +36,13 @@ class AmazonBedrockPromptDriver(BaseMultiModelPromptDriver):
             raise Exception("model response is empty")
 
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        model_input = self.prompt_model_driver.prompt_stack_to_model_input(
-            prompt_stack
-        )
-        payload = {
-            **self.prompt_model_driver.prompt_stack_to_model_params(
-                prompt_stack
-            )
-        }
+        model_input = self.prompt_model_driver.prompt_stack_to_model_input(prompt_stack)
+        payload = {**self.prompt_model_driver.prompt_stack_to_model_params(prompt_stack)}
         if isinstance(model_input, dict):
             payload.update(model_input)
 
         response = self.bedrock_client.invoke_model_with_response_stream(
-            modelId=self.model,
-            contentType="application/json",
-            accept="application/json",
-            body=json.dumps(payload),
+            modelId=self.model, contentType="application/json", accept="application/json", body=json.dumps(payload)
         )
 
         response_body = response["body"]

--- a/griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py
@@ -13,16 +13,9 @@ if TYPE_CHECKING:
 
 @define
 class AmazonSageMakerPromptDriver(BaseMultiModelPromptDriver):
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     sagemaker_client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("sagemaker-runtime"),
-            takes_self=True,
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("sagemaker-runtime"), takes_self=True), kw_only=True
     )
     custom_attributes: str = field(default="accept_eula=true", kw_only=True)
     stream: bool = field(default=False, kw_only=True)
@@ -34,12 +27,8 @@ class AmazonSageMakerPromptDriver(BaseMultiModelPromptDriver):
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         payload = {
-            "inputs": self.prompt_model_driver.prompt_stack_to_model_input(
-                prompt_stack
-            ),
-            "parameters": self.prompt_model_driver.prompt_stack_to_model_params(
-                prompt_stack
-            ),
+            "inputs": self.prompt_model_driver.prompt_stack_to_model_input(prompt_stack),
+            "parameters": self.prompt_model_driver.prompt_stack_to_model_params(prompt_stack),
         }
         response = self.sagemaker_client.invoke_endpoint(
             EndpointName=self.model,

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -18,18 +18,13 @@ class AnthropicPromptDriver(BasePromptDriver):
     api_key: str = field(kw_only=True)
     model: str = field(kw_only=True)
     tokenizer: AnthropicTokenizer = field(
-        default=Factory(
-            lambda self: AnthropicTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: AnthropicTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         anthropic = import_optional_dependency("anthropic")
 
-        response = anthropic.Anthropic(api_key=self.api_key).completions.create(
-            **self._base_params(prompt_stack)
-        )
+        response = anthropic.Anthropic(api_key=self.api_key).completions.create(**self._base_params(prompt_stack))
         return TextArtifact(value=response.completion)
 
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
@@ -42,9 +37,7 @@ class AnthropicPromptDriver(BasePromptDriver):
         for chunk in response:
             yield TextArtifact(value=chunk.completion)
 
-    def default_prompt_stack_to_string_converter(
-        self, prompt_stack: PromptStack
-    ) -> str:
+    def default_prompt_stack_to_string_converter(self, prompt_stack: PromptStack) -> str:
         prompt_lines = []
 
         for i in prompt_stack.inputs:

--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -19,13 +19,8 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
     api_type: str = field(default="azure", kw_only=True)
     api_version: str = field(default="2023-05-15", kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
-        return super()._base_params(prompt_stack) | {
-            "deployment_id": self.deployment_id
-        }
+        return super()._base_params(prompt_stack) | {"deployment_id": self.deployment_id}

--- a/griptape/drivers/prompt/azure_openai_completion_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_completion_prompt_driver.py
@@ -12,13 +12,8 @@ class AzureOpenAiCompletionPromptDriver(OpenAiCompletionPromptDriver):
     api_type: str = field(default="azure", kw_only=True)
     api_version: str = field(default="2023-05-15", kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
-        return super()._base_params(prompt_stack) | {
-            "deployment_id": self.deployment_id
-        }
+        return super()._base_params(prompt_stack) | {"deployment_id": self.deployment_id}

--- a/griptape/drivers/prompt/base_multi_model_prompt_driver.py
+++ b/griptape/drivers/prompt/base_multi_model_prompt_driver.py
@@ -29,9 +29,7 @@ class BaseMultiModelPromptDriver(BasePromptDriver, ABC):
     @stream.validator
     def validate_stream(self, _, stream):
         if stream and not self.prompt_model_driver.supports_streaming:
-            raise ValueError(
-                f"{self.prompt_model_driver.__class__.__name__} does not support streaming"
-            )
+            raise ValueError(f"{self.prompt_model_driver.__class__.__name__} does not support streaming")
 
     def __attrs_post_init__(self) -> None:
         self.prompt_model_driver.prompt_driver = self

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -2,11 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional, Callable, Tuple, Type
 from attr import define, field, Factory
-from griptape.events import (
-    StartPromptEvent,
-    FinishPromptEvent,
-    CompletionChunkEvent,
-)
+from griptape.events import StartPromptEvent, FinishPromptEvent, CompletionChunkEvent
 from griptape.utils import PromptStack
 from griptape.mixins import ExponentialBackoffMixin
 from griptape.tokenizers import BaseTokenizer
@@ -22,15 +18,9 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
     max_tokens: Optional[int] = field(default=None, kw_only=True)
     structure: Optional[Structure] = field(default=None, kw_only=True)
     prompt_stack_to_string: Callable[[PromptStack], str] = field(
-        default=Factory(
-            lambda self: self.default_prompt_stack_to_string_converter,
-            takes_self=True,
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.default_prompt_stack_to_string_converter, takes_self=True), kw_only=True
     )
-    ignored_exception_types: Tuple[Type[Exception], ...] = field(
-        default=Factory(lambda: (ImportError)), kw_only=True
-    )
+    ignored_exception_types: Tuple[Type[Exception], ...] = field(default=Factory(lambda: (ImportError)), kw_only=True)
     model: str
     tokenizer: BaseTokenizer
     stream: bool = field(default=False, kw_only=True)
@@ -44,23 +34,15 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
             return tokens_left
 
     def token_count(self, prompt_stack: PromptStack) -> int:
-        return self.tokenizer.count_tokens(
-            self.prompt_stack_to_string(prompt_stack)
-        )
+        return self.tokenizer.count_tokens(self.prompt_stack_to_string(prompt_stack))
 
     def before_run(self, prompt_stack: PromptStack) -> None:
         if self.structure:
-            self.structure.publish_event(
-                StartPromptEvent(token_count=self.token_count(prompt_stack))
-            )
+            self.structure.publish_event(StartPromptEvent(token_count=self.token_count(prompt_stack)))
 
     def after_run(self, result: TextArtifact) -> None:
         if self.structure:
-            self.structure.publish_event(
-                FinishPromptEvent(
-                    token_count=result.token_count(self.tokenizer)
-                )
-            )
+            self.structure.publish_event(FinishPromptEvent(token_count=result.token_count(self.tokenizer)))
 
     def run(self, prompt_stack: PromptStack) -> TextArtifact:
         for attempt in self.retrying():
@@ -71,9 +53,7 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
                     tokens = []
                     completion_chunks = self.try_stream(prompt_stack)
                     for chunk in completion_chunks:
-                        self.structure.publish_event(
-                            CompletionChunkEvent(token=chunk.value)
-                        )
+                        self.structure.publish_event(CompletionChunkEvent(token=chunk.value))
                         tokens.append(chunk.value)
                     result = TextArtifact(value="".join(tokens).strip())
                 else:
@@ -86,9 +66,7 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
         else:
             raise Exception("prompt driver failed after all retry attempts")
 
-    def default_prompt_stack_to_string_converter(
-        self, prompt_stack: PromptStack
-    ) -> str:
+    def default_prompt_stack_to_string_converter(self, prompt_stack: PromptStack) -> str:
         prompt_lines = []
 
         for i in prompt_stack.inputs:

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -23,19 +23,11 @@ class CoherePromptDriver(BasePromptDriver):
     api_key: str = field(kw_only=True)
     model: str = field(kw_only=True)
     client: Client = field(
-        default=Factory(
-            lambda self: import_optional_dependency("cohere").Client(
-                self.api_key
-            ),
-            takes_self=True,
-        ),
+        default=Factory(lambda self: import_optional_dependency("cohere").Client(self.api_key), takes_self=True),
         kw_only=True,
     )
     tokenizer: CohereTokenizer = field(
-        default=Factory(
-            lambda self: CohereTokenizer(model=self.model, client=self.client),
-            takes_self=True,
-        ),
+        default=Factory(lambda self: CohereTokenizer(model=self.model, client=self.client), takes_self=True),
         kw_only=True,
     )
 
@@ -48,16 +40,12 @@ class CoherePromptDriver(BasePromptDriver):
 
                 return TextArtifact(value=generation.text.strip())
             else:
-                raise Exception(
-                    "completion with more than one choice is not supported yet"
-                )
+                raise Exception("completion with more than one choice is not supported yet")
         else:
             raise Exception("model response is empty")
 
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        result = self.client.generate(
-            **self._base_params(prompt_stack), stream=True
-        )
+        result = self.client.generate(**self._base_params(prompt_stack), stream=True)
 
         for chunk in result:
             yield TextArtifact(value=chunk.text)

--- a/griptape/drivers/prompt/hugging_face_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/hugging_face_hub_prompt_driver.py
@@ -29,10 +29,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
 
     SUPPORTED_TASKS = ["text2text-generation", "text-generation"]
     MAX_NEW_TOKENS = 250
-    DEFAULT_PARAMS = {
-        "return_full_text": False,
-        "max_new_tokens": MAX_NEW_TOKENS,
-    }
+    DEFAULT_PARAMS = {"return_full_text": False, "max_new_tokens": MAX_NEW_TOKENS}
 
     api_token: str = field(kw_only=True)
     use_gpu: bool = field(default=False, kw_only=True)
@@ -40,9 +37,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
     model: str = field(kw_only=True)
     client: InferenceApi = field(
         default=Factory(
-            lambda self: import_optional_dependency(
-                "huggingface_hub"
-            ).InferenceApi(
+            lambda self: import_optional_dependency("huggingface_hub").InferenceApi(
                 repo_id=self.model, token=self.api_token, gpu=self.use_gpu
             ),
             takes_self=True,
@@ -52,9 +47,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
     tokenizer: HuggingFaceTokenizer = field(
         default=Factory(
             lambda self: HuggingFaceTokenizer(
-                tokenizer=import_optional_dependency(
-                    "transformers"
-                ).AutoTokenizer.from_pretrained(self.model),
+                tokenizer=import_optional_dependency("transformers").AutoTokenizer.from_pretrained(self.model),
                 max_tokens=self.MAX_NEW_TOKENS,
             ),
             takes_self=True,
@@ -72,20 +65,14 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
         prompt = self.prompt_stack_to_string(prompt_stack)
 
         if self.client.task in self.SUPPORTED_TASKS:
-            response = self.client(
-                inputs=prompt, params=self.DEFAULT_PARAMS | self.params
-            )
+            response = self.client(inputs=prompt, params=self.DEFAULT_PARAMS | self.params)
 
             if len(response) == 1:
                 return TextArtifact(value=response[0]["generated_text"].strip())
             else:
-                raise Exception(
-                    "completion with more than one choice is not supported yet"
-                )
+                raise Exception("completion with more than one choice is not supported yet")
         else:
-            raise Exception(
-                f"only models with the following tasks are supported: {self.SUPPORTED_TASKS}"
-            )
+            raise Exception(f"only models with the following tasks are supported: {self.SUPPORTED_TASKS}")
 
     def try_stream(self, _: PromptStack) -> Iterator[TextArtifact]:
         raise NotImplementedError("streaming is not supported")

--- a/griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/hugging_face_pipeline_prompt_driver.py
@@ -30,9 +30,7 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
     tokenizer: HuggingFaceTokenizer = field(
         default=Factory(
             lambda self: HuggingFaceTokenizer(
-                tokenizer=import_optional_dependency(
-                    "transformers"
-                ).AutoTokenizer.from_pretrained(self.model)
+                tokenizer=import_optional_dependency("transformers").AutoTokenizer.from_pretrained(self.model)
             ),
             takes_self=True,
         ),
@@ -50,24 +48,16 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         )
 
         if generator.task in self.SUPPORTED_TASKS:
-            extra_params = {
-                "pad_token_id": self.tokenizer.tokenizer.eos_token_id
-            }
+            extra_params = {"pad_token_id": self.tokenizer.tokenizer.eos_token_id}
 
-            response = generator(
-                prompt, **(self.DEFAULT_PARAMS | extra_params | self.params)
-            )
+            response = generator(prompt, **(self.DEFAULT_PARAMS | extra_params | self.params))
 
             if len(response) == 1:
                 return TextArtifact(value=response[0]["generated_text"].strip())
             else:
-                raise Exception(
-                    "completion with more than one choice is not supported yet"
-                )
+                raise Exception("completion with more than one choice is not supported yet")
         else:
-            raise Exception(
-                f"only models with the following tasks are supported: {self.SUPPORTED_TASKS}"
-            )
+            raise Exception(f"only models with the following tasks are supported: {self.SUPPORTED_TASKS}")
 
     def try_stream(self, _: PromptStack) -> Iterator[TextArtifact]:
         raise NotImplementedError("streaming is not supported")

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -38,67 +38,44 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     api_type: str = field(default=openai.api_type, kw_only=True)
     api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     api_base: str = field(default=openai.api_base, kw_only=True)
-    api_key: Optional[str] = field(
-        default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True
-    )
-    organization: Optional[str] = field(
-        default=openai.organization, kw_only=True
-    )
+    api_key: Optional[str] = field(default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True)
+    organization: Optional[str] = field(default=openai.organization, kw_only=True)
     model: str = field(kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
     user: str = field(default="", kw_only=True)
     ignored_exception_types: Tuple[Type[Exception], ...] = field(
         default=Factory(lambda: openai.InvalidRequestError), kw_only=True
     )
     _ratelimit_request_limit: Optional[int] = field(init=False, default=None)
-    _ratelimit_requests_remaining: Optional[int] = field(
-        init=False, default=None
-    )
-    _ratelimit_requests_reset_at: Optional[datetime] = field(
-        init=False, default=None
-    )
+    _ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
     _ratelimit_token_limit: Optional[int] = field(init=False, default=None)
     _ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
-    _ratelimit_tokens_reset_at: Optional[datetime] = field(
-        init=False, default=None
-    )
+    _ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
 
     def __attrs_post_init__(self) -> None:
         # Define a hook to pull rate limit metadata from the OpenAI API response header.
         openai.requestssession = requests.Session()
-        openai.requestssession.hooks = {
-            "response": self._extract_ratelimit_metadata
-        }
+        openai.requestssession.hooks = {"response": self._extract_ratelimit_metadata}
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         result = openai.ChatCompletion.create(**self._base_params(prompt_stack))
 
         if len(result.choices) == 1:
-            return TextArtifact(
-                value=result.choices[0]["message"]["content"].strip()
-            )
+            return TextArtifact(value=result.choices[0]["message"]["content"].strip())
         else:
-            raise Exception(
-                "Completion with more than one choice is not supported yet."
-            )
+            raise Exception("Completion with more than one choice is not supported yet.")
 
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        result = openai.ChatCompletion.create(
-            **self._base_params(prompt_stack), stream=True
-        )
+        result = openai.ChatCompletion.create(**self._base_params(prompt_stack), stream=True)
 
         for chunk in result:
             if len(chunk.choices) == 1:
                 delta = chunk.choices[0]["delta"]
             else:
-                raise Exception(
-                    "Completion with more than one choice is not supported yet."
-                )
+                raise Exception("Completion with more than one choice is not supported yet.")
 
             if "content" in delta:
                 delta_content = delta["content"]
@@ -106,17 +83,10 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                 yield TextArtifact(value=delta_content)
 
     def token_count(self, prompt_stack: PromptStack) -> int:
-        return self.tokenizer.count_tokens(
-            self._prompt_stack_to_messages(prompt_stack)
-        )
+        return self.tokenizer.count_tokens(self._prompt_stack_to_messages(prompt_stack))
 
-    def _prompt_stack_to_messages(
-        self, prompt_stack: PromptStack
-    ) -> list[dict]:
-        return [
-            {"role": self.__to_openai_role(i), "content": i.content}
-            for i in prompt_stack.inputs
-        ]
+    def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:
+        return [{"role": self.__to_openai_role(i), "content": i.content} for i in prompt_stack.inputs]
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         messages = self._prompt_stack_to_messages(prompt_stack)
@@ -163,9 +133,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             # If the API returns, for example, "13ms", dateparser.parse() returns None. In this case, we will set
             # the time value to the current time plus a one second buffer.
             if self._ratelimit_requests_reset_at is None:
-                self._ratelimit_requests_reset_at = datetime.now() + timedelta(
-                    seconds=1
-                )
+                self._ratelimit_requests_reset_at = datetime.now() + timedelta(seconds=1)
 
         reset_tokens_at = response.headers.get("x-ratelimit-reset-tokens")
         if reset_tokens_at is not None:
@@ -174,19 +142,9 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             )
 
             if self._ratelimit_tokens_reset_at is None:
-                self._ratelimit_tokens_reset_at = datetime.now() + timedelta(
-                    seconds=1
-                )
+                self._ratelimit_tokens_reset_at = datetime.now() + timedelta(seconds=1)
 
-        self._ratelimit_request_limit = response.headers.get(
-            "x-ratelimit-limit-requests"
-        )
-        self._ratelimit_requests_remaining = response.headers.get(
-            "x-ratelimit-remaining-requests"
-        )
-        self._ratelimit_token_limit = response.headers.get(
-            "x-ratelimit-limit-tokens"
-        )
-        self._ratelimit_tokens_remaining = response.headers.get(
-            "x-ratelimit-remaining-tokens"
-        )
+        self._ratelimit_request_limit = response.headers.get("x-ratelimit-limit-requests")
+        self._ratelimit_requests_remaining = response.headers.get("x-ratelimit-remaining-requests")
+        self._ratelimit_token_limit = response.headers.get("x-ratelimit-limit-tokens")
+        self._ratelimit_tokens_remaining = response.headers.get("x-ratelimit-remaining-tokens")

--- a/griptape/drivers/prompt/openai_completion_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_completion_prompt_driver.py
@@ -28,23 +28,15 @@ class OpenAiCompletionPromptDriver(BasePromptDriver):
     api_type: str = field(default=openai.api_type, kw_only=True)
     api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     api_base: str = field(default=openai.api_base, kw_only=True)
-    api_key: Optional[str] = field(
-        default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True
-    )
-    organization: Optional[str] = field(
-        default=openai.organization, kw_only=True
-    )
+    api_key: Optional[str] = field(default=Factory(lambda: os.environ.get("OPENAI_API_KEY")), kw_only=True)
+    organization: Optional[str] = field(default=openai.organization, kw_only=True)
     model: str = field(kw_only=True)
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda self: OpenAiTokenizer(model=self.model), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
     user: str = field(default="", kw_only=True)
     ignored_exception_types: Tuple[Type[Exception], ...] = field(
-        default=Factory(lambda: (ImportError, openai.InvalidRequestError)),
-        kw_only=True,
+        default=Factory(lambda: (ImportError, openai.InvalidRequestError)), kw_only=True
     )
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
@@ -53,14 +45,10 @@ class OpenAiCompletionPromptDriver(BasePromptDriver):
         if len(result.choices) == 1:
             return TextArtifact(value=result.choices[0].text.strip())
         else:
-            raise Exception(
-                "completion with more than one choice is not supported yet"
-            )
+            raise Exception("completion with more than one choice is not supported yet")
 
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        result = openai.Completion.create(
-            **self._base_params(prompt_stack), stream=True
-        )
+        result = openai.Completion.create(**self._base_params(prompt_stack), stream=True)
 
         for chunk in result:
             if len(chunk.choices) == 1:
@@ -69,9 +57,7 @@ class OpenAiCompletionPromptDriver(BasePromptDriver):
                 yield TextArtifact(value=delta_content)
 
             else:
-                raise Exception(
-                    "completion with more than one choice is not supported yet"
-                )
+                raise Exception("completion with more than one choice is not supported yet")
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         prompt = self.prompt_stack_to_string(prompt_stack)

--- a/griptape/drivers/prompt_model/base_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/base_prompt_model_driver.py
@@ -11,9 +11,7 @@ from griptape.tokenizers import BaseTokenizer
 @define
 class BasePromptModelDriver(ABC):
     max_tokens: int = field(default=600, kw_only=True)
-    prompt_driver: Optional[BasePromptDriver] = field(
-        default=None, kw_only=True
-    )
+    prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
     supports_streaming: bool = field(default=True, kw_only=True)
 
     @property
@@ -22,9 +20,7 @@ class BasePromptModelDriver(ABC):
         ...
 
     @abstractmethod
-    def prompt_stack_to_model_input(
-        self, prompt_stack: PromptStack
-    ) -> str | list | dict:
+    def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> str | list | dict:
         ...
 
     @abstractmethod

--- a/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
@@ -12,9 +12,7 @@ class BedrockClaudePromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.999, kw_only=True)
     top_k: int = field(default=250, kw_only=True)
     _tokenizer: BedrockClaudeTokenizer = field(default=None, kw_only=True)
-    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(
-        default=None, kw_only=True
-    )
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockClaudeTokenizer:
@@ -35,9 +33,7 @@ class BedrockClaudePromptModelDriver(BasePromptModelDriver):
         if self._tokenizer:
             return self._tokenizer
         else:
-            self._tokenizer = BedrockClaudeTokenizer(
-                model=self.prompt_driver.model
-            )
+            self._tokenizer = BedrockClaudeTokenizer(model=self.prompt_driver.model)
             return self._tokenizer
 
     def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> dict:
@@ -57,9 +53,7 @@ class BedrockClaudePromptModelDriver(BasePromptModelDriver):
         prompt = self.prompt_stack_to_model_input(prompt_stack)["prompt"]
 
         return {
-            "max_tokens_to_sample": self.prompt_driver.max_output_tokens(
-                prompt
-            ),
+            "max_tokens_to_sample": self.prompt_driver.max_output_tokens(prompt),
             "stop_sequences": self.tokenizer.stop_sequences,
             "temperature": self.prompt_driver.temperature,
             "top_p": self.top_p,

--- a/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
@@ -12,9 +12,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockJurassicPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockJurassicTokenizer = field(default=None, kw_only=True)
-    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(
-        default=None, kw_only=True
-    )
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
     supports_streaming: bool = field(default=False, kw_only=True)
 
     @property
@@ -37,8 +35,7 @@ class BedrockJurassicPromptModelDriver(BasePromptModelDriver):
             return self._tokenizer
         else:
             self._tokenizer = BedrockJurassicTokenizer(
-                model=self.prompt_driver.model,
-                session=self.prompt_driver.session,
+                model=self.prompt_driver.model, session=self.prompt_driver.session
             )
             return self._tokenizer
 

--- a/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
@@ -13,9 +13,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockTitanPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockTitanTokenizer = field(default=None, kw_only=True)
-    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(
-        default=None, kw_only=True
-    )
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockTitanTokenizer:
@@ -36,10 +34,7 @@ class BedrockTitanPromptModelDriver(BasePromptModelDriver):
         if self._tokenizer:
             return self._tokenizer
         else:
-            self._tokenizer = BedrockTitanTokenizer(
-                model=self.prompt_driver.model,
-                session=self.prompt_driver.session,
-            )
+            self._tokenizer = BedrockTitanTokenizer(model=self.prompt_driver.model, session=self.prompt_driver.session)
             return self._tokenizer
 
     def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> dict:

--- a/griptape/drivers/prompt_model/sagemaker_falcon_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/sagemaker_falcon_prompt_model_driver.py
@@ -10,9 +10,7 @@ class SageMakerFalconPromptModelDriver(BasePromptModelDriver):
     tokenizer: BaseTokenizer = field(
         default=Factory(
             lambda self: HuggingFaceTokenizer(
-                tokenizer=import_optional_dependency(
-                    "transformers"
-                ).AutoTokenizer.from_pretrained(
+                tokenizer=import_optional_dependency("transformers").AutoTokenizer.from_pretrained(
                     "tiiuae/falcon-40b", model_max_length=self.max_tokens
                 )
             ),

--- a/griptape/drivers/prompt_model/sagemaker_llama_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/sagemaker_llama_prompt_model_driver.py
@@ -10,11 +10,8 @@ class SageMakerLlamaPromptModelDriver(BasePromptModelDriver):
     tokenizer: BaseTokenizer = field(
         default=Factory(
             lambda self: HuggingFaceTokenizer(
-                tokenizer=import_optional_dependency(
-                    "transformers"
-                ).LlamaTokenizerFast.from_pretrained(
-                    "hf-internal-testing/llama-tokenizer",
-                    model_max_length=self.max_tokens,
+                tokenizer=import_optional_dependency("transformers").LlamaTokenizerFast.from_pretrained(
+                    "hf-internal-testing/llama-tokenizer", model_max_length=self.max_tokens
                 )
             ),
             takes_self=True,
@@ -23,12 +20,7 @@ class SageMakerLlamaPromptModelDriver(BasePromptModelDriver):
     )
 
     def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> list:
-        return [
-            [
-                {"role": i.role, "content": i.content}
-                for i in prompt_stack.inputs
-            ]
-        ]
+        return [[{"role": i.role, "content": i.content} for i in prompt_stack.inputs]]
 
     def prompt_stack_to_model_params(self, prompt_stack: PromptStack) -> dict:
         prompt = self.prompt_driver.prompt_stack_to_string(prompt_stack)

--- a/griptape/drivers/sql/amazon_redshift_sql_driver.py
+++ b/griptape/drivers/sql/amazon_redshift_sql_driver.py
@@ -15,39 +15,26 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
     cluster_identifier: Optional[str] = field(default=None, kw_only=True)
     workgroup_name: Optional[str] = field(default=None, kw_only=True)
     db_user: Optional[str] = field(default=None, kw_only=True)
-    database_credentials_secret_arn: Optional[str] = field(
-        default=None, kw_only=True
-    )
+    database_credentials_secret_arn: Optional[str] = field(default=None, kw_only=True)
     wait_for_query_completion_sec: float = field(default=0.3, kw_only=True)
     client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("redshift-data"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("redshift-data"), takes_self=True), kw_only=True
     )
 
     @workgroup_name.validator
     def validate_params(self, _, workgroup_name: Optional[str]) -> None:
         if not self.cluster_identifier and not self.workgroup_name:
-            raise ValueError(
-                "Provide a value for one of `cluster_identifier` or `workgroup_name`"
-            )
+            raise ValueError("Provide a value for one of `cluster_identifier` or `workgroup_name`")
         elif self.cluster_identifier and self.workgroup_name:
-            raise ValueError(
-                "Provide a value for either `cluster_identifier` or `workgroup_name`, but not both"
-            )
+            raise ValueError("Provide a value for either `cluster_identifier` or `workgroup_name`, but not both")
 
     @classmethod
     def _process_rows_from_records(cls, records) -> list[list]:
         return [[c[list(c.keys())[0]] for c in r] for r in records]
 
     @classmethod
-    def _process_cells_from_rows_and_columns(
-        cls, columns: list, rows: list[list]
-    ) -> list[dict[str, Any]]:
-        return [
-            {column: r[idx] for idx, column in enumerate(columns)} for r in rows
-        ]
+    def _process_cells_from_rows_and_columns(cls, columns: list, rows: list[list]) -> list[dict[str, Any]]:
+        return [{column: r[idx] for idx, column in enumerate(columns)} for r in rows]
 
     @classmethod
     def _process_columns_from_column_metadata(cls, meta) -> list:
@@ -59,9 +46,7 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
         rows = cls._process_rows_from_records(records)
         return cls._process_cells_from_rows_and_columns(columns, rows)
 
-    def execute_query(
-        self, query: str
-    ) -> Optional[list[BaseSqlDriver.RowResult]]:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
         if rows:
             return [BaseSqlDriver.RowResult(row) for row in rows]
@@ -98,16 +83,12 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
                 )
                 results = results + response.get("Records", [])
 
-            return self._post_process(
-                statement_result["ColumnMetadata"], results
-            )
+            return self._post_process(statement_result["ColumnMetadata"], results)
 
         elif statement["Status"] in ["FAILED", "ABORTED"]:
             return None
 
-    def get_table_schema(
-        self, table: str, schema: Optional[str] = None
-    ) -> Optional[str]:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         function_kwargs = {"Database": self.database, "Table": table}
         if schema:
             function_kwargs["Schema"] = schema

--- a/griptape/drivers/sql/base_sql_driver.py
+++ b/griptape/drivers/sql/base_sql_driver.py
@@ -19,7 +19,5 @@ class BaseSqlDriver(ABC):
         ...
 
     @abstractmethod
-    def get_table_schema(
-        self, table: str, schema: Optional[str] = None
-    ) -> Optional[str]:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         ...

--- a/griptape/drivers/sql/snowflake_sql_driver.py
+++ b/griptape/drivers/sql/snowflake_sql_driver.py
@@ -25,31 +25,21 @@ class SnowflakeSqlDriver(BaseSqlDriver):
     )
 
     @connection_func.validator
-    def validate_connection_func(
-        self, _, connection_func: Callable[[], SnowflakeConnection]
-    ) -> None:
+    def validate_connection_func(self, _, connection_func: Callable[[], SnowflakeConnection]) -> None:
         snowflake_connection = connection_func()
         snowflake = import_optional_dependency("snowflake")
 
-        if not isinstance(
-            snowflake_connection, snowflake.connector.SnowflakeConnection
-        ):
-            raise ValueError(
-                "The connection_func must return a SnowflakeConnection"
-            )
+        if not isinstance(snowflake_connection, snowflake.connector.SnowflakeConnection):
+            raise ValueError("The connection_func must return a SnowflakeConnection")
         if not snowflake_connection.schema or not snowflake_connection.database:
-            raise ValueError(
-                "Provide a schema and database for the Snowflake connection"
-            )
+            raise ValueError("Provide a schema and database for the Snowflake connection")
 
     @engine.validator
     def validate_engine_url(self, _, engine: Engine) -> None:
         if not engine.url.render_as_string().startswith("snowflake://"):
             raise ValueError("Provide a Snowflake connection")
 
-    def execute_query(
-        self, query: str
-    ) -> Optional[list[BaseSqlDriver.RowResult]]:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
 
         if rows:
@@ -64,28 +54,17 @@ class SnowflakeSqlDriver(BaseSqlDriver):
             results = con.execute(sqlalchemy.text(query))
 
             if results.returns_rows:
-                return [
-                    {column: value for column, value in result.items()}
-                    for result in results
-                ]
+                return [{column: value for column, value in result.items()} for result in results]
             else:
                 return None
 
-    def get_table_schema(
-        self, table: str, schema: Optional[str] = None
-    ) -> Optional[str]:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         try:
             metadata_obj = sqlalchemy.MetaData()
             metadata_obj.reflect(bind=self.engine)
-            table = sqlalchemy.Table(
-                table,
-                metadata_obj,
-                schema=schema,
-                autoload=True,
-                autoload_with=self.engine,
-            )
+            table = sqlalchemy.Table(table, metadata_obj, schema=schema, autoload=True, autoload_with=self.engine)
             return str([(c.name, c.type) for c in table.columns])
         except sqlalchemy.exc.NoSuchTableError:
             return None

--- a/griptape/drivers/sql/sql_driver.py
+++ b/griptape/drivers/sql/sql_driver.py
@@ -18,13 +18,9 @@ class SqlDriver(BaseSqlDriver):
     def __attrs_post_init__(self) -> None:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
-        self.engine = sqlalchemy.create_engine(
-            self.engine_url, **self.create_engine_params
-        )
+        self.engine = sqlalchemy.create_engine(self.engine_url, **self.create_engine_params)
 
-    def execute_query(
-        self, query: str
-    ) -> Optional[list[BaseSqlDriver.RowResult]]:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
 
         if rows:
@@ -39,25 +35,16 @@ class SqlDriver(BaseSqlDriver):
             results = con.execute(sqlalchemy.text(query))
 
             if results.returns_rows:
-                return [
-                    {column: value for column, value in result.items()}
-                    for result in results
-                ]
+                return [{column: value for column, value in result.items()} for result in results]
             else:
                 return None
 
-    def get_table_schema(
-        self, table: str, schema: Optional[str] = None
-    ) -> Optional[str]:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         try:
             table = sqlalchemy.Table(
-                table,
-                sqlalchemy.MetaData(bind=self.engine),
-                schema=schema,
-                autoload=True,
-                autoload_with=self.engine,
+                table, sqlalchemy.MetaData(bind=self.engine), schema=schema, autoload=True, autoload_with=self.engine
             )
             return str([(c.name, c.type) for c in table.columns])
         except sqlalchemy.exc.NoSuchTableError:

--- a/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
@@ -23,9 +23,7 @@ class AmazonOpenSearchVectorStoreDriver(OpenSearchVectorStoreDriver):
 
     http_auth: Optional[str | Tuple[str, str]] = field(
         default=Factory(
-            lambda self: import_optional_dependency(
-                "requests_aws4auth"
-            ).AWS4Auth(
+            lambda self: import_optional_dependency("requests_aws4auth").AWS4Auth(
                 self.session.get_credentials().access_key,
                 self.session.get_credentials().secret_key,
                 self.session.region_name,

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -28,32 +28,21 @@ class BaseVectorStoreDriver(ABC):
         namespace: Optional[str] = None
 
     embedding_driver: BaseEmbeddingDriver = field(kw_only=True)
-    futures_executor: futures.Executor = field(
-        default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True
-    )
+    futures_executor: futures.Executor = field(default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True)
 
     def upsert_text_artifacts(
-        self,
-        artifacts: dict[str, list[TextArtifact]],
-        meta: Optional[dict] = None,
-        **kwargs
+        self, artifacts: dict[str, list[TextArtifact]], meta: Optional[dict] = None, **kwargs
     ) -> None:
         utils.execute_futures_dict(
             {
-                namespace: self.futures_executor.submit(
-                    self.upsert_text_artifact, a, namespace, meta, **kwargs
-                )
+                namespace: self.futures_executor.submit(self.upsert_text_artifact, a, namespace, meta, **kwargs)
                 for namespace, artifact_list in artifacts.items()
                 for a in artifact_list
             }
         )
 
     def upsert_text_artifact(
-        self,
-        artifact: TextArtifact,
-        namespace: Optional[str] = None,
-        meta: Optional[dict] = None,
-        **kwargs
+        self, artifact: TextArtifact, namespace: Optional[str] = None, meta: Optional[dict] = None, **kwargs
     ) -> str:
         if not meta:
             meta = {}
@@ -65,13 +54,7 @@ class BaseVectorStoreDriver(ABC):
         else:
             vector = artifact.generate_embedding(self.embedding_driver)
 
-        return self.upsert_vector(
-            vector,
-            vector_id=artifact.id,
-            namespace=namespace,
-            meta=meta,
-            **kwargs
-        )
+        return self.upsert_vector(vector, vector_id=artifact.id, namespace=namespace, meta=meta, **kwargs)
 
     def upsert_text(
         self,
@@ -101,9 +84,7 @@ class BaseVectorStoreDriver(ABC):
         ...
 
     @abstractmethod
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Entry:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Entry:
         ...
 
     @abstractmethod

--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -8,12 +8,8 @@ from attr import define, field
 
 @define
 class LocalVectorStoreDriver(BaseVectorStoreDriver):
-    entries: dict[str, BaseVectorStoreDriver.Entry] = field(
-        factory=dict, kw_only=True
-    )
-    relatedness_fn: Callable = field(
-        default=lambda x, y: dot(x, y) / (norm(x) * norm(y)), kw_only=True
-    )
+    entries: dict[str, BaseVectorStoreDriver.Entry] = field(factory=dict, kw_only=True)
+    relatedness_fn: Callable = field(default=lambda x, y: dot(x, y) / (norm(x) * norm(y)), kw_only=True)
 
     def upsert_vector(
         self,
@@ -25,29 +21,17 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
     ) -> str:
         vector_id = vector_id if vector_id else utils.str_to_hash(str(vector))
 
-        self.entries[
-            self._namespaced_vector_id(vector_id, namespace)
-        ] = self.Entry(
+        self.entries[self._namespaced_vector_id(vector_id, namespace)] = self.Entry(
             id=vector_id, vector=vector, meta=meta, namespace=namespace
         )
 
         return vector_id
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Optional[BaseVectorStoreDriver.Entry]:
-        return self.entries.get(
-            self._namespaced_vector_id(vector_id, namespace), None
-        )
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
+        return self.entries.get(self._namespaced_vector_id(vector_id, namespace), None)
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        return [
-            entry
-            for key, entry in self.entries.items()
-            if namespace is None or entry.namespace == namespace
-        ]
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
+        return [entry for key, entry in self.entries.items() if namespace is None or entry.namespace == namespace]
 
     def query(
         self,
@@ -60,24 +44,17 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         query_embedding = self.embedding_driver.embed_string(query)
 
         if namespace:
-            entries = {
-                k: v
-                for (k, v) in self.entries.items()
-                if k.startswith(f"{namespace}-")
-            }
+            entries = {k: v for (k, v) in self.entries.items() if k.startswith(f"{namespace}-")}
         else:
             entries = self.entries
 
         entries_and_relatednesses = [
-            (entry, self.relatedness_fn(query_embedding, entry.vector))
-            for entry in entries.values()
+            (entry, self.relatedness_fn(query_embedding, entry.vector)) for entry in entries.values()
         ]
         entries_and_relatednesses.sort(key=lambda x: x[1], reverse=True)
 
         result = [
-            BaseVectorStoreDriver.QueryResult(
-                id=er[0].id, vector=er[0].vector, score=er[1], meta=er[0].meta
-            )
+            BaseVectorStoreDriver.QueryResult(id=er[0].id, vector=er[0].vector, score=er[1], meta=er[0].meta)
             for er in entries_and_relatednesses
         ][:count]
 
@@ -85,13 +62,7 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
             return result
         else:
             return [
-                BaseVectorStoreDriver.QueryResult(
-                    id=r.id,
-                    vector=[],
-                    score=r.score,
-                    meta=r.meta,
-                    namespace=r.namespace,
-                )
+                BaseVectorStoreDriver.QueryResult(id=r.id, vector=[], score=r.score, meta=r.meta, namespace=r.namespace)
                 for r in result
             ]
 

--- a/griptape/drivers/vector/mongodb_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_vector_store_driver.py
@@ -24,10 +24,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
     collection_name: str = field(kw_only=True)
     client: Optional[MongoClient] = field(
         default=Factory(
-            lambda self: import_optional_dependency("pymongo").MongoClient(
-                self.connection_string
-            ),
-            takes_self=True,
+            lambda self: import_optional_dependency("pymongo").MongoClient(self.connection_string), takes_self=True
         )
     )
 
@@ -50,21 +47,15 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
         collection = self.get_collection()
 
         if vector_id is None:
-            result = collection.insert_one(
-                {"vector": vector, "namespace": namespace, "meta": meta}
-            )
+            result = collection.insert_one({"vector": vector, "namespace": namespace, "meta": meta})
             vector_id = str(result.inserted_id)
         else:
             collection.replace_one(
-                {"_id": vector_id},
-                {"vector": vector, "namespace": namespace, "meta": meta},
-                upsert=True,
+                {"_id": vector_id}, {"vector": vector, "namespace": namespace, "meta": meta}, upsert=True
             )
         return vector_id
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Optional[BaseVectorStoreDriver.Entry]:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Loads a document entry from the MongoDB collection based on the vector ID.
 
         Returns:
@@ -75,15 +66,10 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
         if doc is None:
             return None
         return BaseVectorStoreDriver.Entry(
-            id=str(doc["_id"]),
-            vector=doc["vector"],
-            namespace=doc["namespace"],
-            meta=doc["meta"],
+            id=str(doc["_id"]), vector=doc["vector"], namespace=doc["namespace"], meta=doc["meta"]
         )
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Loads all document entries from the MongoDB collection.
 
         Entries can optionally be filtered by namespace.
@@ -96,10 +82,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
 
         for doc in cursor:
             yield BaseVectorStoreDriver.Entry(
-                id=str(doc["_id"]),
-                vector=doc["vector"],
-                namespace=doc["namespace"],
-                meta=doc["meta"],
+                id=str(doc["_id"]), vector=doc["vector"], namespace=doc["namespace"], meta=doc["meta"]
             )
 
     def query(
@@ -123,24 +106,14 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
 
         knn_k = count if count else 10
         pipeline = [
-            {
-                "$search": {
-                    "knnBeta": {
-                        "vector": vector,
-                        "path": "vector",
-                        "k": knn_k + offset,
-                    }
-                }
-            },
+            {"$search": {"knnBeta": {"vector": vector, "path": "vector", "k": knn_k + offset}}},
             {
                 "$project": {
                     "_id": 1,
                     "vector": 1,
                     "namespace": 1,
                     "meta": 1,
-                    "score": {
-                        "$meta": "searchScore"
-                    },  # Include the score in the projection
+                    "score": {"$meta": "searchScore"},  # Include the score in the projection
                 }
             },
             {"$skip": offset},

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -25,9 +25,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
 
     host: str = field(kw_only=True)
     port: int = field(default=443, kw_only=True)
-    http_auth: Optional[str | Tuple[str, str]] = field(
-        default=None, kw_only=True
-    )
+    http_auth: Optional[str | Tuple[str, str]] = field(default=None, kw_only=True)
     use_ssl: bool = field(default=True, kw_only=True)
     verify_certs: bool = field(default=True, kw_only=True)
     index_name: str = field(kw_only=True)
@@ -62,15 +60,11 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
         vector_id = vector_id if vector_id else utils.str_to_hash(str(vector))
         doc = {"vector": vector, "namespace": namespace, "metadata": meta}
         doc.update(kwargs)
-        response = self.client.index(
-            index=self.index_name, id=vector_id, body=doc
-        )
+        response = self.client.index(index=self.index_name, id=vector_id, body=doc)
 
         return response["_id"]
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Optional[BaseVectorStoreDriver.Entry]:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Retrieves a specific vector entry from OpenSearch based on its identifier and optional namespace.
 
         Returns:
@@ -82,9 +76,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             if namespace:
                 query["bool"]["must"].append({"term": {"namespace": namespace}})
 
-            response = self.client.search(
-                index=self.index_name, body={"query": query, "size": 1}
-            )
+            response = self.client.search(index=self.index_name, body={"query": query, "size": 1})
 
             if response["hits"]["total"]["value"] > 0:
                 vector_data = response["hits"]["hits"][0]["_source"]
@@ -101,9 +93,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             logging.error(f"Error while loading entry: {e}")
             return None
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Retrieves all vector entries from OpenSearch that match the optional namespace.
 
         Returns:
@@ -148,18 +138,12 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
         count = count if count else BaseVectorStoreDriver.DEFAULT_QUERY_COUNT
         vector = self.embedding_driver.embed_string(query)
         # Base k-NN query
-        query_body = {
-            "size": count,
-            "query": {"knn": {field_name: {"vector": vector, "k": count}}},
-        }
+        query_body = {"size": count, "query": {"knn": {field_name: {"vector": vector, "k": count}}}}
 
         if namespace:
             query_body["query"] = {
                 "bool": {
-                    "must": [
-                        {"match": {"namespace": namespace}},
-                        {"knn": {field_name: {"vector": vector, "k": count}}},
-                    ]
+                    "must": [{"match": {"namespace": namespace}}, {"knn": {field_name: {"vector": vector, "k": count}}}]
                 }
             }
 
@@ -168,25 +152,15 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
         return [
             BaseVectorStoreDriver.QueryResult(
                 id=hit["_id"],
-                namespace=hit["_source"].get("namespace")
-                if namespace
-                else None,
+                namespace=hit["_source"].get("namespace") if namespace else None,
                 score=hit["_score"],
-                vector=hit["_source"].get("vector")
-                if include_vectors
-                else None,
-                meta=hit["_source"].get("metadata")
-                if include_metadata
-                else None,
+                vector=hit["_source"].get("vector") if include_vectors else None,
+                meta=hit["_source"].get("metadata") if include_metadata else None,
             )
             for hit in response["hits"]["hits"]
         ]
 
-    def create_index(
-        self,
-        vector_dimension: Optional[int] = None,
-        settings_override: Optional[dict] = None,
-    ) -> None:
+    def create_index(self, vector_dimension: Optional[int] = None, settings_override: Optional[dict] = None) -> None:
         """Creates a new vector index in OpenSearch.
 
         The index is structured to support k-NN (k-nearest neighbors) queries.
@@ -195,11 +169,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             vector_dimension: The dimension of vectors that will be stored in this index.
 
         """
-        default_settings = {
-            "number_of_shards": 1,
-            "number_of_replicas": 1,
-            "index.knn": True,
-        }
+        default_settings = {"number_of_shards": 1, "number_of_replicas": 1, "index.knn": True}
 
         if settings_override:
             default_settings.update(settings_override)
@@ -213,10 +183,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
                     "settings": default_settings,
                     "mappings": {
                         "properties": {
-                            "vector": {
-                                "type": "knn_vector",
-                                "dimension": vector_dimension,
-                            },
+                            "vector": {"type": "knn_vector", "dimension": vector_dimension},
                             "namespace": {"type": "keyword"},
                             "metadata": {"type": "object", "enabled": True},
                         }

--- a/griptape/drivers/vector/pgvector_vector_store_driver.py
+++ b/griptape/drivers/vector/pgvector_vector_store_driver.py
@@ -26,16 +26,10 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
     create_engine_params: dict = field(factory=dict, kw_only=True)
     engine: Optional[Engine] = field(default=None, kw_only=True)
     table_name: str = field(kw_only=True)
-    _model: any = field(
-        default=Factory(
-            lambda self: self.default_vector_model(), takes_self=True
-        )
-    )
+    _model: any = field(default=Factory(lambda self: self.default_vector_model(), takes_self=True))
 
     @connection_string.validator
-    def validate_connection_string(
-        self, _, connection_string: Optional[str]
-    ) -> None:
+    def validate_connection_string(self, _, connection_string: Optional[str]) -> None:
         # If an engine is provided, the connection string is not used.
         if self.engine is not None:
             return
@@ -45,9 +39,7 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
             raise ValueError("An engine or connection string is required")
 
         if not connection_string.startswith("postgresql://"):
-            raise ValueError(
-                "The connection string must describe a Postgres database connection"
-            )
+            raise ValueError("The connection string must describe a Postgres database connection")
 
     @engine.validator
     def validate_engine(self, _, engine: Optional[Engine]) -> None:
@@ -64,15 +56,10 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
         If not, a connection string is used to create a new database connection here.
         """
         if self.engine is None:
-            self.engine = create_engine(
-                self.connection_string, **self.create_engine_params
-            )
+            self.engine = create_engine(self.connection_string, **self.create_engine_params)
 
     def setup(
-        self,
-        create_schema: bool = True,
-        install_uuid_extension: bool = True,
-        install_vector_extension: bool = True,
+        self, create_schema: bool = True, install_uuid_extension: bool = True, install_vector_extension: bool = True
     ) -> None:
         """Provides a mechanism to initialize the database schema and extensions."""
         if install_uuid_extension:
@@ -94,32 +81,23 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
     ) -> str:
         """Inserts or updates a vector in the collection."""
         with Session(self.engine) as session:
-            obj = self._model(
-                id=vector_id, vector=vector, namespace=namespace, meta=meta
-            )
+            obj = self._model(id=vector_id, vector=vector, namespace=namespace, meta=meta)
 
             obj = session.merge(obj)
             session.commit()
 
             return str(obj.id)
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> BaseVectorStoreDriver.Entry:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> BaseVectorStoreDriver.Entry:
         """Retrieves a specific vector entry from the collection based on its identifier and optional namespace."""
         with Session(self.engine) as session:
             result = session.get(self._model, vector_id)
 
             return BaseVectorStoreDriver.Entry(
-                id=result.id,
-                vector=result.vector,
-                namespace=result.namespace,
-                meta=result.meta,
+                id=result.id, vector=result.vector, namespace=result.namespace, meta=result.meta
             )
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Retrieves all vector entries from the collection, optionally filtering to only
         those that match the provided namespace.
         """
@@ -132,10 +110,7 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
 
             return [
                 BaseVectorStoreDriver.Entry(
-                    id=str(result.id),
-                    vector=result.vector,
-                    namespace=result.namespace,
-                    meta=result.meta,
+                    id=str(result.id), vector=result.vector, namespace=result.namespace, meta=result.meta
                 )
                 for result in results
             ]
@@ -167,9 +142,7 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
             vector = self.embedding_driver.embed_string(query)
 
             # The query should return both the vector and the distance metric score.
-            query = session.query(
-                self._model, op(vector).label("score")
-            ).order_by(op(vector))
+            query = session.query(self._model, op(vector).label("score")).order_by(op(vector))
 
             if namespace:
                 query = query.filter_by(namespace=namespace)
@@ -194,13 +167,7 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
         class VectorModel(Base):
             __tablename__ = self.table_name
 
-            id = Column(
-                UUID(as_uuid=True),
-                primary_key=True,
-                default=uuid.uuid4,
-                unique=True,
-                nullable=False,
-            )
+            id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
             vector = Column(Vector())
             namespace = Column(String)
             meta = Column(JSON)

--- a/griptape/drivers/vector/pinecone_vector_store_driver.py
+++ b/griptape/drivers/vector/pinecone_vector_store_driver.py
@@ -18,11 +18,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
 
     def __attrs_post_init__(self) -> None:
         pinecone = import_optional_dependency("pinecone")
-        pinecone.init(
-            api_key=self.api_key,
-            environment=self.environment,
-            project_name=self.project_name,
-        )
+        pinecone.init(api_key=self.api_key, environment=self.environment, project_name=self.project_name)
 
         self.index = pinecone.Index(self.index_name)
 
@@ -42,46 +38,31 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
 
         return vector_id
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Optional[BaseVectorStoreDriver.Entry]:
-        result = self.index.fetch(
-            ids=[vector_id], namespace=namespace
-        ).to_dict()
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
+        result = self.index.fetch(ids=[vector_id], namespace=namespace).to_dict()
         vectors = list(result["vectors"].values())
 
         if len(vectors) > 0:
             vector = vectors[0]
 
             return BaseVectorStoreDriver.Entry(
-                id=vector["id"],
-                meta=vector["metadata"],
-                vector=vector["values"],
-                namespace=result["namespace"],
+                id=vector["id"], meta=vector["metadata"], vector=vector["values"], namespace=result["namespace"]
             )
         else:
             return None
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         # This is a hacky way to query up to 10,000 values from Pinecone. Waiting on an official API for fetching
         # all values from a namespace:
         # https://community.pinecone.io/t/is-there-a-way-to-query-all-the-vectors-and-or-metadata-from-a-namespace/797/5
 
         results = self.index.query(
-            self.embedding_driver.embed_string(""),
-            top_k=10000,
-            include_metadata=True,
-            namespace=namespace,
+            self.embedding_driver.embed_string(""), top_k=10000, include_metadata=True, namespace=namespace
         )
 
         return [
             BaseVectorStoreDriver.Entry(
-                id=r["id"],
-                vector=r["values"],
-                meta=r["metadata"],
-                namespace=results["namespace"],
+                id=r["id"], vector=r["values"], meta=r["metadata"], namespace=results["namespace"]
             )
             for r in results["matches"]
         ]
@@ -99,9 +80,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
         vector = self.embedding_driver.embed_string(query)
 
         params = {
-            "top_k": count
-            if count
-            else BaseVectorStoreDriver.DEFAULT_QUERY_COUNT,
+            "top_k": count if count else BaseVectorStoreDriver.DEFAULT_QUERY_COUNT,
             "namespace": namespace,
             "include_values": include_vectors,
             "include_metadata": include_metadata,
@@ -111,20 +90,13 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
 
         return [
             BaseVectorStoreDriver.QueryResult(
-                id=r["id"],
-                vector=r["values"],
-                score=r["score"],
-                meta=r["metadata"],
-                namespace=results["namespace"],
+                id=r["id"], vector=r["values"], score=r["score"], meta=r["metadata"], namespace=results["namespace"]
             )
             for r in results["matches"]
         ]
 
     def create_index(self, name: str, **kwargs) -> None:
-        params = {
-            "name": name,
-            "dimension": self.embedding_driver.dimensions,
-        } | kwargs
+        params = {"name": name, "dimension": self.embedding_driver.dimensions} | kwargs
 
         pinecone = import_optional_dependency("pinecone")
         pinecone.create_index(**params)

--- a/griptape/drivers/vector/redis_vector_store_driver.py
+++ b/griptape/drivers/vector/redis_vector_store_driver.py
@@ -38,11 +38,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     client: Redis = field(
         default=Factory(
             lambda self: import_optional_dependency("redis").Redis(
-                host=self.host,
-                port=self.port,
-                db=self.db,
-                password=self.password,
-                decode_responses=False,
+                host=self.host, port=self.port, db=self.db, password=self.password, decode_responses=False
             ),
             takes_self=True,
         )
@@ -65,10 +61,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         key = self._generate_key(vector_id, namespace)
         bytes_vector = json.dumps(vector).encode("utf-8")
 
-        mapping = {
-            "vector": np.array(vector, dtype=np.float32).tobytes(),
-            "vec_string": bytes_vector,
-        }
+        mapping = {"vector": np.array(vector, dtype=np.float32).tobytes(), "vec_string": bytes_vector}
 
         if meta:
             mapping["metadata"] = json.dumps(meta)
@@ -77,9 +70,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
 
         return vector_id
 
-    def load_entry(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> Optional[BaseVectorStoreDriver.Entry]:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Retrieves a specific vector entry from Redis based on its identifier and optional namespace.
 
         Returns:
@@ -88,17 +79,11 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         key = self._generate_key(vector_id, namespace)
         result = self.client.hgetall(key)
         vector = np.frombuffer(result[b"vector"], dtype=np.float32).tolist()
-        meta = (
-            json.loads(result[b"metadata"]) if b"metadata" in result else None
-        )
+        meta = json.loads(result[b"metadata"]) if b"metadata" in result else None
 
-        return BaseVectorStoreDriver.Entry(
-            id=vector_id, meta=meta, vector=vector, namespace=namespace
-        )
+        return BaseVectorStoreDriver.Entry(id=vector_id, meta=meta, vector=vector, namespace=namespace)
 
-    def load_entries(
-        self, namespace: Optional[str] = None
-    ) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Retrieves all vector entries from Redis that match the optional namespace.
 
         Returns:
@@ -107,17 +92,10 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         pattern = f"{namespace}:*" if namespace else "*"
         keys = self.client.keys(pattern)
 
-        return [
-            self.load_entry(key.decode("utf-8"), namespace=namespace)
-            for key in keys
-        ]
+        return [self.load_entry(key.decode("utf-8"), namespace=namespace) for key in keys]
 
     def query(
-        self,
-        query: str,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
-        **kwargs,
+        self, query: str, count: Optional[int] = None, namespace: Optional[str] = None, **kwargs
     ) -> List[BaseVectorStoreDriver.QueryResult]:
         """Performs a nearest neighbor search on Redis to find vectors similar to the provided input vector.
 
@@ -140,21 +118,13 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
 
         query_params = {"vector": np.array(vector, dtype=np.float32).tobytes()}
 
-        results = (
-            self.client.ft(self.index)
-            .search(query_expression, query_params)
-            .docs
-        )
+        results = self.client.ft(self.index).search(query_expression, query_params).docs
 
         query_results = []
         for document in results:
             metadata = getattr(document, "metadata", None)
-            namespace = (
-                document.id.split(":")[0] if ":" in document.id else None
-            )
-            vector_id = (
-                document.id.split(":")[1] if ":" in document.id else document.id
-            )
+            namespace = document.id.split(":")[0] if ":" in document.id else None
+            vector_id = document.id.split(":")[1] if ":" in document.id else document.id
             vector_float_list = json.loads(document["vec_string"])
             query_results.append(
                 BaseVectorStoreDriver.QueryResult(
@@ -167,11 +137,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
             )
         return query_results
 
-    def create_index(
-        self,
-        namespace: Optional[str] = None,
-        vector_dimension: Optional[int] = None,
-    ) -> None:
+    def create_index(self, namespace: Optional[str] = None, vector_dimension: Optional[int] = None) -> None:
         """Creates a new index in Redis with the specified properties.
 
         If an index with the given name already exists, a warning is logged and the method does not proceed.
@@ -179,18 +145,10 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         Optionally, a namespace can be provided which will determine the prefix for document keys.
         The index is constructed with a TagField named "tag" and a VectorField that utilizes the cosine distance metric on FLOAT32 type vectors.
         """
-        TagField = import_optional_dependency(
-            "redis.commands.search.field"
-        ).TagField
-        VectorField = import_optional_dependency(
-            "redis.commands.search.field"
-        ).VectorField
-        IndexDefinition = import_optional_dependency(
-            "redis.commands.search.indexDefinition"
-        ).IndexDefinition
-        IndexType = import_optional_dependency(
-            "redis.commands.search.indexDefinition"
-        ).IndexType
+        TagField = import_optional_dependency("redis.commands.search.field").TagField
+        VectorField = import_optional_dependency("redis.commands.search.field").VectorField
+        IndexDefinition = import_optional_dependency("redis.commands.search.indexDefinition").IndexDefinition
+        IndexType = import_optional_dependency("redis.commands.search.indexDefinition").IndexType
 
         try:
             self.client.ft(self.index).info()
@@ -199,27 +157,15 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
             schema = (
                 TagField("tag"),
                 VectorField(
-                    "vector",
-                    "FLAT",
-                    {
-                        "TYPE": "FLOAT32",
-                        "DIM": vector_dimension,
-                        "DISTANCE_METRIC": "COSINE",
-                    },
+                    "vector", "FLAT", {"TYPE": "FLOAT32", "DIM": vector_dimension, "DISTANCE_METRIC": "COSINE"}
                 ),
             )
 
             doc_prefix = self._get_doc_prefix(namespace)
-            definition = IndexDefinition(
-                prefix=[doc_prefix], index_type=IndexType.HASH
-            )
-            self.client.ft(self.index).create_index(
-                fields=schema, definition=definition
-            )
+            definition = IndexDefinition(prefix=[doc_prefix], index_type=IndexType.HASH)
+            self.client.ft(self.index).create_index(fields=schema, definition=definition)
 
-    def _generate_key(
-        self, vector_id: str, namespace: Optional[str] = None
-    ) -> str:
+    def _generate_key(self, vector_id: str, namespace: Optional[str] = None) -> str:
         """Generates a Redis key using the provided vector ID and optionally a namespace."""
         return f"{namespace}:{vector_id}" if namespace else vector_id
 

--- a/griptape/engines/extraction/base_extraction_engine.py
+++ b/griptape/engines/extraction/base_extraction_engine.py
@@ -14,28 +14,19 @@ class BaseExtractionEngine(ABC):
     max_token_multiplier: float = field(default=0.5, kw_only=True)
     chunk_joiner: str = field(default="\n\n", kw_only=True)
     prompt_driver: BasePromptDriver = field(
-        default=Factory(
-            lambda: OpenAiChatPromptDriver(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
+        default=Factory(lambda: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)),
         kw_only=True,
     )
     chunker: BaseChunker = field(
         default=Factory(
-            lambda self: TextChunker(
-                tokenizer=self.prompt_driver.tokenizer,
-                max_tokens=self.max_chunker_tokens,
-            ),
+            lambda self: TextChunker(tokenizer=self.prompt_driver.tokenizer, max_tokens=self.max_chunker_tokens),
             takes_self=True,
         ),
         kw_only=True,
     )
 
     @max_token_multiplier.validator
-    def validate_max_token_multiplier(
-        self, _, max_token_multiplier: int
-    ) -> None:
+    def validate_max_token_multiplier(self, _, max_token_multiplier: int) -> None:
         if max_token_multiplier > 1:
             raise ValueError("has to be less than or equal to 1")
         elif max_token_multiplier <= 0:
@@ -43,23 +34,15 @@ class BaseExtractionEngine(ABC):
 
     @property
     def max_chunker_tokens(self) -> int:
-        return round(
-            self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier
-        )
+        return round(self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier)
 
     @property
     def min_response_tokens(self) -> int:
         return round(
             self.prompt_driver.tokenizer.max_tokens
-            - self.prompt_driver.tokenizer.max_tokens
-            * self.max_token_multiplier
+            - self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier
         )
 
     @abstractmethod
-    def extract(
-        self,
-        text: str | ListArtifact,
-        rulesets: Optional[list[Ruleset]] = None,
-        **kwargs,
-    ) -> ListArtifact:
+    def extract(self, text: str | ListArtifact, rulesets: Optional[list[Ruleset]] = None, **kwargs) -> ListArtifact:
         ...

--- a/griptape/engines/extraction/json_extraction_engine.py
+++ b/griptape/engines/extraction/json_extraction_engine.py
@@ -11,25 +11,17 @@ from griptape.rules import Ruleset, rule
 
 @define
 class JsonExtractionEngine(BaseExtractionEngine):
-    template_generator: J2 = field(
-        default=Factory(lambda: J2("engines/extraction/json_extraction.j2")),
-        kw_only=True,
-    )
+    template_generator: J2 = field(default=Factory(lambda: J2("engines/extraction/json_extraction.j2")), kw_only=True)
 
     def extract(
-        self,
-        text: str | ListArtifact,
-        template_schema: dict,
-        rulesets: Optional[Ruleset] = None,
+        self, text: str | ListArtifact, template_schema: dict, rulesets: Optional[Ruleset] = None
     ) -> ListArtifact | ErrorArtifact:
         try:
             json_schema = json.dumps(template_schema)
 
             return ListArtifact(
                 self._extract_rec(
-                    text.value
-                    if isinstance(text, ListArtifact)
-                    else [TextArtifact(text)],
+                    text.value if isinstance(text, ListArtifact) else [TextArtifact(text)],
                     json_schema,
                     [],
                     rulesets=rulesets,
@@ -56,20 +48,11 @@ class JsonExtractionEngine(BaseExtractionEngine):
             rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
         )
 
-        if (
-            self.prompt_driver.tokenizer.count_tokens_left(full_text)
-            >= self.min_response_tokens
-        ):
+        if self.prompt_driver.tokenizer.count_tokens_left(full_text) >= self.min_response_tokens:
             extractions.extend(
                 self.json_to_text_artifacts(
                     self.prompt_driver.run(
-                        PromptStack(
-                            inputs=[
-                                PromptStack.Input(
-                                    full_text, role=PromptStack.USER_ROLE
-                                )
-                            ]
-                        )
+                        PromptStack(inputs=[PromptStack.Input(full_text, role=PromptStack.USER_ROLE)])
                     ).value
                 )
             )
@@ -86,17 +69,9 @@ class JsonExtractionEngine(BaseExtractionEngine):
             extractions.extend(
                 self.json_to_text_artifacts(
                     self.prompt_driver.run(
-                        PromptStack(
-                            inputs=[
-                                PromptStack.Input(
-                                    partial_text, role=PromptStack.USER_ROLE
-                                )
-                            ]
-                        )
+                        PromptStack(inputs=[PromptStack.Input(partial_text, role=PromptStack.USER_ROLE)])
                     ).value
                 )
             )
 
-            return self._extract_rec(
-                chunks[1:], json_template_schema, extractions, rulesets=rulesets
-            )
+            return self._extract_rec(chunks[1:], json_template_schema, extractions, rulesets=rulesets)

--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -9,11 +9,7 @@ from griptape.rules import Ruleset
 class BaseQueryEngine(ABC):
     @abstractmethod
     def query(
-        self,
-        query: str,
-        namespace: Optional[str] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        **kwargs
+        self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None, **kwargs
     ) -> TextArtifact:
         ...
 
@@ -22,13 +18,9 @@ class BaseQueryEngine(ABC):
         ...
 
     @abstractmethod
-    def upsert_text_artifact(
-        self, artifact: TextArtifact, namespace: Optional[str] = None
-    ) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
         ...
 
     @abstractmethod
-    def upsert_text_artifacts(
-        self, artifacts: list[TextArtifact], namespace: str
-    ) -> None:
+    def upsert_text_artifacts(self, artifacts: list[TextArtifact], namespace: str) -> None:
         ...

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -17,17 +17,10 @@ class VectorQueryEngine(BaseQueryEngine):
     answer_token_offset: int = field(default=400, kw_only=True)
     vector_store_driver: BaseVectorStoreDriver = field(kw_only=True)
     prompt_driver: BasePromptDriver = field(
-        default=Factory(
-            lambda: OpenAiChatPromptDriver(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
+        default=Factory(lambda: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)),
         kw_only=True,
     )
-    template_generator: J2 = field(
-        default=Factory(lambda: J2("engines/query/vector_query.j2")),
-        kw_only=True,
-    )
+    template_generator: J2 = field(default=Factory(lambda: J2("engines/query/vector_query.j2")), kw_only=True)
 
     def query(
         self,
@@ -40,11 +33,7 @@ class VectorQueryEngine(BaseQueryEngine):
         tokenizer = self.prompt_driver.tokenizer
         result = self.vector_store_driver.query(query, top_n, namespace)
         artifacts = [
-            a
-            for a in [
-                BaseArtifact.from_json(r.meta["artifact"]) for r in result
-            ]
-            if isinstance(a, TextArtifact)
+            a for a in [BaseArtifact.from_json(r.meta["artifact"]) for r in result] if isinstance(a, TextArtifact)
         ]
         text_segments = []
         message = ""
@@ -59,58 +48,33 @@ class VectorQueryEngine(BaseQueryEngine):
                 rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
             )
             message_token_count = self.prompt_driver.token_count(
-                PromptStack(
-                    inputs=[
-                        PromptStack.Input(message, role=PromptStack.USER_ROLE)
-                    ]
-                )
+                PromptStack(inputs=[PromptStack.Input(message, role=PromptStack.USER_ROLE)])
             )
 
-            if (
-                message_token_count + self.answer_token_offset
-                >= tokenizer.max_tokens
-            ):
+            if message_token_count + self.answer_token_offset >= tokenizer.max_tokens:
                 text_segments.pop()
 
                 message = self.template_generator.render(
                     metadata=metadata,
                     query=query,
                     text_segments=text_segments,
-                    rulesets=J2("rulesets/rulesets.j2").render(
-                        rulesets=rulesets
-                    ),
+                    rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
                 )
 
                 break
 
-        return self.prompt_driver.run(
-            PromptStack(
-                inputs=[PromptStack.Input(message, role=PromptStack.USER_ROLE)]
-            )
-        )
+        return self.prompt_driver.run(PromptStack(inputs=[PromptStack.Input(message, role=PromptStack.USER_ROLE)]))
 
-    def upsert_text_artifact(
-        self, artifact: TextArtifact, namespace: Optional[str] = None
-    ) -> str:
-        result = self.vector_store_driver.upsert_text_artifact(
-            artifact, namespace=namespace
-        )
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
+        result = self.vector_store_driver.upsert_text_artifact(artifact, namespace=namespace)
 
         return result
 
-    def upsert_text_artifacts(
-        self, artifacts: list[TextArtifact], namespace: str
-    ) -> None:
+    def upsert_text_artifacts(self, artifacts: list[TextArtifact], namespace: str) -> None:
         self.vector_store_driver.upsert_text_artifacts({namespace: artifacts})
 
     def load_artifacts(self, namespace: str) -> ListArtifact:
         result = self.vector_store_driver.load_entries(namespace)
-        artifacts = [
-            BaseArtifact.from_json(r.meta["artifact"])
-            for r in result
-            if r.meta.get("artifact")
-        ]
+        artifacts = [BaseArtifact.from_json(r.meta["artifact"]) for r in result if r.meta.get("artifact")]
 
-        return ListArtifact(
-            [a for a in artifacts if isinstance(a, TextArtifact)]
-        )
+        return ListArtifact([a for a in artifacts if isinstance(a, TextArtifact)])

--- a/griptape/engines/summary/base_summary_engine.py
+++ b/griptape/engines/summary/base_summary_engine.py
@@ -7,15 +7,9 @@ from griptape.rules import Ruleset
 
 @define
 class BaseSummaryEngine(ABC):
-    def summarize_text(
-        self, text: str, rulesets: Optional[list[Ruleset]] = None
-    ) -> str:
-        return self.summarize_artifacts(
-            ListArtifact([TextArtifact(text)]), rulesets=rulesets
-        ).value
+    def summarize_text(self, text: str, rulesets: Optional[list[Ruleset]] = None) -> str:
+        return self.summarize_artifacts(ListArtifact([TextArtifact(text)]), rulesets=rulesets).value
 
     @abstractmethod
-    def summarize_artifacts(
-        self, artifacts: ListArtifact, rulesets: Optional[list[Ruleset]] = None
-    ) -> TextArtifact:
+    def summarize_artifacts(self, artifacts: ListArtifact, rulesets: Optional[list[Ruleset]] = None) -> TextArtifact:
         ...

--- a/griptape/engines/summary/prompt_summary_engine.py
+++ b/griptape/engines/summary/prompt_summary_engine.py
@@ -14,24 +14,14 @@ from griptape.rules import Ruleset
 class PromptSummaryEngine(BaseSummaryEngine):
     chunk_joiner: str = field(default="\n\n", kw_only=True)
     max_token_multiplier: float = field(default=0.5, kw_only=True)
-    template_generator: J2 = field(
-        default=Factory(lambda: J2("engines/summary/prompt_summary.j2")),
-        kw_only=True,
-    )
+    template_generator: J2 = field(default=Factory(lambda: J2("engines/summary/prompt_summary.j2")), kw_only=True)
     prompt_driver: BasePromptDriver = field(
-        default=Factory(
-            lambda: OpenAiChatPromptDriver(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
+        default=Factory(lambda: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)),
         kw_only=True,
     )
     chunker: BaseChunker = field(
         default=Factory(
-            lambda self: TextChunker(
-                tokenizer=self.prompt_driver.tokenizer,
-                max_tokens=self.max_chunker_tokens,
-            ),
+            lambda self: TextChunker(tokenizer=self.prompt_driver.tokenizer, max_tokens=self.max_chunker_tokens),
             takes_self=True,
         ),
         kw_only=True,
@@ -46,71 +36,42 @@ class PromptSummaryEngine(BaseSummaryEngine):
 
     @property
     def max_chunker_tokens(self) -> int:
-        return round(
-            self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier
-        )
+        return round(self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier)
 
     @property
     def min_response_tokens(self) -> int:
         return round(
             self.prompt_driver.tokenizer.max_tokens
-            - self.prompt_driver.tokenizer.max_tokens
-            * self.max_token_multiplier
+            - self.prompt_driver.tokenizer.max_tokens * self.max_token_multiplier
         )
 
-    def summarize_artifacts(
-        self, artifacts: ListArtifact, rulesets: Optional[Ruleset] = None
-    ) -> TextArtifact:
-        return self.summarize_artifacts_rec(
-            artifacts.value, None, rulesets=rulesets
-        )
+    def summarize_artifacts(self, artifacts: ListArtifact, rulesets: Optional[Ruleset] = None) -> TextArtifact:
+        return self.summarize_artifacts_rec(artifacts.value, None, rulesets=rulesets)
 
     def summarize_artifacts_rec(
-        self,
-        artifacts: list[BaseArtifact],
-        summary: Optional[str],
-        rulesets: Optional[Ruleset] = None,
+        self, artifacts: list[BaseArtifact], summary: Optional[str], rulesets: Optional[Ruleset] = None
     ) -> TextArtifact:
-        artifacts_text = self.chunk_joiner.join(
-            [a.to_text() for a in artifacts]
-        )
+        artifacts_text = self.chunk_joiner.join([a.to_text() for a in artifacts])
 
         full_text = self.template_generator.render(
-            summary=summary,
-            text=artifacts_text,
-            rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
+            summary=summary, text=artifacts_text, rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets)
         )
 
-        if (
-            self.prompt_driver.tokenizer.count_tokens_left(full_text)
-            >= self.min_response_tokens
-        ):
+        if self.prompt_driver.tokenizer.count_tokens_left(full_text) >= self.min_response_tokens:
             return self.prompt_driver.run(
-                PromptStack(
-                    inputs=[
-                        PromptStack.Input(full_text, role=PromptStack.USER_ROLE)
-                    ]
-                )
+                PromptStack(inputs=[PromptStack.Input(full_text, role=PromptStack.USER_ROLE)])
             )
         else:
             chunks = self.chunker.chunk(artifacts_text)
 
             partial_text = self.template_generator.render(
-                summary=summary,
-                text=chunks[0].value,
-                rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
+                summary=summary, text=chunks[0].value, rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets)
             )
 
             return self.summarize_artifacts_rec(
                 chunks[1:],
                 self.prompt_driver.run(
-                    PromptStack(
-                        inputs=[
-                            PromptStack.Input(
-                                partial_text, role=PromptStack.USER_ROLE
-                            )
-                        ]
-                    )
+                    PromptStack(inputs=[PromptStack.Input(partial_text, role=PromptStack.USER_ROLE)])
                 ).value,
                 rulesets=rulesets,
             )

--- a/griptape/events/base_event.py
+++ b/griptape/events/base_event.py
@@ -10,10 +10,7 @@ from attr import define, field, Factory
 @define
 class BaseEvent(ABC):
     timestamp: float = field(default=Factory(lambda: time.time()), kw_only=True)
-    type: str = field(
-        default=Factory(lambda self: self.__class__.__name__, takes_self=True),
-        kw_only=True,
-    )
+    type: str = field(default=Factory(lambda self: self.__class__.__name__, takes_self=True), kw_only=True)
 
     @classmethod
     def from_dict(cls, event_dict: dict) -> BaseEvent:
@@ -33,26 +30,14 @@ class BaseEvent(ABC):
         class_registry.register("FinishPromptEvent", FinishPromptEventSchema)
         class_registry.register("StartTaskEvent", StartTaskEventSchema)
         class_registry.register("FinishTaskEvent", FinishTaskEventSchema)
-        class_registry.register(
-            "StartActionSubtaskEvent", StartActionSubtaskEventSchema
-        )
-        class_registry.register(
-            "FinishActionSubtaskEvent", FinishActionSubtaskEventSchema
-        )
-        class_registry.register(
-            "StartStructureRunEvent", StartStructureRunEventSchema
-        )
-        class_registry.register(
-            "FinishStructureRunEvent", FinishStructureRunEventSchema
-        )
-        class_registry.register(
-            "CompletionChunkEvent", CompletionChunkEventSchema
-        )
+        class_registry.register("StartActionSubtaskEvent", StartActionSubtaskEventSchema)
+        class_registry.register("FinishActionSubtaskEvent", FinishActionSubtaskEventSchema)
+        class_registry.register("StartStructureRunEvent", StartStructureRunEventSchema)
+        class_registry.register("FinishStructureRunEvent", FinishStructureRunEventSchema)
+        class_registry.register("CompletionChunkEvent", CompletionChunkEventSchema)
 
         try:
-            return class_registry.get_class(event_dict["type"])().load(
-                event_dict
-            )
+            return class_registry.get_class(event_dict["type"])().load(event_dict)
         except RegistryError:
             raise ValueError("Unsupported event type")
 

--- a/griptape/events/event_listener.py
+++ b/griptape/events/event_listener.py
@@ -6,6 +6,4 @@ from .base_event import BaseEvent
 @define
 class EventListener:
     handler: Callable[[BaseEvent], Any] = field()
-    event_types: Optional[list[Type[BaseEvent]]] = field(
-        default=None, kw_only=True
-    )
+    event_types: Optional[list[Type[BaseEvent]]] = field(default=None, kw_only=True)

--- a/griptape/loaders/base_loader.py
+++ b/griptape/loaders/base_loader.py
@@ -7,16 +7,12 @@ from griptape.artifacts import BaseArtifact
 
 @define
 class BaseLoader(ABC):
-    futures_executor: futures.Executor = field(
-        default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True
-    )
+    futures_executor: futures.Executor = field(default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True)
 
     @abstractmethod
     def load(self, *args, **kwargs) -> BaseArtifact | list[BaseArtifact]:
         ...
 
     @abstractmethod
-    def load_collection(
-        self, *args, **kwargs
-    ) -> dict[str, list[BaseArtifact | list[BaseArtifact]]]:
+    def load_collection(self, *args, **kwargs) -> dict[str, list[BaseArtifact | list[BaseArtifact]]]:
         ...

--- a/griptape/loaders/csv_loader.py
+++ b/griptape/loaders/csv_loader.py
@@ -9,22 +9,16 @@ from griptape.loaders import BaseLoader
 
 @define
 class CsvLoader(BaseLoader):
-    embedding_driver: Optional[BaseEmbeddingDriver] = field(
-        default=None, kw_only=True
-    )
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
     delimiter: str = field(default=",", kw_only=True)
 
     def load(self, filename: str) -> list[CsvRowArtifact]:
         return self._load_file(filename)
 
-    def load_collection(
-        self, filenames: list[str]
-    ) -> dict[str, list[CsvRowArtifact]]:
+    def load_collection(self, filenames: list[str]) -> dict[str, list[CsvRowArtifact]]:
         return utils.execute_futures_dict(
             {
-                utils.str_to_hash(filename): self.futures_executor.submit(
-                    self._load_file, filename
-                )
+                utils.str_to_hash(filename): self.futures_executor.submit(self._load_file, filename)
                 for filename in filenames
             }
         )

--- a/griptape/loaders/dataframe_loader.py
+++ b/griptape/loaders/dataframe_loader.py
@@ -14,21 +14,15 @@ if TYPE_CHECKING:
 
 @define
 class DataFrameLoader(BaseLoader):
-    embedding_driver: Optional[BaseEmbeddingDriver] = field(
-        default=None, kw_only=True
-    )
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
 
     def load(self, dataframe: DataFrame) -> list[CsvRowArtifact]:
         return self._load_file(dataframe)
 
-    def load_collection(
-        self, dataframes: list[DataFrame]
-    ) -> dict[str, list[CsvRowArtifact]]:
+    def load_collection(self, dataframes: list[DataFrame]) -> dict[str, list[CsvRowArtifact]]:
         return utils.execute_futures_dict(
             {
-                self._dataframe_to_hash(
-                    dataframe
-                ): self.futures_executor.submit(self._load_file, dataframe)
+                self._dataframe_to_hash(dataframe): self.futures_executor.submit(self._load_file, dataframe)
                 for dataframe in dataframes
             }
         )
@@ -36,9 +30,7 @@ class DataFrameLoader(BaseLoader):
     def _load_file(self, dataframe: DataFrame) -> list[CsvRowArtifact]:
         artifacts = []
 
-        chunks = [
-            CsvRowArtifact(row) for row in dataframe.to_dict(orient="records")
-        ]
+        chunks = [CsvRowArtifact(row) for row in dataframe.to_dict(orient="records")]
 
         if self.embedding_driver:
             for chunk in chunks:
@@ -50,6 +42,4 @@ class DataFrameLoader(BaseLoader):
         return artifacts
 
     def _dataframe_to_hash(self, dataframe: DataFrame) -> str:
-        return hashlib.sha256(
-            pd.util.hash_pandas_object(dataframe, index=True).values
-        ).hexdigest()
+        return hashlib.sha256(pd.util.hash_pandas_object(dataframe, index=True).values).hexdigest()

--- a/griptape/loaders/email_loader.py
+++ b/griptape/loaders/email_loader.py
@@ -34,21 +34,15 @@ class EmailLoader(BaseLoader):
     def load(self, query: EmailQuery) -> ListArtifact:
         return self._retrieve_email(query)
 
-    def load_collection(
-        self, queries: list[EmailQuery]
-    ) -> dict[str, ListArtifact | ErrorArtifact]:
+    def load_collection(self, queries: list[EmailQuery]) -> dict[str, ListArtifact | ErrorArtifact]:
         return utils.execute_futures_dict(
             {
-                utils.str_to_hash(str(query)): self.futures_executor.submit(
-                    self._retrieve_email, query
-                )
+                utils.str_to_hash(str(query)): self.futures_executor.submit(self._retrieve_email, query)
                 for query in set(queries)
             }
         )
 
-    def _retrieve_email(
-        self, query: EmailQuery
-    ) -> ListArtifact | ErrorArtifact:
+    def _retrieve_email(self, query: EmailQuery) -> ListArtifact | ErrorArtifact:
         label, key, search_criteria, max_count = astuple(query)
 
         list_artifact = ListArtifact()
@@ -61,9 +55,7 @@ class EmailLoader(BaseLoader):
                     raise Exception(mailbox[1][0].decode())
 
                 if key and search_criteria:
-                    _typ, [message_numbers] = client.search(
-                        None, key, f'"{search_criteria}"'
-                    )
+                    _typ, [message_numbers] = client.search(None, key, f'"{search_criteria}"')
                     messages_count = self._count_messages(message_numbers)
                 else:
                     messages_count = int(mailbox[1][0])
@@ -75,9 +67,7 @@ class EmailLoader(BaseLoader):
                     # Note: mailparser only populates the text_plain field
                     # if the message content type is explicitly set to 'text/plain'.
                     if message.text_plain:
-                        list_artifact.value.append(
-                            TextArtifact("\n".join(message.text_plain))
-                        )
+                        list_artifact.value.append(TextArtifact("\n".join(message.text_plain)))
 
                 client.close()
 

--- a/griptape/loaders/file_loader.py
+++ b/griptape/loaders/file_loader.py
@@ -12,40 +12,23 @@ from griptape.loaders import BaseLoader
 class FileLoader(BaseLoader):
     encoding: Optional[str] = field(default=None, kw_only=True)
 
-    def load(
-        self, path: str | Path
-    ) -> TextArtifact | BlobArtifact | ErrorArtifact:
+    def load(self, path: str | Path) -> TextArtifact | BlobArtifact | ErrorArtifact:
         return self.file_to_artifact(path)
 
-    def load_collection(
-        self, paths: list[str | Path]
-    ) -> dict[str, TextArtifact | BlobArtifact | ErrorArtifact]:
+    def load_collection(self, paths: list[str | Path]) -> dict[str, TextArtifact | BlobArtifact | ErrorArtifact]:
         return utils.execute_futures_dict(
-            {
-                utils.str_to_hash(str(path)): self.futures_executor.submit(
-                    self.file_to_artifact, path
-                )
-                for path in paths
-            }
+            {utils.str_to_hash(str(path)): self.futures_executor.submit(self.file_to_artifact, path) for path in paths}
         )
 
-    def file_to_artifact(
-        self, path: str | Path
-    ) -> TextArtifact | BlobArtifact | ErrorArtifact:
+    def file_to_artifact(self, path: str | Path) -> TextArtifact | BlobArtifact | ErrorArtifact:
         file_name = os.path.basename(path)
 
         try:
             with open(path, "rb") as file:
                 if self.encoding:
-                    return TextArtifact(
-                        file.read().decode(self.encoding), name=file_name
-                    )
+                    return TextArtifact(file.read().decode(self.encoding), name=file_name)
                 else:
-                    return BlobArtifact(
-                        file.read(),
-                        name=file_name,
-                        dir_name=os.path.dirname(path),
-                    )
+                    return BlobArtifact(file.read(), name=file_name, dir_name=os.path.dirname(path))
         except FileNotFoundError:
             return ErrorArtifact(f"file {file_name} not found")
         except Exception as e:

--- a/griptape/loaders/pdf_loader.py
+++ b/griptape/loaders/pdf_loader.py
@@ -12,18 +12,11 @@ from griptape.loaders import TextLoader
 @define
 class PdfLoader(TextLoader):
     chunker: PdfChunker = field(
-        default=Factory(
-            lambda self: PdfChunker(
-                tokenizer=self.tokenizer, max_tokens=self.max_tokens
-            ),
-            takes_self=True,
-        ),
+        default=Factory(lambda self: PdfChunker(tokenizer=self.tokenizer, max_tokens=self.max_tokens), takes_self=True),
         kw_only=True,
     )
 
-    def load(
-        self, stream: str | IO | Path, password: Optional[str] = None
-    ) -> list[TextArtifact]:
+    def load(self, stream: str | IO | Path, password: Optional[str] = None) -> list[TextArtifact]:
         return self._load_pdf(stream, password)
 
     def load_collection(
@@ -33,18 +26,12 @@ class PdfLoader(TextLoader):
             {
                 str_to_hash(s.decode())
                 if isinstance(s, bytes)
-                else str_to_hash(str(s)): self.futures_executor.submit(
-                    self._load_pdf, s, password
-                )
+                else str_to_hash(str(s)): self.futures_executor.submit(self._load_pdf, s, password)
                 for s in streams
             }
         )
 
-    def _load_pdf(
-        self, stream: str | IO | Path, password: Optional[str]
-    ) -> list[TextArtifact]:
+    def _load_pdf(self, stream: str | IO | Path, password: Optional[str]) -> list[TextArtifact]:
         reader = PdfReader(stream, strict=True, password=password)
 
-        return self.text_to_artifacts(
-            "\n".join([p.extract_text() for p in reader.pages])
-        )
+        return self.text_to_artifacts("\n".join([p.extract_text() for p in reader.pages]))

--- a/griptape/loaders/sql_loader.py
+++ b/griptape/loaders/sql_loader.py
@@ -9,21 +9,15 @@ from griptape.loaders import BaseLoader
 @define
 class SqlLoader(BaseLoader):
     sql_driver: BaseSqlDriver = field(kw_only=True)
-    embedding_driver: Optional[BaseEmbeddingDriver] = field(
-        default=None, kw_only=True
-    )
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
 
     def load(self, select_query: str) -> list[CsvRowArtifact]:
         return self._load_query(select_query)
 
-    def load_collection(
-        self, select_queries: list[str]
-    ) -> dict[str, list[CsvRowArtifact]]:
+    def load_collection(self, select_queries: list[str]) -> dict[str, list[CsvRowArtifact]]:
         return utils.execute_futures_dict(
             {
-                utils.str_to_hash(query): self.futures_executor.submit(
-                    self._load_query, query
-                )
+                utils.str_to_hash(query): self.futures_executor.submit(self._load_query, query)
                 for query in select_queries
             }
         )

--- a/griptape/loaders/text_loader.py
+++ b/griptape/loaders/text_loader.py
@@ -15,48 +15,26 @@ class TextLoader(BaseLoader):
     MAX_TOKEN_RATIO = 0.5
 
     tokenizer: OpenAiTokenizer = field(
-        default=Factory(
-            lambda: OpenAiTokenizer(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
-        kw_only=True,
+        default=Factory(lambda: OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)), kw_only=True
     )
     max_tokens: int = field(
-        default=Factory(
-            lambda self: round(
-                self.tokenizer.max_tokens * self.MAX_TOKEN_RATIO
-            ),
-            takes_self=True,
-        ),
+        default=Factory(lambda self: round(self.tokenizer.max_tokens * self.MAX_TOKEN_RATIO), takes_self=True),
         kw_only=True,
     )
     chunker: TextChunker = field(
         default=Factory(
-            lambda self: TextChunker(
-                tokenizer=self.tokenizer, max_tokens=self.max_tokens
-            ),
-            takes_self=True,
+            lambda self: TextChunker(tokenizer=self.tokenizer, max_tokens=self.max_tokens), takes_self=True
         ),
         kw_only=True,
     )
-    embedding_driver: Optional[BaseEmbeddingDriver] = field(
-        default=None, kw_only=True
-    )
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
 
     def load(self, text: str | Path) -> list[TextArtifact]:
         return self.text_to_artifacts(text)
 
-    def load_collection(
-        self, texts: list[str | Path]
-    ) -> dict[str, list[TextArtifact]]:
+    def load_collection(self, texts: list[str | Path]) -> dict[str, list[TextArtifact]]:
         return utils.execute_futures_dict(
-            {
-                utils.str_to_hash(str(text)): self.futures_executor.submit(
-                    self.text_to_artifacts, text
-                )
-                for text in texts
-            }
+            {utils.str_to_hash(str(text)): self.futures_executor.submit(self.text_to_artifacts, text) for text in texts}
         )
 
     def text_to_artifacts(self, text: str | Path) -> list[TextArtifact]:

--- a/griptape/loaders/web_loader.py
+++ b/griptape/loaders/web_loader.py
@@ -12,24 +12,13 @@ class WebLoader(TextLoader):
     def load(self, url: str, include_links: bool = True) -> list[TextArtifact]:
         return self._load_page_to_artifacts(url, include_links)
 
-    def load_collection(
-        self, urls: list[str], include_links: bool = True
-    ) -> dict[str, list[TextArtifact]]:
+    def load_collection(self, urls: list[str], include_links: bool = True) -> dict[str, list[TextArtifact]]:
         return execute_futures_dict(
-            {
-                str_to_hash(u): self.futures_executor.submit(
-                    self._load_page_to_artifacts, u, include_links
-                )
-                for u in urls
-            }
+            {str_to_hash(u): self.futures_executor.submit(self._load_page_to_artifacts, u, include_links) for u in urls}
         )
 
-    def _load_page_to_artifacts(
-        self, url: str, include_links: bool = True
-    ) -> list[TextArtifact]:
-        return self.text_to_artifacts(
-            self.extract_page(url, include_links).get("text")
-        )
+    def _load_page_to_artifacts(self, url: str, include_links: bool = True) -> list[TextArtifact]:
+        return self.text_to_artifacts(self.extract_page(url, include_links).get("text"))
 
     def extract_page(self, url: str, include_links: bool = True) -> dict:
         config = trafilatura.settings.use_config()
@@ -47,10 +36,5 @@ class WebLoader(TextLoader):
             raise Exception("can't access URL")
         else:
             return json.loads(
-                trafilatura.extract(
-                    page,
-                    include_links=include_links,
-                    output_format="json",
-                    config=config,
-                )
+                trafilatura.extract(page, include_links=include_links, output_format="json", config=config)
             )

--- a/griptape/memory/structure/conversation_memory.py
+++ b/griptape/memory/structure/conversation_memory.py
@@ -12,13 +12,8 @@ if TYPE_CHECKING:
 
 @define
 class ConversationMemory:
-    type: str = field(
-        default=Factory(lambda self: self.__class__.__name__, takes_self=True),
-        kw_only=True,
-    )
-    driver: Optional[BaseConversationMemoryDriver] = field(
-        default=None, kw_only=True
-    )
+    type: str = field(default=Factory(lambda self: self.__class__.__name__, takes_self=True), kw_only=True)
+    driver: Optional[BaseConversationMemoryDriver] = field(default=None, kw_only=True)
     runs: list[Run] = field(factory=list, kw_only=True)
     structure: Structure = field(init=False)
     autoload: bool = field(default=True, kw_only=True)

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -19,24 +19,14 @@ if TYPE_CHECKING:
 class SummaryConversationMemory(ConversationMemory):
     offset: int = field(default=1, kw_only=True)
     prompt_driver: BasePromptDriver = field(
-        default=Factory(
-            lambda: OpenAiChatPromptDriver(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ),
+        default=Factory(lambda: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)),
         kw_only=True,
     )
     summary: Optional[str] = field(default=None, kw_only=True)
     summary_index: int = field(default=0, kw_only=True)
-    summary_template_generator: J2 = field(
-        default=Factory(lambda: J2("memory/conversation/summary.j2")),
-        kw_only=True,
-    )
+    summary_template_generator: J2 = field(default=Factory(lambda: J2("memory/conversation/summary.j2")), kw_only=True)
     summarize_conversation_template_generator: J2 = field(
-        default=Factory(
-            lambda: J2("memory/conversation/summarize_conversation.j2")
-        ),
-        kw_only=True,
+        default=Factory(lambda: J2("memory/conversation/summarize_conversation.j2")), kw_only=True
     )
 
     @classmethod
@@ -50,9 +40,7 @@ class SummaryConversationMemory(ConversationMemory):
     def to_prompt_stack(self, last_n: Optional[int] = None) -> PromptStack:
         stack = PromptStack()
         if self.summary:
-            stack.add_user_input(
-                self.summary_template_generator.render(summary=self.summary)
-            )
+            stack.add_user_input(self.summary_template_generator.render(summary=self.summary))
 
         for r in self.unsummarized_runs(last_n):
             stack.add_user_input(r.input)
@@ -80,9 +68,7 @@ class SummaryConversationMemory(ConversationMemory):
         super().try_add_run(run)
 
         unsummarized_runs = self.unsummarized_runs()
-        runs_to_summarize = unsummarized_runs[
-            : max(0, len(unsummarized_runs) - self.offset)
-        ]
+        runs_to_summarize = unsummarized_runs[: max(0, len(unsummarized_runs) - self.offset)]
 
         if len(runs_to_summarize) > 0:
             self.summary = self.summarize_runs(self.summary, runs_to_summarize)
@@ -91,17 +77,9 @@ class SummaryConversationMemory(ConversationMemory):
     def summarize_runs(self, previous_summary: str, runs: list[Run]) -> str:
         try:
             if len(runs) > 0:
-                summary = self.summarize_conversation_template_generator.render(
-                    summary=previous_summary, runs=runs
-                )
+                summary = self.summarize_conversation_template_generator.render(summary=previous_summary, runs=runs)
                 return self.prompt_driver.run(
-                    prompt_stack=PromptStack(
-                        inputs=[
-                            PromptStack.Input(
-                                summary, role=PromptStack.USER_ROLE
-                            )
-                        ]
-                    )
+                    prompt_stack=PromptStack(inputs=[PromptStack.Input(summary, role=PromptStack.USER_ROLE)])
                 ).to_text()
             else:
                 return previous_summary

--- a/griptape/memory/tool/storage/base_artifact_storage.py
+++ b/griptape/memory/tool/storage/base_artifact_storage.py
@@ -22,7 +22,5 @@ class BaseArtifactStorage(ABC):
         ...
 
     @abstractmethod
-    def query(
-        self, namespace: str, query: str, metadata: any = None
-    ) -> TextArtifact:
+    def query(self, namespace: str, query: str, metadata: any = None) -> TextArtifact:
         ...

--- a/griptape/memory/tool/storage/blob_artifact_storage.py
+++ b/griptape/memory/tool/storage/blob_artifact_storage.py
@@ -1,10 +1,5 @@
 from attr import define, field
-from griptape.artifacts import (
-    BaseArtifact,
-    ListArtifact,
-    BlobArtifact,
-    InfoArtifact,
-)
+from griptape.artifacts import BaseArtifact, ListArtifact, BlobArtifact, InfoArtifact
 from griptape.memory.tool.storage import BaseArtifactStorage
 
 
@@ -22,21 +17,10 @@ class BlobArtifactStorage(BaseArtifactStorage):
         self.blobs[namespace].append(artifact)
 
     def load_artifacts(self, namespace: str) -> ListArtifact:
-        return ListArtifact(
-            next(
-                (
-                    blobs
-                    for key, blobs in self.blobs.items()
-                    if key == namespace
-                ),
-                [],
-            )
-        )
+        return ListArtifact(next((blobs for key, blobs in self.blobs.items() if key == namespace), []))
 
     def summarize(self, namespace: str) -> InfoArtifact:
         return InfoArtifact("can't summarize artifacts")
 
-    def query(
-        self, namespace: str, query: str, metadata: any = None
-    ) -> InfoArtifact:
+    def query(self, namespace: str, query: str, metadata: any = None) -> InfoArtifact:
         return InfoArtifact("can't query artifacts")

--- a/griptape/memory/tool/storage/text_artifact_storage.py
+++ b/griptape/memory/tool/storage/text_artifact_storage.py
@@ -5,12 +5,7 @@ from griptape.artifacts import TextArtifact, BaseArtifact, ListArtifact
 from griptape.memory.tool.storage import BaseArtifactStorage
 
 if TYPE_CHECKING:
-    from griptape.engines import (
-        BaseSummaryEngine,
-        CsvExtractionEngine,
-        JsonExtractionEngine,
-        VectorQueryEngine,
-    )
+    from griptape.engines import BaseSummaryEngine, CsvExtractionEngine, JsonExtractionEngine, VectorQueryEngine
 
 
 @define
@@ -30,15 +25,7 @@ class TextArtifactStorage(BaseArtifactStorage):
         return self.query_engine.load_artifacts(namespace)
 
     def summarize(self, namespace: str) -> TextArtifact:
-        return self.summary_engine.summarize_artifacts(
-            self.load_artifacts(namespace)
-        )
+        return self.summary_engine.summarize_artifacts(self.load_artifacts(namespace))
 
-    def query(
-        self, namespace: str, query: str, metadata: any = None
-    ) -> TextArtifact:
-        return self.query_engine.query(
-            namespace=namespace,
-            query=query,
-            metadata=str(metadata) if metadata else None,
-        )
+    def query(self, namespace: str, query: str, metadata: any = None) -> TextArtifact:
+        return self.query_engine.query(namespace=namespace, query=query, metadata=str(metadata) if metadata else None)

--- a/griptape/memory/tool/tool_memory.py
+++ b/griptape/memory/tool/tool_memory.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type, Any, Callable
 from attr import define, field, Factory
-from griptape.artifacts import (
-    BaseArtifact,
-    InfoArtifact,
-    ListArtifact,
-    ErrorArtifact,
-    TextArtifact,
-)
+from griptape.artifacts import BaseArtifact, InfoArtifact, ListArtifact, ErrorArtifact, TextArtifact
 from griptape.mixins import ActivityMixin
 
 if TYPE_CHECKING:
@@ -17,39 +11,23 @@ if TYPE_CHECKING:
 
 @define
 class ToolMemory(ActivityMixin):
-    name: str = field(
-        default=Factory(lambda self: self.__class__.__name__, takes_self=True),
-        kw_only=True,
-    )
-    artifact_storages: dict[Type, BaseArtifactStorage] = field(
-        factory=dict, kw_only=True
-    )
-    namespace_storage: dict[str, BaseArtifactStorage] = field(
-        factory=dict, kw_only=True
-    )
+    name: str = field(default=Factory(lambda self: self.__class__.__name__, takes_self=True), kw_only=True)
+    artifact_storages: dict[Type, BaseArtifactStorage] = field(factory=dict, kw_only=True)
+    namespace_storage: dict[str, BaseArtifactStorage] = field(factory=dict, kw_only=True)
     namespace_metadata: dict[str, Any] = field(factory=dict, kw_only=True)
 
     @artifact_storages.validator
-    def validate_artifact_storages(
-        self, _, artifact_storage: dict[Type, BaseArtifactStorage]
-    ) -> None:
+    def validate_artifact_storages(self, _, artifact_storage: dict[Type, BaseArtifactStorage]) -> None:
         seen_types = []
 
         for storage in artifact_storage.values():
             if type(storage) in seen_types:
-                raise ValueError(
-                    "can't have more than memory storage of the same type"
-                )
+                raise ValueError("can't have more than memory storage of the same type")
 
             seen_types.append(type(storage))
 
-    def get_storage_for(
-        self, artifact: BaseArtifact
-    ) -> Optional[BaseArtifactStorage]:
-        find_storage = lambda a: next(
-            (v for k, v in self.artifact_storages.items() if isinstance(a, k)),
-            None,
-        )
+    def get_storage_for(self, artifact: BaseArtifact) -> Optional[BaseArtifactStorage]:
+        find_storage = lambda a: next((v for k, v in self.artifact_storages.items() if isinstance(a, k)), None)
 
         if isinstance(artifact, ListArtifact):
             if artifact.has_items():
@@ -60,10 +38,7 @@ class ToolMemory(ActivityMixin):
             return find_storage(artifact)
 
     def process_output(
-        self,
-        tool_activity: Callable,
-        subtask: ActionSubtask,
-        output_artifact: BaseArtifact,
+        self, tool_activity: Callable, subtask: ActionSubtask, output_artifact: BaseArtifact
     ) -> BaseArtifact:
         from griptape.utils import J2
 
@@ -90,9 +65,7 @@ class ToolMemory(ActivityMixin):
         else:
             return InfoArtifact("tool output is empty")
 
-    def store_artifact(
-        self, namespace: str, artifact: BaseArtifact
-    ) -> Optional[BaseArtifact]:
+    def store_artifact(self, namespace: str, artifact: BaseArtifact) -> Optional[BaseArtifact]:
         namespace_storage = self.namespace_storage.get(namespace)
         storage = self.get_storage_for(artifact)
 
@@ -134,9 +107,7 @@ class ToolMemory(ActivityMixin):
         else:
             return None
 
-    def summarize_namespace(
-        self, namespace: str
-    ) -> TextArtifact | InfoArtifact:
+    def summarize_namespace(self, namespace: str) -> TextArtifact | InfoArtifact:
         storage = self.namespace_storage.get(namespace)
 
         if storage:
@@ -144,16 +115,10 @@ class ToolMemory(ActivityMixin):
         else:
             return InfoArtifact("Can't find memory content")
 
-    def query_namespace(
-        self, namespace: str, query: str
-    ) -> TextArtifact | InfoArtifact:
+    def query_namespace(self, namespace: str, query: str) -> TextArtifact | InfoArtifact:
         storage = self.namespace_storage.get(namespace)
 
         if storage:
-            return storage.query(
-                namespace=namespace,
-                query=query,
-                metadata=self.namespace_metadata.get(namespace),
-            )
+            return storage.query(namespace=namespace, query=query, metadata=self.namespace_metadata.get(namespace))
         else:
             return InfoArtifact("Can't find memory content")

--- a/griptape/mixins/__init__.py
+++ b/griptape/mixins/__init__.py
@@ -2,8 +2,4 @@ from .activity_mixin import ActivityMixin
 from .exponential_backoff_mixin import ExponentialBackoffMixin
 from .action_subtask_origin_mixin import ActionSubtaskOriginMixin
 
-__all__ = [
-    "ActivityMixin",
-    "ExponentialBackoffMixin",
-    "ActionSubtaskOriginMixin",
-]
+__all__ = ["ActivityMixin", "ExponentialBackoffMixin", "ActionSubtaskOriginMixin"]

--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -45,21 +45,11 @@ class ActivityMixin:
     def activities(self) -> list[Callable]:
         methods = []
 
-        for name, method in inspect.getmembers(
-            self, predicate=inspect.ismethod
-        ):
-            allowlist_condition = (
-                self.allowlist is None or name in self.allowlist
-            )
-            denylist_condition = (
-                self.denylist is None or name not in self.denylist
-            )
+        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            allowlist_condition = self.allowlist is None or name in self.allowlist
+            denylist_condition = self.denylist is None or name not in self.denylist
 
-            if (
-                getattr(method, "is_activity", False)
-                and allowlist_condition
-                and denylist_condition
-            ):
+            if getattr(method, "is_activity", False) and allowlist_condition and denylist_condition:
                 methods.append(method)
 
         return methods
@@ -81,19 +71,13 @@ class ActivityMixin:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
         else:
-            return Template(activity.config["description"]).render(
-                {"_self": self}
-            )
+            return Template(activity.config["description"]).render({"_self": self})
 
     def activity_schema(self, activity: Callable) -> Optional[dict]:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
         elif activity.config["schema"]:
-            full_schema = {
-                "values": activity.config["schema"].schema
-                if activity.config["schema"]
-                else {}
-            }
+            full_schema = {"values": activity.config["schema"].schema if activity.config["schema"] else {}}
 
             return Schema(full_schema).json_schema("InputSchema")
         else:
@@ -105,6 +89,4 @@ class ActivityMixin:
         activity = getattr(tool, activity_name, None)
 
         if not activity or not getattr(activity, "is_activity", False):
-            raise ValueError(
-                f"activity {activity_name} is not a valid activity for {tool}"
-            )
+            raise ValueError(f"activity {activity_name} is not a valid activity for {tool}")

--- a/griptape/mixins/exponential_backoff_mixin.py
+++ b/griptape/mixins/exponential_backoff_mixin.py
@@ -1,12 +1,7 @@
 import logging
 from abc import ABC
 from attr import define, field
-from tenacity import (
-    Retrying,
-    wait_exponential,
-    stop_after_attempt,
-    retry_if_not_exception_type,
-)
+from tenacity import Retrying, wait_exponential, stop_after_attempt, retry_if_not_exception_type
 from typing import Tuple, Type, Callable
 
 
@@ -15,18 +10,12 @@ class ExponentialBackoffMixin(ABC):
     min_retry_delay: float = field(default=2, kw_only=True)
     max_retry_delay: float = field(default=10, kw_only=True)
     max_attempts: int = field(default=10, kw_only=True)
-    after_hook: Callable = field(
-        default=lambda s: logging.warning(s), kw_only=True
-    )
-    ignored_exception_types: Tuple[Type[Exception], ...] = field(
-        factory=tuple, kw_only=True
-    )
+    after_hook: Callable = field(default=lambda s: logging.warning(s), kw_only=True)
+    ignored_exception_types: Tuple[Type[Exception], ...] = field(factory=tuple, kw_only=True)
 
     def retrying(self) -> Retrying:
         return Retrying(
-            wait=wait_exponential(
-                min=self.min_retry_delay, max=self.max_retry_delay
-            ),
+            wait=wait_exponential(min=self.min_retry_delay, max=self.max_retry_delay),
             retry=retry_if_not_exception_type(self.ignored_exception_types),
             stop=stop_after_attempt(self.max_attempts),
             reraise=True,

--- a/griptape/schemas/__init__.py
+++ b/griptape/schemas/__init__.py
@@ -12,29 +12,19 @@ from .artifacts.list_artifact_schema import ListArtifactSchema
 
 from .memory.run_schema import RunSchema
 from .memory.conversation_memory_schema import ConversationMemorySchema
-from .memory.summary_conversation_memory_schema import (
-    SummaryConversationMemorySchema,
-)
+from .memory.summary_conversation_memory_schema import SummaryConversationMemorySchema
 
 from .events.base_event_schema import BaseEventSchema
 from .events.base_task_event_schema import BaseTaskEventSchema
-from .events.base_action_subtask_event_schema import (
-    BaseActionSubtaskEventSchema,
-)
+from .events.base_action_subtask_event_schema import BaseActionSubtaskEventSchema
 from .events.start_task_event_schema import StartTaskEventSchema
 from .events.finish_task_event_schema import FinishTaskEventSchema
 from .events.start_action_event_schema import StartActionSubtaskEventSchema
-from .events.finish_action_subtask_event_schema import (
-    FinishActionSubtaskEventSchema,
-)
+from .events.finish_action_subtask_event_schema import FinishActionSubtaskEventSchema
 from .events.start_prompt_event_schema import StartPromptEventSchema
 from .events.finish_prompt_event_schema import FinishPromptEventSchema
-from .events.start_structure_run_event_schema import (
-    StartStructureRunEventSchema,
-)
-from .events.finish_structure_run_event_schema import (
-    FinishStructureRunEventSchema,
-)
+from .events.start_structure_run_event_schema import StartStructureRunEventSchema
+from .events.finish_structure_run_event_schema import FinishStructureRunEventSchema
 from .events.completion_chunk_event_schema import CompletionChunkEventSchema
 
 __all__ = [

--- a/griptape/schemas/polymorphic_schema.py
+++ b/griptape/schemas/polymorphic_schema.py
@@ -10,12 +10,7 @@ class PolymorphicSchema(BaseSchema):
     PolymorphicSchema is based on https://github.com/marshmallow-code/marshmallow-oneofschema
     """
 
-    def get_schema(
-        self,
-        class_name: str,
-        obj: Optional[object],
-        schema_namespace: Optional[str],
-    ):
+    def get_schema(self, class_name: str, obj: Optional[object], schema_namespace: Optional[str]):
         if schema_namespace:
             namespace = schema_namespace
         elif obj is not None and hasattr(obj, "schema_namespace"):
@@ -80,22 +75,14 @@ class PolymorphicSchema(BaseSchema):
         obj_type = self.get_obj_type(obj)
 
         if not obj_type:
-            return (
-                None,
-                {
-                    "_schema": "Unknown object class: %s"
-                    % obj.__class__.__name__
-                },
-            )
+            return (None, {"_schema": "Unknown object class: %s" % obj.__class__.__name__})
 
         type_schema = self.get_schema(obj_type, obj, None)
 
         if not type_schema:
             return None, {"_schema": "Unsupported object type: %s" % obj_type}
 
-        schema = (
-            type_schema if isinstance(type_schema, Schema) else type_schema()
-        )
+        schema = type_schema if isinstance(type_schema, Schema) else type_schema()
 
         schema.context.update(getattr(self, "context", {}))
 
@@ -115,9 +102,7 @@ class PolymorphicSchema(BaseSchema):
             partial = self.partial
         if not many:
             try:
-                result = result_data = self._load(
-                    data, partial=partial, unknown=unknown, **kwargs
-                )
+                result = result_data = self._load(data, partial=partial, unknown=unknown, **kwargs)
                 #  result_data.append(result)
             except ValidationError as error:
                 result_errors = error.normalized_messages()
@@ -149,9 +134,7 @@ class PolymorphicSchema(BaseSchema):
         data_type = self.get_data_type(data)
 
         if data_type is None:
-            raise ValidationError(
-                {self.type_field: ["Missing data for required field."]}
-            )
+            raise ValidationError({self.type_field: ["Missing data for required field."]})
 
         schema_namespace = data.get("schema_namespace")
 
@@ -159,23 +142,15 @@ class PolymorphicSchema(BaseSchema):
             type_schema = self.get_schema(data_type, None, schema_namespace)
         except TypeError:
             # data_type could be unhashable
-            raise ValidationError(
-                {self.type_field: ["Invalid value: %s" % data_type]}
-            )
+            raise ValidationError({self.type_field: ["Invalid value: %s" % data_type]})
         if not type_schema:
-            raise ValidationError(
-                {self.type_field: ["Unsupported value: %s" % data_type]}
-            )
+            raise ValidationError({self.type_field: ["Unsupported value: %s" % data_type]})
 
-        schema = (
-            type_schema if isinstance(type_schema, Schema) else type_schema()
-        )
+        schema = type_schema if isinstance(type_schema, Schema) else type_schema()
 
         schema.context.update(getattr(self, "context", {}))
 
-        return schema.load(
-            data, many=False, partial=partial, unknown=unknown, **kwargs
-        )
+        return schema.load(data, many=False, partial=partial, unknown=unknown, **kwargs)
 
     def validate(self, data, *, many=None, partial=None):
         try:

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
 @define
 class Agent(Structure):
     input_template: str = field(default=PromptTask.DEFAULT_INPUT_TEMPLATE)
-    memory: Optional[ConversationMemory] = field(
-        default=Factory(lambda: ConversationMemory()), kw_only=True
-    )
+    memory: Optional[ConversationMemory] = field(default=Factory(lambda: ConversationMemory()), kw_only=True)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
@@ -55,10 +53,7 @@ class Agent(Structure):
         self.task.execute()
 
         if self.memory:
-            run = Run(
-                input=self.task.input.to_text(),
-                output=self.task.output.to_text(),
-            )
+            run = Run(input=self.task.input.to_text(), output=self.task.output.to_text())
 
             self.memory.add_run(run)
 

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -50,10 +50,7 @@ class Pipeline(Structure):
         self.__run_from_task(self.input_task)
 
         if self.memory:
-            run = Run(
-                input=self.input_task.input.to_text(),
-                output=self.output_task.output.to_text(),
-            )
+            run = Run(input=self.input_task.input.to_text(), output=self.output_task.output.to_text())
 
             self.memory.add_run(run)
 
@@ -66,9 +63,7 @@ class Pipeline(Structure):
 
         context.update(
             {
-                "parent_output": task.parents[0].output.to_text()
-                if task.parents and task.parents[0].output
-                else None,
+                "parent_output": task.parents[0].output.to_text() if task.parents and task.parents[0].output else None,
                 "parent": task.parents[0] if task.parents else None,
                 "child": task.children[0] if task.children else None,
             }

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -8,27 +8,16 @@ from attr import define, field, Factory
 from rich.logging import RichHandler
 from griptape.artifacts import TextArtifact, BlobArtifact
 from griptape.drivers import BasePromptDriver, OpenAiChatPromptDriver
-from griptape.drivers.embedding.openai_embedding_driver import (
-    OpenAiEmbeddingDriver,
-    BaseEmbeddingDriver,
-)
+from griptape.drivers.embedding.openai_embedding_driver import OpenAiEmbeddingDriver, BaseEmbeddingDriver
 from griptape.events.finish_structure_run_event import FinishStructureRunEvent
 from griptape.events.start_structure_run_event import StartStructureRunEvent
 from griptape.memory.structure import ConversationMemory
 from griptape.memory import ToolMemory
-from griptape.memory.tool.storage import (
-    BlobArtifactStorage,
-    TextArtifactStorage,
-)
+from griptape.memory.tool.storage import BlobArtifactStorage, TextArtifactStorage
 from griptape.rules import Ruleset, Rule
 from griptape.events import BaseEvent
 from griptape.tokenizers import OpenAiTokenizer
-from griptape.engines import (
-    VectorQueryEngine,
-    PromptSummaryEngine,
-    CsvExtractionEngine,
-    JsonExtractionEngine,
-)
+from griptape.engines import VectorQueryEngine, PromptSummaryEngine, CsvExtractionEngine, JsonExtractionEngine
 from griptape.drivers import LocalVectorStoreDriver
 from griptape.events import EventListener
 
@@ -44,17 +33,12 @@ class Structure(ABC):
     stream: bool = field(default=False, kw_only=True)
     prompt_driver: BasePromptDriver = field(
         default=Factory(
-            lambda self: OpenAiChatPromptDriver(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL,
-                stream=self.stream,
-            ),
+            lambda self: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL, stream=self.stream),
             takes_self=True,
         ),
         kw_only=True,
     )
-    embedding_driver: BaseEmbeddingDriver = field(
-        default=Factory(lambda: OpenAiEmbeddingDriver()), kw_only=True
-    )
+    embedding_driver: BaseEmbeddingDriver = field(default=Factory(lambda: OpenAiEmbeddingDriver()), kw_only=True)
     rulesets: list[Ruleset] = field(factory=list, kw_only=True)
     rules: list[Rule] = field(factory=list, kw_only=True)
     tasks: list[BaseTask] = field(factory=list, kw_only=True)
@@ -69,19 +53,11 @@ class Structure(ABC):
                     TextArtifact: TextArtifactStorage(
                         query_engine=VectorQueryEngine(
                             prompt_driver=self.prompt_driver,
-                            vector_store_driver=LocalVectorStoreDriver(
-                                embedding_driver=self.embedding_driver
-                            ),
+                            vector_store_driver=LocalVectorStoreDriver(embedding_driver=self.embedding_driver),
                         ),
-                        summary_engine=PromptSummaryEngine(
-                            prompt_driver=self.prompt_driver
-                        ),
-                        csv_extraction_engine=CsvExtractionEngine(
-                            prompt_driver=self.prompt_driver
-                        ),
-                        json_extraction_engine=JsonExtractionEngine(
-                            prompt_driver=self.prompt_driver
-                        ),
+                        summary_engine=PromptSummaryEngine(prompt_driver=self.prompt_driver),
+                        csv_extraction_engine=CsvExtractionEngine(prompt_driver=self.prompt_driver),
+                        json_extraction_engine=JsonExtractionEngine(prompt_driver=self.prompt_driver),
                     ),
                     BlobArtifact: BlobArtifactStorage(),
                 }
@@ -119,11 +95,7 @@ class Structure(ABC):
         self.prompt_driver.structure = self
 
     def __add__(self, other: BaseTask | list[BaseTask]) -> list[BaseTask]:
-        return (
-            self.add_tasks(*other)
-            if isinstance(other, list)
-            else self + [other]
-        )
+        return self.add_tasks(*other) if isinstance(other, list) else self + [other]
 
     @property
     def execution_args(self) -> tuple:
@@ -140,9 +112,7 @@ class Structure(ABC):
                 self._logger.propagate = False
                 self._logger.level = self.logger_level
 
-                self._logger.handlers = [
-                    RichHandler(show_time=True, show_path=False)
-                ]
+                self._logger.handlers = [RichHandler(show_time=True, show_path=False)]
             return self._logger
 
     @property
@@ -172,9 +142,7 @@ class Structure(ABC):
     def add_tasks(self, *tasks: BaseTask) -> list[BaseTask]:
         return [self.add_task(s) for s in tasks]
 
-    def add_event_listener(
-        self, event_listener: EventListener
-    ) -> EventListener:
+    def add_event_listener(self, event_listener: EventListener) -> EventListener:
         if event_listener not in self.event_listeners:
             self.event_listeners.append(event_listener)
 

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -10,9 +10,7 @@ from griptape.tasks import BaseTask
 
 @define
 class Workflow(Structure):
-    futures_executor: futures.Executor = field(
-        default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True
-    )
+    futures_executor: futures.Executor = field(default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True)
 
     def add_task(self, task: BaseTask) -> BaseTask:
         task.preprocess(self)
@@ -26,11 +24,7 @@ class Workflow(Structure):
         return task
 
     def insert_task(
-        self,
-        parent_task: BaseTask,
-        child_task: BaseTask,
-        task: BaseTask,
-        preserve_relationship: bool = False,
+        self, parent_task: BaseTask, child_task: BaseTask, task: BaseTask, preserve_relationship: bool = False
     ) -> BaseTask:
         """Insert a task between two tasks in the workflow.
 
@@ -94,8 +88,7 @@ class Workflow(Structure):
         context.update(
             {
                 "parent_outputs": {
-                    parent.id: parent.output.to_text() if parent.output else ""
-                    for parent in task.parents
+                    parent.id: parent.output.to_text() if parent.output else "" for parent in task.parents
                 },
                 "parents": {parent.id: parent for parent in task.parents},
                 "children": {child.id: child for child in task.children},
@@ -117,7 +110,4 @@ class Workflow(Structure):
         return graph
 
     def order_tasks(self) -> list[BaseTask]:
-        return [
-            self.find_task(task_id)
-            for task_id in TopologicalSorter(self.to_graph()).static_order()
-        ]
+        return [self.find_task(task_id) for task_id in TopologicalSorter(self.to_graph()).static_order()]

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -34,15 +34,11 @@ class BaseTask(ABC):
 
     @property
     def parents(self) -> list[BaseTask]:
-        return [
-            self.structure.find_task(parent_id) for parent_id in self.parent_ids
-        ]
+        return [self.structure.find_task(parent_id) for parent_id in self.parent_ids]
 
     @property
     def children(self) -> list[BaseTask]:
-        return [
-            self.structure.find_task(child_id) for child_id in self.child_ids
-        ]
+        return [self.structure.find_task(child_id) for child_id in self.child_ids]
 
     def __str__(self) -> str:
         return str(self.output.value)
@@ -79,9 +75,7 @@ class BaseTask(ABC):
 
             self.after_run()
         except Exception as e:
-            self.structure.logger.error(
-                f"{self.__class__.__name__} {self.id}\n{e}", exc_info=True
-            )
+            self.structure.logger.error(f"{self.__class__.__name__} {self.id}\n{e}", exc_info=True)
 
             self.output = ErrorArtifact(str(e))
         finally:
@@ -90,9 +84,7 @@ class BaseTask(ABC):
             return self.output
 
     def can_execute(self) -> bool:
-        return self.state == BaseTask.State.PENDING and all(
-            parent.is_finished() for parent in self.parents
-        )
+        return self.state == BaseTask.State.PENDING and all(parent.is_finished() for parent in self.parents)
 
     def reset(self) -> BaseTask:
         self.state = BaseTask.State.PENDING

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -21,9 +21,7 @@ class BaseTextInputTask(BaseTask, ABC):
 
     @property
     def input(self) -> TextArtifact:
-        return TextArtifact(
-            J2().render_from_string(self.input_template, **self.full_context)
-        )
+        return TextArtifact(J2().render_from_string(self.input_template, **self.full_context))
 
     @property
     def full_context(self) -> dict[str, Any]:
@@ -60,12 +58,7 @@ class BaseTextInputTask(BaseTask, ABC):
             if self.structure.rulesets:
                 structure_rulesets = self.structure.rulesets
             elif self.structure.rules:
-                structure_rulesets = [
-                    Ruleset(
-                        name=self.DEFAULT_RULESET_NAME,
-                        rules=self.structure.rules,
-                    )
-                ]
+                structure_rulesets = [Ruleset(name=self.DEFAULT_RULESET_NAME, rules=self.structure.rules)]
 
         task_rulesets = []
         if self.rulesets:
@@ -83,13 +76,9 @@ class BaseTextInputTask(BaseTask, ABC):
     def before_run(self) -> None:
         super().before_run()
 
-        self.structure.logger.info(
-            f"{self.__class__.__name__} {self.id}\nInput: {self.input.to_text()}"
-        )
+        self.structure.logger.info(f"{self.__class__.__name__} {self.id}\nInput: {self.input.to_text()}")
 
     def after_run(self) -> None:
         super().after_run()
 
-        self.structure.logger.info(
-            f"{self.__class__.__name__} {self.id}\nOutput: {self.output.to_text()}"
-        )
+        self.structure.logger.info(f"{self.__class__.__name__} {self.id}\nOutput: {self.output.to_text()}")

--- a/griptape/tasks/extraction_task.py
+++ b/griptape/tasks/extraction_task.py
@@ -10,6 +10,4 @@ class ExtractionTask(BaseTextInputTask):
     args: dict = field(kw_only=True)
 
     def run(self) -> ListArtifact:
-        return self.extraction_engine.extract(
-            self.input.to_text(), rulesets=self.all_rulesets, **self.args
-        )
+        return self.extraction_engine.extract(self.input.to_text(), rulesets=self.all_rulesets, **self.args)

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -12,19 +12,12 @@ if TYPE_CHECKING:
 
 @define
 class PromptTask(BaseTextInputTask):
-    prompt_driver: Optional[BasePromptDriver] = field(
-        default=None, kw_only=True
-    )
+    prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
     generate_system_template: Callable[[PromptTask], str] = field(
-        default=Factory(
-            lambda self: self.default_system_template_generator, takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.default_system_template_generator, takes_self=True), kw_only=True
     )
 
-    output: Optional[TextArtifact | ErrorArtifact | InfoArtifact] = field(
-        default=None, init=False
-    )
+    output: Optional[TextArtifact | ErrorArtifact | InfoArtifact] = field(default=None, init=False)
 
     @property
     def prompt_stack(self) -> PromptStack:
@@ -46,9 +39,7 @@ class PromptTask(BaseTextInputTask):
 
     def default_system_template_generator(self, _: PromptTask) -> str:
         return J2("tasks/prompt_task/system.j2").render(
-            rulesets=J2("rulesets/rulesets.j2").render(
-                rulesets=self.all_rulesets
-            )
+            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets)
         )
 
     def run(self) -> TextArtifact:

--- a/griptape/tasks/text_query_task.py
+++ b/griptape/tasks/text_query_task.py
@@ -9,23 +9,15 @@ from griptape.tasks import BaseTextInputTask
 @define
 class TextQueryTask(BaseTextInputTask):
     query_engine: BaseQueryEngine = field(kw_only=True)
-    loader: TextLoader = field(
-        default=Factory(lambda: TextLoader()), kw_only=True
-    )
+    loader: TextLoader = field(default=Factory(lambda: TextLoader()), kw_only=True)
     namespace: str = field(kw_only=True)
 
     def run(self) -> TextArtifact:
-        return self.query_engine.query(
-            self.input.to_text(),
-            namespace=self.namespace,
-            rulesets=self.all_rulesets,
-        )
+        return self.query_engine.query(self.input.to_text(), namespace=self.namespace, rulesets=self.all_rulesets)
 
     def load(self, content: Any) -> list[TextArtifact]:
         artifacts = self.loader.load(content)
 
-        self.query_engine.upsert_text_artifacts(
-            artifacts, namespace=self.namespace
-        )
+        self.query_engine.upsert_text_artifacts(artifacts, namespace=self.namespace)
 
         return artifacts

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -11,13 +11,7 @@ if TYPE_CHECKING:
 
 @define
 class TextSummaryTask(BaseTextInputTask):
-    summary_engine: BaseSummaryEngine = field(
-        kw_only=True, default=Factory(lambda: PromptSummaryEngine())
-    )
+    summary_engine: BaseSummaryEngine = field(kw_only=True, default=Factory(lambda: PromptSummaryEngine()))
 
     def run(self) -> TextArtifact:
-        return TextArtifact(
-            self.summary_engine.summarize_text(
-                self.input.to_text(), rulesets=self.all_rulesets
-            )
-        )
+        return TextArtifact(self.summary_engine.summarize_text(self.input.to_text(), rulesets=self.all_rulesets))

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -16,22 +16,16 @@ class ToolTask(PromptTask, ActionSubtaskOriginMixin):
     subtask: Optional[ActionSubtask] = field(default=None, kw_only=True)
 
     def default_system_template_generator(self, _: PromptTask) -> str:
-        action_schema = utils.minify_json(
-            json.dumps(ActionSubtask.ACTION_SCHEMA.json_schema("ActionSchema"))
-        )
+        action_schema = utils.minify_json(json.dumps(ActionSubtask.ACTION_SCHEMA.json_schema("ActionSchema")))
 
         return J2("tasks/tool_task/system.j2").render(
-            rulesets=J2("rulesets/rulesets.j2").render(
-                rulesets=self.all_rulesets
-            ),
+            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets),
             action_schema=action_schema,
             action=J2("tasks/partials/_action.j2").render(tool=self.tool),
         )
 
     def run(self) -> TextArtifact:
-        output = (
-            self.active_driver().run(prompt_stack=self.prompt_stack).to_text()
-        )
+        output = self.active_driver().run(prompt_stack=self.prompt_stack).to_text()
 
         subtask = self.add_subtask(ActionSubtask(f"Action: {output}"))
 

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -25,18 +25,10 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
     tool_memory: Optional[ToolMemory] = field(default=None, kw_only=True)
     subtasks: list[ActionSubtask] = field(factory=list)
     generate_assistant_subtask_template: Callable[[ActionSubtask], str] = field(
-        default=Factory(
-            lambda self: self.default_assistant_subtask_template_generator,
-            takes_self=True,
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.default_assistant_subtask_template_generator, takes_self=True), kw_only=True
     )
     generate_user_subtask_template: Callable[[ActionSubtask], str] = field(
-        default=Factory(
-            lambda self: self.default_user_subtask_template_generator,
-            takes_self=True,
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.default_user_subtask_template_generator, takes_self=True), kw_only=True
     )
 
     def __attrs_post_init__(self) -> None:
@@ -53,9 +45,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
     def tool_output_memory(self) -> list[ToolMemory]:
         unique_memory_dict = {}
 
-        for memories in [
-            tool.output_memory for tool in self.tools if tool.output_memory
-        ]:
+        for memories in [tool.output_memory for tool in self.tools if tool.output_memory]:
             for memory_list in memories.values():
                 for memory in memory_list:
                     if memory.name not in unique_memory_dict:
@@ -76,9 +66,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
             stack.add_assistant_input(self.output.to_text())
         else:
             for s in self.subtasks:
-                stack.add_assistant_input(
-                    self.generate_assistant_subtask_template(s)
-                )
+                stack.add_assistant_input(self.generate_assistant_subtask_template(s))
                 stack.add_user_input(self.generate_user_subtask_template(s))
 
         if memory:
@@ -96,41 +84,25 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
         return self
 
     def default_system_template_generator(self, _: PromptTask) -> str:
-        memories = [
-            r for r in self.tool_output_memory if len(r.activities()) > 0
-        ]
+        memories = [r for r in self.tool_output_memory if len(r.activities()) > 0]
 
-        action_schema = utils.minify_json(
-            json.dumps(ActionSubtask.ACTION_SCHEMA.json_schema("ActionSchema"))
-        )
+        action_schema = utils.minify_json(json.dumps(ActionSubtask.ACTION_SCHEMA.json_schema("ActionSchema")))
 
         return J2("tasks/toolkit_task/system.j2").render(
-            rulesets=J2("rulesets/rulesets.j2").render(
-                rulesets=self.all_rulesets
-            ),
+            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets),
             action_schema=action_schema,
             action_names=str.join(", ", [tool.name for tool in self.tools]),
-            actions=[
-                J2("tasks/partials/_action.j2").render(tool=tool)
-                for tool in self.tools
-            ],
+            actions=[J2("tasks/partials/_action.j2").render(tool=tool) for tool in self.tools],
             memory_names=str.join(", ", [memory.name for memory in memories]),
             stop_sequence=utils.constants.RESPONSE_STOP_SEQUENCE,
         )
 
-    def default_assistant_subtask_template_generator(
-        self, subtask: ActionSubtask
-    ) -> str:
-        return J2("tasks/toolkit_task/assistant_subtask.j2").render(
-            subtask=subtask
-        )
+    def default_assistant_subtask_template_generator(self, subtask: ActionSubtask) -> str:
+        return J2("tasks/toolkit_task/assistant_subtask.j2").render(subtask=subtask)
 
-    def default_user_subtask_template_generator(
-        self, subtask: ActionSubtask
-    ) -> str:
+    def default_user_subtask_template_generator(self, subtask: ActionSubtask) -> str:
         return J2("tasks/toolkit_task/user_subtask.j2").render(
-            stop_sequence=utils.constants.RESPONSE_STOP_SEQUENCE,
-            subtask=subtask,
+            stop_sequence=utils.constants.RESPONSE_STOP_SEQUENCE, subtask=subtask
         )
 
     def set_default_tools_memory(self, memory: ToolMemory) -> None:
@@ -141,29 +113,19 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
                 if tool.input_memory is None:
                     tool.input_memory = [self.tool_memory]
                 if tool.output_memory is None and tool.off_prompt:
-                    tool.output_memory = {
-                        a.name: [self.tool_memory] for a in tool.activities()
-                    }
+                    tool.output_memory = {a.name: [self.tool_memory] for a in tool.activities()}
 
     def run(self) -> TextArtifact:
         from griptape.tasks import ActionSubtask
 
         self.subtasks.clear()
 
-        subtask = self.add_subtask(
-            ActionSubtask(
-                self.active_driver()
-                .run(prompt_stack=self.prompt_stack)
-                .to_text()
-            )
-        )
+        subtask = self.add_subtask(ActionSubtask(self.active_driver().run(prompt_stack=self.prompt_stack).to_text()))
 
         while True:
             if subtask.output is None:
                 if len(self.subtasks) >= self.max_subtasks:
-                    subtask.output = ErrorArtifact(
-                        f"Exceeded tool limit of {self.max_subtasks} subtasks per task"
-                    )
+                    subtask.output = ErrorArtifact(f"Exceeded tool limit of {self.max_subtasks} subtasks per task")
                 elif subtask.action_name is None:
                     # handle case when the LLM failed to follow the ReAct prompt and didn't return a proper action
                     subtask.output = TextArtifact(subtask.input_template)
@@ -173,11 +135,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
                     subtask.after_run()
 
                     subtask = self.add_subtask(
-                        ActionSubtask(
-                            self.active_driver()
-                            .run(prompt_stack=self.prompt_stack)
-                            .to_text()
-                        )
+                        ActionSubtask(self.active_driver().run(prompt_stack=self.prompt_stack).to_text())
                     )
             else:
                 break
@@ -187,10 +145,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
         return self.output
 
     def find_subtask(self, subtask_id: str) -> Optional[ActionSubtask]:
-        return next(
-            (subtask for subtask in self.subtasks if subtask.id == subtask_id),
-            None,
-        )
+        return next((subtask for subtask in self.subtasks if subtask.id == subtask_id), None)
 
     def add_subtask(self, subtask: ActionSubtask) -> ActionSubtask:
         subtask.attach_to(self)
@@ -206,6 +161,4 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
         return next((t for t in self.tools if t.name == tool_name), None)
 
     def find_memory(self, memory_name: str) -> Optional[ToolMemory]:
-        return next(
-            (m for m in self.tool_output_memory if m.name == memory_name), None
-        )
+        return next((m for m in self.tool_output_memory if m.name == memory_name), None)

--- a/griptape/tokenizers/__init__.py
+++ b/griptape/tokenizers/__init__.py
@@ -4,9 +4,7 @@ from griptape.tokenizers.cohere_tokenizer import CohereTokenizer
 from griptape.tokenizers.hugging_face_tokenizer import HuggingFaceTokenizer
 from griptape.tokenizers.anthropic_tokenizer import AnthropicTokenizer
 from griptape.tokenizers.bedrock_titan_tokenizer import BedrockTitanTokenizer
-from griptape.tokenizers.bedrock_jurassic_tokenizer import (
-    BedrockJurassicTokenizer,
-)
+from griptape.tokenizers.bedrock_jurassic_tokenizer import BedrockJurassicTokenizer
 from griptape.tokenizers.bedrock_claude_tokenizer import BedrockClaudeTokenizer
 
 

--- a/griptape/tokenizers/base_tokenizer.py
+++ b/griptape/tokenizers/base_tokenizer.py
@@ -5,10 +5,7 @@ from griptape import utils
 
 @define(frozen=True)
 class BaseTokenizer(ABC):
-    stop_sequences: list[str] = field(
-        default=Factory(lambda: [utils.constants.RESPONSE_STOP_SEQUENCE]),
-        kw_only=True,
-    )
+    stop_sequences: list[str] = field(default=Factory(lambda: [utils.constants.RESPONSE_STOP_SEQUENCE]), kw_only=True)
 
     @property
     @abstractmethod

--- a/griptape/tokenizers/bedrock_jurassic_tokenizer.py
+++ b/griptape/tokenizers/bedrock_jurassic_tokenizer.py
@@ -14,16 +14,10 @@ class BedrockJurassicTokenizer(BaseTokenizer):
     DEFAULT_MODEL = "ai21.j2-ultra-v1"
     DEFAULT_MAX_TOKENS = 8192
 
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     model: str = field(kw_only=True)
     bedrock_client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("bedrock-runtime"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True
     )
 
     @property
@@ -34,10 +28,7 @@ class BedrockJurassicTokenizer(BaseTokenizer):
         payload = {"prompt": text}
 
         response = self.bedrock_client.invoke_model(
-            body=json.dumps(payload),
-            modelId=self.model,
-            accept="application/json",
-            contentType="application/json",
+            body=json.dumps(payload), modelId=self.model, accept="application/json", contentType="application/json"
         )
         response_body = json.loads(response.get("body").read())
 

--- a/griptape/tokenizers/bedrock_titan_tokenizer.py
+++ b/griptape/tokenizers/bedrock_titan_tokenizer.py
@@ -16,17 +16,11 @@ class BedrockTitanTokenizer(BaseTokenizer):
 
     DEFAULT_EMBEDDING_MODELS = "amazon.titan-embed-text-v1"
 
-    session: boto3.Session = field(
-        default=Factory(lambda: import_optional_dependency("boto3").Session()),
-        kw_only=True,
-    )
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     stop_sequences: list[str] = field(factory=list, kw_only=True)
     model: str = field(kw_only=True)
     bedrock_client: Any = field(
-        default=Factory(
-            lambda self: self.session.client("bedrock-runtime"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True
     )
 
     @property
@@ -37,10 +31,7 @@ class BedrockTitanTokenizer(BaseTokenizer):
         payload = {"inputText": text}
 
         response = self.bedrock_client.invoke_model(
-            body=json.dumps(payload),
-            modelId=self.model,
-            accept="application/json",
-            contentType="application/json",
+            body=json.dumps(payload), modelId=self.model, accept="application/json", contentType="application/json"
         )
         response_body = json.loads(response.get("body").read())
 

--- a/griptape/tokenizers/hugging_face_tokenizer.py
+++ b/griptape/tokenizers/hugging_face_tokenizer.py
@@ -15,10 +15,7 @@ from griptape.tokenizers import BaseTokenizer
 class HuggingFaceTokenizer(BaseTokenizer):
     tokenizer: PreTrainedTokenizerBase = field(kw_only=True)
     max_tokens: int = field(
-        default=Factory(
-            lambda self: self.tokenizer.model_max_length, takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.tokenizer.model_max_length, takes_self=True), kw_only=True
     )
 
     def count_tokens(self, text: str) -> int:

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -42,18 +42,12 @@ class OpenAiTokenizer(BaseTokenizer):
 
     @property
     def max_tokens(self) -> int:
-        tokens = next(
-            v
-            for k, v in self.MODEL_PREFIXES_TO_MAX_TOKENS.items()
-            if self.model.startswith(k)
-        )
+        tokens = next(v for k, v in self.MODEL_PREFIXES_TO_MAX_TOKENS.items() if self.model.startswith(k))
         offset = 0 if self.model in self.EMBEDDING_MODELS else self.TOKEN_OFFSET
 
         return (tokens if tokens else self.DEFAULT_MAX_TOKENS) - offset
 
-    def count_tokens(
-        self, text: str | list, model: Optional[str] = None
-    ) -> int:
+    def count_tokens(self, text: str | list, model: Optional[str] = None) -> int:
         """
         Handles the special case of ChatML. Implementation adopted from the official OpenAI notebook:
         https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -84,14 +78,10 @@ class OpenAiTokenizer(BaseTokenizer):
                 # if there's a name, the role is omitted
                 tokens_per_name = -1
             elif "gpt-3.5-turbo" in model or "gpt-35-turbo" in model:
-                logging.info(
-                    "gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613."
-                )
+                logging.info("gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.")
                 return self.count_tokens(text, model="gpt-3.5-turbo-0613")
             elif "gpt-4" in model:
-                logging.info(
-                    "gpt-4 may update over time. Returning num tokens assuming gpt-4-0613."
-                )
+                logging.info("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
                 return self.count_tokens(text, model="gpt-4-0613")
             else:
                 raise NotImplementedError(
@@ -114,8 +104,4 @@ class OpenAiTokenizer(BaseTokenizer):
 
             return num_tokens
         else:
-            return len(
-                self.encoding.encode(
-                    text, allowed_special=set(self.stop_sequences)
-                )
-            )
+            return len(self.encoding.encode(text, allowed_special=set(self.stop_sequences)))

--- a/griptape/tools/aws_iam_client/tool.py
+++ b/griptape/tools/aws_iam_client/tool.py
@@ -13,10 +13,7 @@ if TYPE_CHECKING:
 @define
 class AwsIamClient(BaseAwsClient):
     iam_client: boto3.client = field(
-        default=Factory(
-            lambda self: self.session.client("iam"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("iam"), takes_self=True), kw_only=True
     )
 
     @activity(
@@ -24,9 +21,7 @@ class AwsIamClient(BaseAwsClient):
             "description": "Can be use to get a policy for an AWS IAM user.",
             "schema": Schema(
                 {
-                    Literal(
-                        "user_name", description="Username of the AWS IAM user."
-                    ): str,
+                    Literal("user_name", description="Username of the AWS IAM user."): str,
                     Literal(
                         "policy_name",
                         description="PolicyName of the AWS IAM Policy embedded in the specified IAM user.",
@@ -38,8 +33,7 @@ class AwsIamClient(BaseAwsClient):
     def get_user_policy(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
             policy = self.iam_client.get_user_policy(
-                UserName=params["values"]["user_name"],
-                PolicyName=params["values"]["policy_name"],
+                UserName=params["values"]["user_name"], PolicyName=params["values"]["policy_name"]
             )
             return TextArtifact(policy["PolicyDocument"])
         except Exception as e:
@@ -49,9 +43,7 @@ class AwsIamClient(BaseAwsClient):
     def list_mfa_devices(self, _: dict) -> ListArtifact | ErrorArtifact:
         try:
             devices = self.iam_client.list_mfa_devices()
-            return ListArtifact(
-                [TextArtifact(str(d)) for d in devices["MFADevices"]]
-            )
+            return ListArtifact([TextArtifact(str(d)) for d in devices["MFADevices"]])
         except Exception as e:
             return ErrorArtifact(f"error listing mfa devices: {e}")
 
@@ -59,35 +51,19 @@ class AwsIamClient(BaseAwsClient):
         config={
             "description": "Can be used to list policies for a given IAM user.",
             "schema": Schema(
-                {
-                    Literal(
-                        "user_name",
-                        description="Username of the AWS IAM user for which to list policies.",
-                    ): str
-                }
+                {Literal("user_name", description="Username of the AWS IAM user for which to list policies."): str}
             ),
         }
     )
     def list_user_policies(self, params: dict) -> ListArtifact | ErrorArtifact:
         try:
-            policies = self.iam_client.list_user_policies(
-                UserName=params["values"]["user_name"]
-            )
+            policies = self.iam_client.list_user_policies(UserName=params["values"]["user_name"])
             policy_names = policies["PolicyNames"]
 
-            attached_policies = self.iam_client.list_attached_user_policies(
-                UserName=params["values"]["user_name"]
-            )
-            attached_policy_names = [
-                p["PolicyName"] for p in attached_policies["AttachedPolicies"]
-            ]
+            attached_policies = self.iam_client.list_attached_user_policies(UserName=params["values"]["user_name"])
+            attached_policy_names = [p["PolicyName"] for p in attached_policies["AttachedPolicies"]]
 
-            return ListArtifact(
-                [
-                    TextArtifact(str(p))
-                    for p in policy_names + attached_policy_names
-                ]
-            )
+            return ListArtifact([TextArtifact(str(p)) for p in policy_names + attached_policy_names])
         except Exception as e:
             return ErrorArtifact(f"error listing iam user policies: {e}")
 

--- a/griptape/tools/aws_s3_client/tool.py
+++ b/griptape/tools/aws_s3_client/tool.py
@@ -3,12 +3,7 @@ import io
 from typing import TYPE_CHECKING
 from schema import Schema, Literal
 from attr import define, field, Factory
-from griptape.artifacts import (
-    TextArtifact,
-    ErrorArtifact,
-    InfoArtifact,
-    ListArtifact,
-)
+from griptape.artifacts import TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact
 from griptape.utils.decorators import activity
 from griptape.tools import BaseAwsClient
 
@@ -19,10 +14,7 @@ if TYPE_CHECKING:
 @define
 class AwsS3Client(BaseAwsClient):
     s3_client: boto3.client = field(
-        default=Factory(
-            lambda self: self.session.client("s3"), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.session.client("s3"), takes_self=True), kw_only=True
     )
 
     @activity(
@@ -40,9 +32,7 @@ class AwsS3Client(BaseAwsClient):
     )
     def get_bucket_acl(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            acl = self.s3_client.get_bucket_acl(
-                Bucket=params["values"]["bucket_name"]
-            )
+            acl = self.s3_client.get_bucket_acl(Bucket=params["values"]["bucket_name"])
             return TextArtifact(acl)
         except Exception as e:
             return ErrorArtifact(f"error getting bucket acl: {e}")
@@ -51,20 +41,13 @@ class AwsS3Client(BaseAwsClient):
         config={
             "description": "Can be used to get an AWS S3 bucket policy.",
             "schema": Schema(
-                {
-                    Literal(
-                        "bucket_name",
-                        description="The bucket name for which to get the bucket policy.",
-                    ): str
-                }
+                {Literal("bucket_name", description="The bucket name for which to get the bucket policy."): str}
             ),
         }
     )
     def get_bucket_policy(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            policy = self.s3_client.get_bucket_policy(
-                Bucket=params["values"]["bucket_name"]
-            )
+            policy = self.s3_client.get_bucket_policy(Bucket=params["values"]["bucket_name"])
             return TextArtifact(policy)
         except Exception as e:
             return ErrorArtifact(f"error getting bucket policy: {e}")
@@ -74,14 +57,8 @@ class AwsS3Client(BaseAwsClient):
             "description": "Can be used to get an access control list (ACL) of an object in the AWS S3 bucket.",
             "schema": Schema(
                 {
-                    Literal(
-                        "bucket_name",
-                        description="Name of the AWS S3 bucket for which to get an ACL.",
-                    ): str,
-                    Literal(
-                        "object_key",
-                        description="Key of the object for which to get the ACL information.",
-                    ): str,
+                    Literal("bucket_name", description="Name of the AWS S3 bucket for which to get an ACL."): str,
+                    Literal("object_key", description="Key of the object for which to get the ACL information."): str,
                 }
             ),
         }
@@ -89,8 +66,7 @@ class AwsS3Client(BaseAwsClient):
     def get_object_acl(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
             acl = self.s3_client.get_object_acl(
-                Bucket=params["values"]["bucket_name"],
-                Key=params["values"]["object_key"],
+                Bucket=params["values"]["bucket_name"], Key=params["values"]["object_key"]
             )
             return TextArtifact(acl)
         except Exception as e:
@@ -101,34 +77,21 @@ class AwsS3Client(BaseAwsClient):
         try:
             buckets = self.s3_client.list_buckets()
 
-            return ListArtifact(
-                [TextArtifact(str(b)) for b in buckets["Buckets"]]
-            )
+            return ListArtifact([TextArtifact(str(b)) for b in buckets["Buckets"]])
         except Exception as e:
             return ErrorArtifact(f"error listing s3 buckets: {e}")
 
     @activity(
         config={
             "description": "Can be used to list all objects in an AWS S3 bucket.",
-            "schema": Schema(
-                {
-                    Literal(
-                        "bucket_name",
-                        description="The name of the S3 bucket to list.",
-                    ): str
-                }
-            ),
+            "schema": Schema({Literal("bucket_name", description="The name of the S3 bucket to list."): str}),
         }
     )
     def list_objects(self, params: dict) -> ListArtifact | ErrorArtifact:
         try:
-            objects = self.s3_client.list_objects_v2(
-                Bucket=params["values"]["bucket_name"]
-            )
+            objects = self.s3_client.list_objects_v2(Bucket=params["values"]["bucket_name"])
 
-            return ListArtifact(
-                [TextArtifact(str(o)) for o in objects["Contents"]]
-            )
+            return ListArtifact([TextArtifact(str(o)) for o in objects["Contents"]])
         except Exception as e:
             return ErrorArtifact(f"error listing objects in bucket: {e}")
 
@@ -140,17 +103,12 @@ class AwsS3Client(BaseAwsClient):
                     "memory_name": str,
                     "artifact_namespace": str,
                     "bucket_name": str,
-                    Literal(
-                        "object_key",
-                        description="Destination object key name. For example, 'baz.txt'",
-                    ): str,
+                    Literal("object_key", description="Destination object key name. For example, 'baz.txt'"): str,
                 }
             ),
         }
     )
-    def upload_memory_artifacts_to_s3(
-        self, params: dict
-    ) -> InfoArtifact | ErrorArtifact:
+    def upload_memory_artifacts_to_s3(self, params: dict) -> InfoArtifact | ErrorArtifact:
         memory = self.find_input_memory(params["values"]["memory_name"])
         artifact_namespace = params["values"]["artifact_namespace"]
         bucket_name = params["values"]["bucket_name"]
@@ -163,15 +121,11 @@ class AwsS3Client(BaseAwsClient):
                 return ErrorArtifact("no artifacts found")
             elif len(artifacts) == 1:
                 try:
-                    self._upload_object(
-                        bucket_name, object_key, artifacts.value[0].value
-                    )
+                    self._upload_object(bucket_name, object_key, artifacts.value[0].value)
 
                     return InfoArtifact(f"uploaded successfully")
                 except Exception as e:
-                    return ErrorArtifact(
-                        f"error uploading objects to the bucket: {e}"
-                    )
+                    return ErrorArtifact(f"error uploading objects to the bucket: {e}")
             else:
                 try:
                     for a in artifacts.value:
@@ -179,9 +133,7 @@ class AwsS3Client(BaseAwsClient):
 
                     return InfoArtifact(f"uploaded successfully")
                 except Exception as e:
-                    return ErrorArtifact(
-                        f"error uploading objects to the bucket: {e}"
-                    )
+                    return ErrorArtifact(f"error uploading objects to the bucket: {e}")
         else:
             return ErrorArtifact("memory not found")
 
@@ -191,18 +143,13 @@ class AwsS3Client(BaseAwsClient):
             "schema": Schema(
                 {
                     "bucket_name": str,
-                    Literal(
-                        "object_key",
-                        description="Destination object key name. For example, 'baz.txt'",
-                    ): str,
+                    Literal("object_key", description="Destination object key name. For example, 'baz.txt'"): str,
                     "content": str,
                 }
             ),
         }
     )
-    def upload_content_to_s3(
-        self, params: dict
-    ) -> ErrorArtifact | InfoArtifact:
+    def upload_content_to_s3(self, params: dict) -> ErrorArtifact | InfoArtifact:
         content = params["values"]["content"]
         bucket_name = params["values"]["bucket_name"]
         object_key = params["values"]["object_key"]
@@ -214,15 +161,9 @@ class AwsS3Client(BaseAwsClient):
         except Exception as e:
             return ErrorArtifact(f"error uploading objects to the bucket: {e}")
 
-    def _upload_object(
-        self, bucket_name: str, object_name: str, value: any
-    ) -> None:
+    def _upload_object(self, bucket_name: str, object_name: str, value: any) -> None:
         self.s3_client.create_bucket(Bucket=bucket_name)
 
         self.s3_client.upload_fileobj(
-            Fileobj=io.BytesIO(
-                value.encode() if isinstance(value, str) else value
-            ),
-            Bucket=bucket_name,
-            Key=object_name,
+            Fileobj=io.BytesIO(value.encode() if isinstance(value, str) else value), Bucket=bucket_name, Key=object_name
         )

--- a/griptape/tools/base_aws_client.py
+++ b/griptape/tools/base_aws_client.py
@@ -14,17 +14,11 @@ if TYPE_CHECKING:
 class BaseAwsClient(BaseTool, ABC):
     session: boto3.Session = field(kw_only=True)
 
-    @activity(
-        config={
-            "description": "Can be used to get current AWS account and IAM principal."
-        }
-    )
+    @activity(config={"description": "Can be used to get current AWS account and IAM principal."})
     def get_current_aws_identity(self, params: dict) -> BaseArtifact:
         try:
             session = self.session
             sts = session.client("sts")
             return TextArtifact(str(sts.get_caller_identity()))
         except Exception as e:
-            return ErrorArtifact(
-                f"error getting current aws caller identity: {e}"
-            )
+            return ErrorArtifact(f"error getting current aws caller identity: {e}")

--- a/griptape/tools/base_google_client.py
+++ b/griptape/tools/base_google_client.py
@@ -12,13 +12,7 @@ class BaseGoogleClient(BaseTool, ABC):
 
     service_account_credentials: dict = field(kw_only=True)
 
-    def _build_client(
-        self,
-        scopes: list[str],
-        service_name: str,
-        version: str,
-        owner_email: str,
-    ) -> Any:
+    def _build_client(self, scopes: list[str], service_name: str, version: str, owner_email: str) -> Any:
         from google.oauth2 import service_account
         from googleapiclient.discovery import build
 
@@ -26,15 +20,9 @@ class BaseGoogleClient(BaseTool, ABC):
             self.service_account_credentials, scopes=scopes
         )
 
-        return build(
-            serviceName=service_name,
-            version=version,
-            credentials=credentials.with_subject(owner_email),
-        )
+        return build(serviceName=service_name, version=version, credentials=credentials.with_subject(owner_email))
 
-    def _convert_path_to_file_id(
-        self, service: Any, path: str
-    ) -> Optional[str]:
+    def _convert_path_to_file_id(self, service: Any, path: str) -> Optional[str]:
         parts = path.split("/")
         current_id = "root"
 
@@ -54,11 +42,7 @@ class BaseGoogleClient(BaseTool, ABC):
                         "mimeType": "application/vnd.google-apps.folder",
                         "parents": [current_id],
                     }
-                    folder = (
-                        service.files()
-                        .create(body=folder_metadata, fields="id")
-                        .execute()
-                    )
+                    folder = service.files().create(body=folder_metadata, fields="id").execute()
                     current_id = folder.get("id")
                 else:
                     current_id = None

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -34,18 +34,11 @@ class BaseTool(ActivityMixin, ABC):
     MANIFEST_FILE = "manifest.yml"
     REQUIREMENTS_FILE = "requirements.txt"
 
-    name: str = field(
-        default=Factory(lambda self: self.class_name, takes_self=True),
-        kw_only=True,
-    )
+    name: str = field(default=Factory(lambda self: self.class_name, takes_self=True), kw_only=True)
     input_memory: Optional[list[ToolMemory]] = field(default=None, kw_only=True)
-    output_memory: Optional[dict[str, list[ToolMemory]]] = field(
-        default=None, kw_only=True
-    )
+    output_memory: Optional[dict[str, list[ToolMemory]]] = field(default=None, kw_only=True)
     install_dependencies_on_init: bool = field(default=True, kw_only=True)
-    dependencies_install_directory: Optional[str] = field(
-        default=None, kw_only=True
-    )
+    dependencies_install_directory: Optional[str] = field(default=None, kw_only=True)
     verbose: bool = field(default=False, kw_only=True)
     off_prompt: bool = field(default=True, kw_only=True)
 
@@ -54,9 +47,7 @@ class BaseTool(ActivityMixin, ABC):
             self.install_dependencies(os.environ.copy())
 
     @output_memory.validator
-    def validate_output_memory(
-        self, _, output_memory: Optional[dict[str, list[ToolMemory]]]
-    ) -> None:
+    def validate_output_memory(self, _, output_memory: Optional[dict[str, list[ToolMemory]]]) -> None:
         if output_memory:
             for activity_name, memory_list in output_memory.items():
                 if not self.find_activity(activity_name):
@@ -65,9 +56,7 @@ class BaseTool(ActivityMixin, ABC):
                 output_memory_names = [memory.name for memory in memory_list]
 
                 if len(output_memory_names) > len(set(output_memory_names)):
-                    raise ValueError(
-                        f"memory names have to be unique in activity '{activity_name}' output"
-                    )
+                    raise ValueError(f"memory names have to be unique in activity '{activity_name}' output")
 
     @property
     def class_name(self):
@@ -94,44 +83,32 @@ class BaseTool(ActivityMixin, ABC):
     def abs_dir_path(self):
         return os.path.dirname(self.abs_file_path)
 
-    def execute(
-        self, activity: Callable, subtask: ActionSubtask
-    ) -> BaseArtifact:
+    def execute(self, activity: Callable, subtask: ActionSubtask) -> BaseArtifact:
         preprocessed_input = self.before_run(activity, subtask.action_input)
         output = self.run(activity, subtask, preprocessed_input)
         postprocessed_output = self.after_run(activity, subtask, output)
 
         return postprocessed_output
 
-    def before_run(
-        self, activity: Callable, value: Optional[dict]
-    ) -> Optional[dict]:
+    def before_run(self, activity: Callable, value: Optional[dict]) -> Optional[dict]:
         return value
 
-    def run(
-        self, activity: Callable, subtask: ActionSubtask, value: Optional[dict]
-    ) -> BaseArtifact:
+    def run(self, activity: Callable, subtask: ActionSubtask, value: Optional[dict]) -> BaseArtifact:
         activity_result = activity(value)
 
         if isinstance(activity_result, BaseArtifact):
             result = activity_result
         else:
-            logging.warning(
-                "Activity result is not an artifact; converting result to InfoArtifact"
-            )
+            logging.warning("Activity result is not an artifact; converting result to InfoArtifact")
 
             result = InfoArtifact(activity_result)
 
         return result
 
-    def after_run(
-        self, activity: Callable, subtask: ActionSubtask, value: BaseArtifact
-    ) -> BaseArtifact:
+    def after_run(self, activity: Callable, subtask: ActionSubtask, value: BaseArtifact) -> BaseArtifact:
         if value:
             if self.output_memory:
-                for memory in activity.__self__.output_memory.get(
-                    activity.name, []
-                ):
+                for memory in activity.__self__.output_memory.get(activity.name, []):
                     value = memory.process_output(activity, subtask, value)
 
                 if isinstance(value, BaseArtifact):
@@ -161,19 +138,10 @@ class BaseTool(ActivityMixin, ABC):
 
         return os.path.dirname(os.path.abspath(class_file))
 
-    def install_dependencies(
-        self, env: Optional[dict[str, str]] = None
-    ) -> None:
+    def install_dependencies(self, env: Optional[dict[str, str]] = None) -> None:
         env = env if env else {}
 
-        command = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            "requirements.txt",
-        ]
+        command = [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
 
         if self.dependencies_install_directory is None:
             command.extend(["-U"])
@@ -190,8 +158,6 @@ class BaseTool(ActivityMixin, ABC):
 
     def find_input_memory(self, memory_name: str) -> Optional[ToolMemory]:
         if self.input_memory:
-            return next(
-                (m for m in self.input_memory if m.name == memory_name), None
-            )
+            return next((m for m in self.input_memory if m.name == memory_name), None)
         else:
             return None

--- a/griptape/tools/computer/tool.py
+++ b/griptape/tools/computer/tool.py
@@ -25,29 +25,18 @@ class Computer(BaseTool):
     container_workdir: str = field(default="/griptape", kw_only=True)
     env_vars: dict = field(factory=dict, kw_only=True)
     dockerfile_path: str = field(
-        default=Factory(
-            lambda self: f"{os.path.join(self.tool_dir(), 'resources/Dockerfile')}",
-            takes_self=True,
-        ),
+        default=Factory(lambda self: f"{os.path.join(self.tool_dir(), 'resources/Dockerfile')}", takes_self=True),
         kw_only=True,
     )
     requirements_txt_path: str = field(
-        default=Factory(
-            lambda self: f"{os.path.join(self.tool_dir(), 'resources/requirements.txt')}",
-            takes_self=True,
-        ),
+        default=Factory(lambda self: f"{os.path.join(self.tool_dir(), 'resources/requirements.txt')}", takes_self=True),
         kw_only=True,
     )
     docker_client: DockerClient = field(
-        default=Factory(
-            lambda self: self.default_docker_client(), takes_self=True
-        ),
-        kw_only=True,
+        default=Factory(lambda self: self.default_docker_client(), takes_self=True), kw_only=True
     )
 
-    __tempdir: Optional[tempfile.TemporaryDirectory] = field(
-        default=None, kw_only=True
-    )
+    __tempdir: Optional[tempfile.TemporaryDirectory] = field(default=None, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
@@ -61,13 +50,9 @@ class Computer(BaseTool):
     @docker_client.validator
     def validate_docker_client(self, _, docker_client: DockerClient) -> None:
         if not docker_client:
-            raise ValueError(
-                "Docker client can't be initialized: make sure the Docker daemon is running"
-            )
+            raise ValueError("Docker client can't be initialized: make sure the Docker daemon is running")
 
-    def install_dependencies(
-        self, env: Optional[dict[str, str]] = None
-    ) -> None:
+    def install_dependencies(self, env: Optional[dict[str, str]] = None) -> None:
         super().install_dependencies(env)
 
         self.remove_existing_container(self.container_name(self))
@@ -83,8 +68,7 @@ class Computer(BaseTool):
                 {
                     Literal("code", description="Python code to execute"): str,
                     Literal(
-                        "filename",
-                        description="name of the file to put the Python code in before executing it",
+                        "filename", description="name of the file to put the Python code in before executing it"
                     ): str,
                 }
             ),
@@ -99,13 +83,7 @@ class Computer(BaseTool):
     @activity(
         config={
             "description": "Can be used to execute shell commands in Linux",
-            "schema": Schema(
-                {
-                    Literal(
-                        "command", description="shell command to execute"
-                    ): str
-                }
-            ),
+            "schema": Schema({Literal("command", description="shell command to execute"): str}),
         }
     )
     def execute_command(self, params: dict) -> BaseArtifact:
@@ -115,12 +93,7 @@ class Computer(BaseTool):
 
     def execute_command_in_container(self, command: str) -> BaseArtifact:
         try:
-            binds = {
-                self.local_workdir: {
-                    "bind": self.container_workdir,
-                    "mode": "rw",
-                }
-            }
+            binds = {self.local_workdir: {"bind": self.container_workdir, "mode": "rw"}}
 
             container = self.docker_client.containers.run(
                 self.image_name(self),
@@ -148,9 +121,7 @@ class Computer(BaseTool):
         except Exception as e:
             return ErrorArtifact(f"error executing command: {e}")
 
-    def execute_code_in_container(
-        self, filename: str, code: str
-    ) -> BaseArtifact:
+    def execute_code_in_container(self, filename: str, code: str) -> BaseArtifact:
         container_file_path = os.path.join(self.container_workdir, filename)
 
         if self.local_workdir:
@@ -166,9 +137,7 @@ class Computer(BaseTool):
             with open(local_file_path, "w") as f:
                 f.write(code)
 
-            return self.execute_command_in_container(
-                f"python {container_file_path}"
-            )
+            return self.execute_command_in_container(f"python {container_file_path}")
         except Exception as e:
             return ErrorArtifact(f"error executing code: {e}")
         finally:
@@ -203,9 +172,7 @@ class Computer(BaseTool):
             shutil.copy(self.dockerfile_path, temp_dir)
             shutil.copy(self.requirements_txt_path, temp_dir)
 
-            image = self.docker_client.images.build(
-                path=temp_dir, tag=self.image_name(tool), rm=True, forcerm=True
-            )
+            image = self.docker_client.images.build(path=temp_dir, tag=self.image_name(tool), rm=True, forcerm=True)
 
             response = [line for line in image]
 

--- a/griptape/tools/date_time/tool.py
+++ b/griptape/tools/date_time/tool.py
@@ -6,9 +6,7 @@ from griptape.utils.decorators import activity
 
 
 class DateTime(BaseTool):
-    @activity(
-        config={"description": "Can be used to return current date and time."}
-    )
+    @activity(config={"description": "Can be used to return current date and time."})
     def get_current_datetime(self, _: dict) -> BaseArtifact:
         try:
             current_datetime = datetime.now()

--- a/griptape/tools/email_client/tool.py
+++ b/griptape/tools/email_client/tool.py
@@ -41,31 +41,15 @@ class EmailClient(BaseTool):
     smtp_host: Optional[str] = field(default=None, kw_only=True)
     smtp_port: Optional[int] = field(default=None, kw_only=True)
     smtp_use_ssl: bool = field(default=True, kw_only=True)
-    smtp_user: Optional[str] = field(
-        default=Factory(lambda self: self.username, takes_self=True),
-        kw_only=True,
-    )
-    smtp_password: Optional[str] = field(
-        default=Factory(lambda self: self.password, takes_self=True),
-        kw_only=True,
-    )
+    smtp_user: Optional[str] = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
+    smtp_password: Optional[str] = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
     imap_url: Optional[str] = field(default=None, kw_only=True)
-    imap_user: Optional[str] = field(
-        default=Factory(lambda self: self.username, takes_self=True),
-        kw_only=True,
-    )
-    imap_password: Optional[str] = field(
-        default=Factory(lambda self: self.password, takes_self=True),
-        kw_only=True,
-    )
+    imap_user: Optional[str] = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
+    imap_password: Optional[str] = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
     mailboxes: Optional[dict[str, str]] = field(default=None, kw_only=True)
     email_loader: EmailLoader = field(
         default=Factory(
-            lambda self: EmailLoader(
-                imap_url=self.imap_url,
-                username=self.imap_user,
-                password=self.imap_password,
-            ),
+            lambda self: EmailLoader(imap_url=self.imap_url, username=self.imap_user, password=self.imap_password),
             takes_self=True,
         ),
         kw_only=True,
@@ -77,38 +61,21 @@ class EmailClient(BaseTool):
             "{% if _self.mailboxes %} Available mailboxes: {{ _self.mailboxes }}{% endif %}",
             "schema": Schema(
                 {
-                    Literal(
-                        "label",
-                        description="Label to retrieve emails from such as 'INBOX' or 'SENT'",
+                    Literal("label", description="Label to retrieve emails from such as 'INBOX' or 'SENT'"): str,
+                    schema.Optional(
+                        Literal("key", description="Optional key for filtering such as 'FROM' or 'SUBJECT'")
                     ): str,
                     schema.Optional(
-                        Literal(
-                            "key",
-                            description="Optional key for filtering such as 'FROM' or 'SUBJECT'",
-                        )
+                        Literal("search_criteria", description="Optional search criteria to filter emails by key")
                     ): str,
-                    schema.Optional(
-                        Literal(
-                            "search_criteria",
-                            description="Optional search criteria to filter emails by key",
-                        )
-                    ): str,
-                    schema.Optional(
-                        Literal(
-                            "max_count", description="Optional max email count"
-                        )
-                    ): int,
+                    schema.Optional(Literal("max_count", description="Optional max email count")): int,
                 }
             ),
         }
     )
     def retrieve(self, params: dict) -> ListArtifact | ErrorArtifact:
         values = params["values"]
-        max_count = (
-            int(values["max_count"])
-            if values.get("max_count")
-            else self.email_max_retrieve_count
-        )
+        max_count = int(values["max_count"]) if values.get("max_count") else self.email_max_retrieve_count
 
         return self.email_loader.load(
             EmailLoader.EmailQuery(

--- a/griptape/tools/file_manager/tool.py
+++ b/griptape/tools/file_manager/tool.py
@@ -4,21 +4,10 @@ import logging
 import os
 from pathlib import Path
 from attr import define, field, Factory
-from griptape.artifacts import (
-    ErrorArtifact,
-    InfoArtifact,
-    ListArtifact,
-    BaseArtifact,
-)
+from griptape.artifacts import ErrorArtifact, InfoArtifact, ListArtifact, BaseArtifact
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
-from griptape.loaders import (
-    FileLoader,
-    BaseLoader,
-    PdfLoader,
-    CsvLoader,
-    TextLoader,
-)
+from griptape.loaders import FileLoader, BaseLoader, PdfLoader, CsvLoader, TextLoader
 from schema import Schema, Literal
 from typing import Optional
 
@@ -71,9 +60,7 @@ class FileManager(BaseTool):
             ),
         }
     )
-    def load_files_from_disk(
-        self, params: dict
-    ) -> ListArtifact | ErrorArtifact:
+    def load_files_from_disk(self, params: dict) -> ListArtifact | ErrorArtifact:
         list_artifact = ListArtifact()
 
         for path in params["values"]["paths"]:
@@ -100,19 +87,14 @@ class FileManager(BaseTool):
                         "dir_name",
                         description="Destination directory name on disk in the POSIX format. For example, 'foo/bar'",
                     ): str,
-                    Literal(
-                        "file_name",
-                        description="Destination file name. For example, 'baz.txt'",
-                    ): str,
+                    Literal("file_name", description="Destination file name. For example, 'baz.txt'"): str,
                     "memory_name": str,
                     "artifact_namespace": str,
                 }
             ),
         }
     )
-    def save_memory_artifacts_to_disk(
-        self, params: dict
-    ) -> ErrorArtifact | InfoArtifact:
+    def save_memory_artifacts_to_disk(self, params: dict) -> ErrorArtifact | InfoArtifact:
         memory = self.find_input_memory(params["values"]["memory_name"])
         artifact_namespace = params["values"]["artifact_namespace"]
         dir_name = params["values"]["dir_name"]
@@ -125,10 +107,7 @@ class FileManager(BaseTool):
                 return ErrorArtifact("no artifacts found")
             elif len(list_artifact) == 1:
                 try:
-                    self._save_to_disk(
-                        os.path.join(self.workdir, dir_name, file_name),
-                        list_artifact.value[0].value,
-                    )
+                    self._save_to_disk(os.path.join(self.workdir, dir_name, file_name), list_artifact.value[0].value)
 
                     return InfoArtifact(f"saved successfully")
                 except Exception as e:
@@ -136,12 +115,7 @@ class FileManager(BaseTool):
             else:
                 try:
                     for a in list_artifact.value:
-                        self._save_to_disk(
-                            os.path.join(
-                                self.workdir, dir_name, f"{a.name}-{file_name}"
-                            ),
-                            a.to_text(),
-                        )
+                        self._save_to_disk(os.path.join(self.workdir, dir_name, f"{a.name}-{file_name}"), a.to_text())
 
                     return InfoArtifact(f"saved successfully")
                 except Exception as e:
@@ -163,9 +137,7 @@ class FileManager(BaseTool):
             ),
         }
     )
-    def save_content_to_file(
-        self, params: dict
-    ) -> ErrorArtifact | InfoArtifact:
+    def save_content_to_file(self, params: dict) -> ErrorArtifact | InfoArtifact:
         content = params["values"]["content"]
         new_path = params["values"]["path"]
         full_path = os.path.join(self.workdir, new_path)

--- a/griptape/tools/google_cal/tool.py
+++ b/griptape/tools/google_cal/tool.py
@@ -3,12 +3,7 @@ import logging
 import datetime
 from schema import Schema, Literal, Optional
 from attr import define, field
-from griptape.artifacts import (
-    TextArtifact,
-    ErrorArtifact,
-    InfoArtifact,
-    ListArtifact,
-)
+from griptape.artifacts import TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact
 from griptape.utils.decorators import activity
 from griptape.tools import BaseGoogleClient
 
@@ -26,14 +21,8 @@ class GoogleCalendarClient(BaseGoogleClient):
             "description": "Can be used to get upcoming events from a google calendar",
             "schema": Schema(
                 {
-                    Literal(
-                        "calendar_id",
-                        description="id of the google calendar such as 'primary'",
-                    ): str,
-                    Literal(
-                        "max_events",
-                        description="maximum number of events to return",
-                    ): int,
+                    Literal("calendar_id", description="id of the google calendar such as 'primary'"): str,
+                    Literal("max_events", description="maximum number of events to return"): int,
                 }
             ),
         }
@@ -94,16 +83,11 @@ class GoogleCalendarClient(BaseGoogleClient):
                         "according to IANA time zone data base name, such as 'Europe/Zurich'",
                     ): str,
                     Literal("title", description="title of the event"): str,
+                    Literal("description", description="description of the event"): str,
                     Literal(
-                        "description", description="description of the event"
-                    ): str,
-                    Literal(
-                        "attendees",
-                        description="list of the email addresses of attendees using 'email' as key",
+                        "attendees", description="list of the email addresses of attendees using 'email' as key"
                     ): list,
-                    Optional(
-                        Literal("location", description="location of the event")
-                    ): str,
+                    Optional(Literal("location", description="location of the event")): str,
                 }
             ),
         }
@@ -113,34 +97,19 @@ class GoogleCalendarClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                scopes=self.CREATE_EVENT_SCOPES,
-                service_name="calendar",
-                version="v3",
-                owner_email=self.owner_email,
+                scopes=self.CREATE_EVENT_SCOPES, service_name="calendar", version="v3", owner_email=self.owner_email
             )
 
             event = {
                 "summary": values["title"],
                 "location": values.get("location"),
                 "description": values["description"],
-                "start": {
-                    "dateTime": values["start_datetime"],
-                    "timeZone": values["start_time_zone"],
-                },
-                "end": {
-                    "dateTime": values["end_datetime"],
-                    "timeZone": values["end_time_zone"],
-                },
+                "start": {"dateTime": values["start_datetime"], "timeZone": values["start_time_zone"]},
+                "end": {"dateTime": values["end_datetime"], "timeZone": values["end_time_zone"]},
                 "attendees": values["attendees"],
             }
-            event = (
-                service.events()
-                .insert(calendarId="primary", body=event)
-                .execute()
-            )
-            return InfoArtifact(
-                f'A calendar event was successfully created. (Link:{event.get("htmlLink")})'
-            )
+            event = service.events().insert(calendarId="primary", body=event).execute()
+            return InfoArtifact(f'A calendar event was successfully created. (Link:{event.get("htmlLink")})')
         except Exception as e:
             logging.error(e)
             return ErrorArtifact(f"error creating calendar event: {e}")

--- a/griptape/tools/google_drive/tool.py
+++ b/griptape/tools/google_drive/tool.py
@@ -3,13 +3,7 @@ import logging
 from typing import List, Dict, Any
 from schema import Schema, Literal, Optional, Or
 from attr import define, field
-from griptape.artifacts import (
-    ErrorArtifact,
-    InfoArtifact,
-    ListArtifact,
-    BlobArtifact,
-    TextArtifact,
-)
+from griptape.artifacts import ErrorArtifact, InfoArtifact, ListArtifact, BlobArtifact, TextArtifact
 from griptape.utils.decorators import activity
 from griptape.tools import BaseGoogleClient
 from io import BytesIO
@@ -56,10 +50,7 @@ class GoogleDriveClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                self.LIST_FILES_SCOPES,
-                self.SERVICE_NAME,
-                self.SERVICE_VERSION,
-                self.owner_email,
+                self.LIST_FILES_SCOPES, self.SERVICE_NAME, self.SERVICE_VERSION, self.owner_email
             )
 
             if folder_path == self.DEFAULT_FOLDER_PATH:
@@ -69,17 +60,13 @@ class GoogleDriveClient(BaseGoogleClient):
                 if folder_id:
                     query = f"'{folder_id}' in parents and trashed=false"
                 else:
-                    return ErrorArtifact(
-                        f"Could not find folder: {folder_path}"
-                    )
+                    return ErrorArtifact(f"Could not find folder: {folder_path}")
 
             items = self._list_files(service, query)
             return ListArtifact([TextArtifact(i) for i in items])
 
         except MalformedError:
-            return ErrorArtifact(
-                "error listing files due to malformed credentials"
-            )
+            return ErrorArtifact("error listing files due to malformed credentials")
         except Exception as e:
             return ErrorArtifact(f"error listing files from Google Drive: {e}")
 
@@ -101,9 +88,7 @@ class GoogleDriveClient(BaseGoogleClient):
             ),
         }
     )
-    def save_memory_artifacts_to_drive(
-        self, params: dict
-    ) -> ErrorArtifact | InfoArtifact:
+    def save_memory_artifacts_to_drive(self, params: dict) -> ErrorArtifact | InfoArtifact:
         values = params["values"]
         memory = self.find_input_memory(values["memory_name"])
         file_name = values["file_name"]
@@ -114,41 +99,28 @@ class GoogleDriveClient(BaseGoogleClient):
 
             if artifacts:
                 service = self._build_client(
-                    self.DRIVE_FILE_SCOPES,
-                    self.SERVICE_NAME,
-                    self.SERVICE_VERSION,
-                    self.owner_email,
+                    self.DRIVE_FILE_SCOPES, self.SERVICE_NAME, self.SERVICE_VERSION, self.owner_email
                 )
 
                 if folder_path == self.DEFAULT_FOLDER_PATH:
                     folder_id = self.DEFAULT_FOLDER_PATH
                 else:
-                    folder_id = self._convert_path_to_file_id(
-                        service, folder_path
-                    )
+                    folder_id = self._convert_path_to_file_id(service, folder_path)
 
                 if folder_id:
                     try:
                         if len(artifacts) == 1:
-                            self._save_to_drive(
-                                file_name, artifacts[0].value, folder_id
-                            )
+                            self._save_to_drive(file_name, artifacts[0].value, folder_id)
                         else:
                             for a in artifacts:
-                                self._save_to_drive(
-                                    f"{a.name}-{file_name}", a.value, folder_id
-                                )
+                                self._save_to_drive(f"{a.name}-{file_name}", a.value, folder_id)
 
                         return InfoArtifact(f"saved successfully")
 
                     except Exception as e:
-                        return ErrorArtifact(
-                            f"error saving file to Google Drive: {e}"
-                        )
+                        return ErrorArtifact(f"error saving file to Google Drive: {e}")
                 else:
-                    return ErrorArtifact(
-                        f"Could not find folder: {folder_path}"
-                    )
+                    return ErrorArtifact(f"Could not find folder: {folder_path}")
             else:
                 return ErrorArtifact("no artifacts found")
         else:
@@ -169,9 +141,7 @@ class GoogleDriveClient(BaseGoogleClient):
             ),
         }
     )
-    def save_content_to_drive(
-        self, params: dict
-    ) -> ErrorArtifact | InfoArtifact:
+    def save_content_to_drive(self, params: dict) -> ErrorArtifact | InfoArtifact:
         content = params["values"]["content"]
         filename = params["values"]["path"]
 
@@ -205,10 +175,7 @@ class GoogleDriveClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                self.LIST_FILES_SCOPES,
-                self.SERVICE_NAME,
-                self.SERVICE_VERSION,
-                self.owner_email,
+                self.LIST_FILES_SCOPES, self.SERVICE_NAME, self.SERVICE_VERSION, self.owner_email
             )
 
             for path in values["paths"]:
@@ -219,9 +186,7 @@ class GoogleDriveClient(BaseGoogleClient):
 
                     if mime_type in self.GOOGLE_EXPORT_MIME_MAPPING:
                         export_mime = self.GOOGLE_EXPORT_MIME_MAPPING[mime_type]
-                        request = service.files().export_media(
-                            fileId=file_id, mimeType=export_mime
-                        )
+                        request = service.files().export_media(fileId=file_id, mimeType=export_mime)
                     else:
                         request = service.files().get_media(fileId=file_id)
 
@@ -233,9 +198,7 @@ class GoogleDriveClient(BaseGoogleClient):
         except HttpError as e:
             return ErrorArtifact(f"error downloading file in Google Drive: {e}")
         except MalformedError:
-            return ErrorArtifact(
-                "error downloading file due to malformed credentials"
-            )
+            return ErrorArtifact("error downloading file due to malformed credentials")
         except Exception as e:
             return ErrorArtifact(f"error downloading file to Google Drive: {e}")
 
@@ -275,10 +238,7 @@ class GoogleDriveClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                self.LIST_FILES_SCOPES,
-                self.SERVICE_NAME,
-                self.SERVICE_VERSION,
-                self.owner_email,
+                self.LIST_FILES_SCOPES, self.SERVICE_NAME, self.SERVICE_VERSION, self.owner_email
             )
 
             folder_id = None
@@ -305,13 +265,9 @@ class GoogleDriveClient(BaseGoogleClient):
                 return ErrorArtifact(f"Folder path {folder_path} not found")
 
         except HttpError as e:
-            return ErrorArtifact(
-                f"error searching for file in Google Drive: {e}"
-            )
+            return ErrorArtifact(f"error searching for file in Google Drive: {e}")
         except MalformedError:
-            return ErrorArtifact(
-                "error searching for file due to malformed credentials"
-            )
+            return ErrorArtifact("error searching for file due to malformed credentials")
         except Exception as e:
             return ErrorArtifact(f"error searching file to Google Drive: {e}")
 
@@ -320,13 +276,8 @@ class GoogleDriveClient(BaseGoogleClient):
             "description": "Can be used to share a file with a specified user.",
             "schema": Schema(
                 {
-                    Literal(
-                        "file_path", description="The path of the file to share"
-                    ): str,
-                    Literal(
-                        "email_address",
-                        description="The email address of the user to share with",
-                    ): str,
+                    Literal("file_path", description="The path of the file to share"): str,
+                    Literal("email_address", description="The email address of the user to share with"): str,
                     Optional(
                         "role",
                         default="reader",
@@ -347,10 +298,7 @@ class GoogleDriveClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                scopes=self.DRIVE_AUTH_SCOPES,
-                service_name="drive",
-                version="v3",
-                owner_email=self.owner_email,
+                scopes=self.DRIVE_AUTH_SCOPES, service_name="drive", version="v3", owner_email=self.owner_email
             )
 
             if file_path.lower() == self.DEFAULT_FOLDER_PATH:
@@ -359,42 +307,25 @@ class GoogleDriveClient(BaseGoogleClient):
                 file_id = self._convert_path_to_file_id(service, file_path)
 
             if file_id:
-                batch_update_permission_request_body = {
-                    "role": role,
-                    "type": "user",
-                    "emailAddress": email_address,
-                }
+                batch_update_permission_request_body = {"role": role, "type": "user", "emailAddress": email_address}
                 request = service.permissions().create(
-                    fileId=file_id,
-                    body=batch_update_permission_request_body,
-                    fields="id",
+                    fileId=file_id, body=batch_update_permission_request_body, fields="id"
                 )
                 request.execute()
-                return InfoArtifact(
-                    f"File at {file_path} shared with {email_address} as a {role}"
-                )
+                return InfoArtifact(f"File at {file_path} shared with {email_address} as a {role}")
             else:
                 return ErrorArtifact(f"error finding file at path: {file_path}")
         except HttpError as e:
             return ErrorArtifact(f"error sharing file due to http error: {e}")
         except MalformedError as e:
-            return ErrorArtifact(
-                f"error sharing file due to malformed credentials: {e}"
-            )
+            return ErrorArtifact(f"error sharing file due to malformed credentials: {e}")
         except Exception as e:
             return ErrorArtifact(f"error sharing file: {e}")
 
-    def _save_to_drive(
-        self, filename: str, value: any, parent_folder_id=None
-    ) -> InfoArtifact | ErrorArtifact:
+    def _save_to_drive(self, filename: str, value: any, parent_folder_id=None) -> InfoArtifact | ErrorArtifact:
         from googleapiclient.http import MediaIoBaseUpload
 
-        service = self._build_client(
-            self.DRIVE_FILE_SCOPES,
-            self.SERVICE_NAME,
-            self.SERVICE_VERSION,
-            self.owner_email,
-        )
+        service = self._build_client(self.DRIVE_FILE_SCOPES, self.SERVICE_NAME, self.SERVICE_VERSION, self.owner_email)
 
         if isinstance(value, str):
             value = value.encode()
@@ -411,15 +342,9 @@ class GoogleDriveClient(BaseGoogleClient):
         if parent_folder_id:
             file_metadata["parents"] = [parent_folder_id]
 
-        media = MediaIoBaseUpload(
-            BytesIO(value), mimetype="application/octet-stream", resumable=True
-        )
+        media = MediaIoBaseUpload(BytesIO(value), mimetype="application/octet-stream", resumable=True)
 
-        file = (
-            service.files()
-            .create(body=file_metadata, media_body=media, fields="id")
-            .execute()
-        )
+        file = service.files().create(body=file_metadata, media_body=media, fields="id").execute()
         return InfoArtifact(file)
 
     def _list_files(self, service: Any, query: str) -> List[Dict]:
@@ -427,11 +352,7 @@ class GoogleDriveClient(BaseGoogleClient):
         next_page_token = None
 
         while True:
-            results = (
-                service.files()
-                .list(q=query, pageToken=next_page_token)
-                .execute()
-            )
+            results = service.files().list(q=query, pageToken=next_page_token).execute()
 
             files = results.get("files", [])
             items.extend(files)

--- a/griptape/tools/google_gmail/tool.py
+++ b/griptape/tools/google_gmail/tool.py
@@ -11,9 +11,7 @@ from griptape.tools import BaseGoogleClient
 
 @define
 class GoogleGmailClient(BaseGoogleClient):
-    CREATE_DRAFT_EMAIL_SCOPES = [
-        "https://www.googleapis.com/auth/gmail.compose"
-    ]
+    CREATE_DRAFT_EMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.compose"]
 
     owner_email: str = field(kw_only=True)
 
@@ -22,9 +20,7 @@ class GoogleGmailClient(BaseGoogleClient):
             "description": "Can be used to create a draft email in GMail",
             "schema": Schema(
                 {
-                    Literal(
-                        "to", description="email address which to send to"
-                    ): str,
+                    Literal("to", description="email address which to send to"): str,
                     Literal("subject", description="subject of the email"): str,
                     Literal("body", description="body of the email"): str,
                 }
@@ -36,10 +32,7 @@ class GoogleGmailClient(BaseGoogleClient):
 
         try:
             service = self._build_client(
-                scopes=self.CREATE_DRAFT_EMAIL_SCOPES,
-                service_name="gmail",
-                version="v1",
-                owner_email=self.owner_email,
+                scopes=self.CREATE_DRAFT_EMAIL_SCOPES, service_name="gmail", version="v1", owner_email=self.owner_email
             )
 
             message = EmailMessage()
@@ -48,19 +41,10 @@ class GoogleGmailClient(BaseGoogleClient):
             message["From"] = self.owner_email
             message["Subject"] = values["subject"]
 
-            encoded_message = base64.urlsafe_b64encode(
-                message.as_bytes()
-            ).decode()
+            encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
             create_message = {"message": {"raw": encoded_message}}
-            draft = (
-                service.users()
-                .drafts()
-                .create(userId="me", body=create_message)
-                .execute()
-            )
-            return InfoArtifact(
-                f'An email draft was successfully created (ID: {draft["id"]})'
-            )
+            draft = service.users().drafts().create(userId="me", body=create_message).execute()
+            return InfoArtifact(f'An email draft was successfully created (ID: {draft["id"]})')
 
         except Exception as error:
             logging.error(error)

--- a/griptape/tools/openweather_client/tool.py
+++ b/griptape/tools/openweather_client/tool.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
-from griptape.artifacts import (
-    ListArtifact,
-    TextArtifact,
-    ErrorArtifact,
-    InfoArtifact,
-)
+from griptape.artifacts import ListArtifact, TextArtifact, ErrorArtifact, InfoArtifact
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 from schema import Schema, Literal
@@ -88,20 +83,14 @@ class OpenWeatherClient(BaseTool):
             ),
         }
     )
-    def get_coordinates_by_location(
-        self, params: dict
-    ) -> InfoArtifact | ErrorArtifact:
+    def get_coordinates_by_location(self, params: dict) -> InfoArtifact | ErrorArtifact:
         location = params["values"].get("location")
         coordinates = self._fetch_coordinates(location)
         if coordinates:
             lat, lon = coordinates
-            return InfoArtifact(
-                f"Coordinates for {location}: Latitude: {lat}, Longitude: {lon}"
-            )
+            return InfoArtifact(f"Coordinates for {location}: Latitude: {lat}, Longitude: {lon}")
         else:
-            return ErrorArtifact(
-                f"Error fetching coordinates for location: {location}"
-            )
+            return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
     def _fetch_coordinates(self, location: str) -> tuple[float, float] | None:
         parts = location.split(",")
@@ -126,19 +115,10 @@ class OpenWeatherClient(BaseTool):
         config={
             "description": "Can be used to fetch current weather data for a given location. "
             "Temperatures are returned in {{ _self.units }} by default.",
-            "schema": Schema(
-                {
-                    Literal(
-                        "location",
-                        description="Location to fetch weather data for.",
-                    ): str
-                }
-            ),
+            "schema": Schema({Literal("location", description="Location to fetch weather data for."): str}),
         }
     )
-    def get_current_weather_by_location(
-        self, params: dict
-    ) -> ListArtifact | TextArtifact | ErrorArtifact:
+    def get_current_weather_by_location(self, params: dict) -> ListArtifact | TextArtifact | ErrorArtifact:
         location = params["values"].get("location")
         coordinates = self._fetch_coordinates(location)
         if coordinates:
@@ -152,27 +132,16 @@ class OpenWeatherClient(BaseTool):
             }
             return self._fetch_weather_data(request_params)
         else:
-            return ErrorArtifact(
-                f"Error fetching coordinates for location: {location}"
-            )
+            return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
     @activity(
         config={
             "description": "Can be used to fetch hourly forecast for a given location up to 48 hours ahead. "
             "Temperatures are returned in {{ _self.units }} by default.",
-            "schema": Schema(
-                {
-                    Literal(
-                        "location",
-                        description="Location to fetch hourly forecast for.",
-                    ): str
-                }
-            ),
+            "schema": Schema({Literal("location", description="Location to fetch hourly forecast for."): str}),
         }
     )
-    def get_hourly_forecast_by_location(
-        self, params: dict
-    ) -> ListArtifact | TextArtifact | ErrorArtifact:
+    def get_hourly_forecast_by_location(self, params: dict) -> ListArtifact | TextArtifact | ErrorArtifact:
         location = params["values"].get("location")
         coordinates = self._fetch_coordinates(location)
         if coordinates:
@@ -186,27 +155,16 @@ class OpenWeatherClient(BaseTool):
             }
             return self._fetch_weather_data(request_params)
         else:
-            return ErrorArtifact(
-                f"Error fetching coordinates for location: {location}"
-            )
+            return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
     @activity(
         config={
             "description": "Can be used to fetch daily forecast for a given location up to 8 days ahead. "
             "Temperatures are returned in {{ _self.units }} by default.",
-            "schema": Schema(
-                {
-                    Literal(
-                        "location",
-                        description="Location to fetch daily forecast for.",
-                    ): str
-                }
-            ),
+            "schema": Schema({Literal("location", description="Location to fetch daily forecast for."): str}),
         }
     )
-    def get_daily_forecast_by_location(
-        self, params: dict
-    ) -> ListArtifact | TextArtifact | ErrorArtifact:
+    def get_daily_forecast_by_location(self, params: dict) -> ListArtifact | TextArtifact | ErrorArtifact:
         location = params["values"].get("location")
         coordinates = self._fetch_coordinates(location)
         if coordinates:
@@ -220,13 +178,9 @@ class OpenWeatherClient(BaseTool):
             }
             return self._fetch_weather_data(request_params)
         else:
-            return ErrorArtifact(
-                f"Error fetching coordinates for location: {location}"
-            )
+            return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
-    def _fetch_weather_data(
-        self, request_params: dict
-    ) -> ListArtifact | TextArtifact | ErrorArtifact:
+    def _fetch_weather_data(self, request_params: dict) -> ListArtifact | TextArtifact | ErrorArtifact:
         try:
             response = requests.get(self.BASE_URL, params=request_params)
             if response.status_code == 200:
@@ -237,12 +191,8 @@ class OpenWeatherClient(BaseTool):
                 else:
                     return TextArtifact(str(data))
             else:
-                logging.error(
-                    f"Error fetching weather data. HTTP Status Code: {response.status_code}"
-                )
-                return ErrorArtifact(
-                    "Error fetching weather data from OpenWeather API"
-                )
+                logging.error(f"Error fetching weather data. HTTP Status Code: {response.status_code}")
+                return ErrorArtifact("Error fetching weather data from OpenWeather API")
         except Exception as e:
             logging.error(f"Error fetching weather data: {e}")
             return ErrorArtifact(f"Error fetching weather data: {e}")

--- a/griptape/tools/proxycurl_client/tool.py
+++ b/griptape/tools/proxycurl_client/tool.py
@@ -26,8 +26,7 @@ class ProxycurlClient(BaseTool):
             "schema": Schema(
                 {
                     Literal(
-                        "profile_id",
-                        description="LinkedIn profile ID (i.e., https://www.linkedin.com/in/<profile_id>)",
+                        "profile_id", description="LinkedIn profile ID (i.e., https://www.linkedin.com/in/<profile_id>)"
                     ): str
                 }
             ),
@@ -44,8 +43,7 @@ class ProxycurlClient(BaseTool):
             "schema": Schema(
                 {
                     Literal(
-                        "job_id",
-                        description="LinkedIn job ID (i.e., https://www.linkedin.com/jobs/view/<job_id>)",
+                        "job_id", description="LinkedIn job ID (i.e., https://www.linkedin.com/jobs/view/<job_id>)"
                     ): str
                 }
             ),
@@ -92,29 +90,17 @@ class ProxycurlClient(BaseTool):
 
         return self._call_api("school", "school", school_id)
 
-    def _call_api(
-        self, endpoint_name: str, path: str, item_id: str
-    ) -> ListArtifact | ErrorArtifact:
+    def _call_api(self, endpoint_name: str, path: str, item_id: str) -> ListArtifact | ErrorArtifact:
         headers = {"Authorization": f"Bearer {self.proxycurl_api_key}"}
-        linkedin_url = "/".join(
-            arg.strip("/")
-            for arg in ["https://www.linkedin.com", path, item_id]
-        )
+        linkedin_url = "/".join(arg.strip("/") for arg in ["https://www.linkedin.com", path, item_id])
         params = {"url": linkedin_url}
-        response = requests.get(
-            self.ENDPOINTS[endpoint_name],
-            params=params,
-            headers=headers,
-            timeout=self.timeout,
-        )
+        response = requests.get(self.ENDPOINTS[endpoint_name], params=params, headers=headers, timeout=self.timeout)
 
         if response.status_code == 200:
             try:
                 data = response.json()
                 filtered_data = [
-                    TextArtifact(f"{key}: {value}")
-                    for key, value in data.items()
-                    if value is not None and value
+                    TextArtifact(f"{key}: {value}") for key, value in data.items() if value is not None and value
                 ]
 
                 return ListArtifact(filtered_data)
@@ -122,8 +108,6 @@ class ProxycurlClient(BaseTool):
             except ValueError:
                 return ErrorArtifact("Failed to decode JSON from response")
         else:
-            logging.error(
-                f"Error retrieving information from LinkedIn. HTTP Status Code: {response.status_code}"
-            )
+            logging.error(f"Error retrieving information from LinkedIn. HTTP Status Code: {response.status_code}")
 
             return ErrorArtifact("Error retrieving information from LinkedIn")

--- a/griptape/tools/rest_api_client/tool.py
+++ b/griptape/tools/rest_api_client/tool.py
@@ -25,12 +25,8 @@ class RestApiClient(BaseTool):
     base_url: str = field(kw_only=True)
     path: Optional[str] = field(default=None, kw_only=True)
     description: str = field(kw_only=True)
-    request_path_params_schema: Optional[str] = field(
-        default=None, kw_only=True
-    )
-    request_query_params_schema: Optional[str] = field(
-        default=None, kw_only=True
-    )
+    request_path_params_schema: Optional[str] = field(default=None, kw_only=True)
+    request_query_params_schema: Optional[str] = field(default=None, kw_only=True)
     request_body_schema: Optional[str] = field(default=None, kw_only=True)
     response_body_schema: Optional[str] = field(default=None, kw_only=True)
 
@@ -48,9 +44,7 @@ class RestApiClient(BaseTool):
                 {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
                 """
             ),
-            "schema": Schema(
-                {Literal("body", description="The request body."): dict}
-            ),
+            "schema": Schema({Literal("body", description="The request body."): dict}),
         }
     )
     def put(self, params: dict) -> BaseArtifact:
@@ -82,10 +76,7 @@ class RestApiClient(BaseTool):
             ),
             "schema": Schema(
                 {
-                    Literal(
-                        "path_params",
-                        description="The request path parameters.",
-                    ): list,
+                    Literal("path_params", description="The request path parameters."): list,
                     Literal("body", description="The request body."): dict,
                 }
             ),
@@ -117,9 +108,7 @@ class RestApiClient(BaseTool):
                 {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
                 """
             ),
-            "schema": Schema(
-                {Literal("body", description="The request body."): dict}
-            ),
+            "schema": Schema({Literal("body", description="The request body."): dict}),
         }
     )
     def post(self, params: dict) -> BaseArtifact:
@@ -151,18 +140,8 @@ class RestApiClient(BaseTool):
             "schema": schema.Optional(
                 Schema(
                     {
-                        schema.Optional(
-                            Literal(
-                                "query_params",
-                                description="The request query parameters.",
-                            )
-                        ): dict,
-                        schema.Optional(
-                            Literal(
-                                "path_params",
-                                description="The request path parameters.",
-                            )
-                        ): list,
+                        schema.Optional(Literal("query_params", description="The request query parameters.")): dict,
+                        schema.Optional(Literal("path_params", description="The request path parameters.")): list,
                     }
                 )
             ),
@@ -200,18 +179,8 @@ class RestApiClient(BaseTool):
             ),
             "schema": Schema(
                 {
-                    schema.Optional(
-                        Literal(
-                            "query_params",
-                            description="The request query parameters.",
-                        )
-                    ): dict,
-                    schema.Optional(
-                        Literal(
-                            "path_params",
-                            description="The request path parameters.",
-                        )
-                    ): list,
+                    schema.Optional(Literal("query_params", description="The request query parameters.")): dict,
+                    schema.Optional(Literal("path_params", description="The request path parameters.")): list,
                 }
             ),
         }

--- a/griptape/tools/sql_client/tool.py
+++ b/griptape/tools/sql_client/tool.py
@@ -18,17 +18,11 @@ class SqlClient(BaseTool):
 
     @property
     def full_table_name(self) -> str:
-        return (
-            f"{self.schema_name}.{self.table_name}"
-            if self.schema_name
-            else self.table_name
-        )
+        return f"{self.schema_name}.{self.table_name}" if self.schema_name else self.table_name
 
     @property
     def table_schema(self) -> str:
-        return self.sql_loader.sql_driver.get_table_schema(
-            self.full_table_name, schema=self.schema_name
-        )
+        return self.sql_loader.sql_driver.get_table_schema(self.full_table_name, schema=self.schema_name)
 
     @activity(
         config={

--- a/griptape/tools/tool_memory_client/tool.py
+++ b/griptape/tools/tool_memory_client/tool.py
@@ -45,8 +45,6 @@ class ToolMemoryClient(BaseTool):
         query = params["values"]["query"]
 
         if memory:
-            return memory.query_namespace(
-                namespace=artifact_namespace, query=query
-            )
+            return memory.query_namespace(namespace=artifact_namespace, query=query)
         else:
             return ErrorArtifact("memory not found")

--- a/griptape/tools/vector_store_client/tool.py
+++ b/griptape/tools/vector_store_client/tool.py
@@ -30,8 +30,7 @@ class VectorStoreClient(BaseTool):
             "schema": Schema(
                 {
                     Literal(
-                        "query",
-                        description="A natural language search query to run against the vector database",
+                        "query", description="A natural language search query to run against the vector database"
                     ): str
                 }
             ),
@@ -41,8 +40,6 @@ class VectorStoreClient(BaseTool):
         query = params["values"]["query"]
 
         try:
-            return self.query_engine.query(
-                query, top_n=self.top_n, namespace=self.namespace
-            )
+            return self.query_engine.query(query, top_n=self.top_n, namespace=self.namespace)
         except Exception as e:
             return ErrorArtifact(f"error querying vector store: {e}")

--- a/griptape/tools/web_scraper/tool.py
+++ b/griptape/tools/web_scraper/tool.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 from attr import define, field
-from griptape.artifacts import (
-    BaseArtifact,
-    TextArtifact,
-    ErrorArtifact,
-    ListArtifact,
-)
+from griptape.artifacts import BaseArtifact, TextArtifact, ErrorArtifact, ListArtifact
 from griptape.loaders import TextLoader
 from schema import Schema, Literal
 from griptape.tools import BaseTool
@@ -20,9 +15,7 @@ class WebScraper(BaseTool):
     @activity(
         config={
             "description": "Can be used to browse a web page and load its content",
-            "schema": Schema(
-                {Literal("url", description="Valid HTTP URL"): str}
-            ),
+            "schema": Schema({Literal("url", description="Valid HTTP URL"): str}),
         }
     )
     def get_content(self, params: dict) -> ListArtifact | ErrorArtifact:
@@ -32,16 +25,12 @@ class WebScraper(BaseTool):
         if isinstance(page, ErrorArtifact):
             return page
         else:
-            return ListArtifact(
-                TextLoader().text_to_artifacts(page.get("text"))
-            )
+            return ListArtifact(TextLoader().text_to_artifacts(page.get("text")))
 
     @activity(
         config={
             "description": "Can be used to load a web page author",
-            "schema": Schema(
-                {Literal("url", description="Valid HTTP URL"): str}
-            ),
+            "schema": Schema({Literal("url", description="Valid HTTP URL"): str}),
         }
     )
     def get_author(self, params: dict) -> BaseArtifact:

--- a/griptape/tools/web_search/tool.py
+++ b/griptape/tools/web_search/tool.py
@@ -32,12 +32,7 @@ class WebSearch(BaseTool):
         query = props["values"]["query"]
 
         try:
-            return ListArtifact(
-                [
-                    TextArtifact(str(result))
-                    for result in self._search_google(query)
-                ]
-            )
+            return ListArtifact([TextArtifact(str(result)) for result in self._search_google(query)])
         except Exception as e:
             return ErrorArtifact(f"error searching Google: {e}")
 
@@ -57,14 +52,7 @@ class WebSearch(BaseTool):
         if response.status_code == 200:
             data = response.json()
 
-            links = [
-                {
-                    "url": r["link"],
-                    "title": r["title"],
-                    "description": r["snippet"],
-                }
-                for r in data["items"]
-            ]
+            links = [{"url": r["link"], "title": r["title"], "description": r["snippet"]} for r in data["items"]]
 
             return links
         else:

--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -15,9 +15,7 @@ class Chat:
     intro_text: Optional[str] = field(default=None, kw_only=True)
     prompt_prefix: str = field(default="Q: ", kw_only=True)
     response_prefix: str = field(default="A: ", kw_only=True)
-    output_fn: Callable[[str], None] = field(
-        default=Factory(lambda: print), kw_only=True
-    )
+    output_fn: Callable[[str], None] = field(default=Factory(lambda: print), kw_only=True)
 
     def start(self) -> None:
         if self.intro_text:
@@ -32,6 +30,4 @@ class Chat:
             else:
                 self.output_fn(self.processing_text)
 
-            self.output_fn(
-                f"{self.response_prefix}{self.structure.run(question).output.to_text()}"
-            )
+            self.output_fn(f"{self.response_prefix}{self.structure.run(question).output.to_text()}")

--- a/griptape/utils/command_runner.py
+++ b/griptape/utils/command_runner.py
@@ -6,9 +6,7 @@ from griptape.artifacts import BaseArtifact, TextArtifact, ErrorArtifact
 @define
 class CommandRunner:
     def run(self, command: str) -> BaseArtifact:
-        process = subprocess.Popen(
-            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+        process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         stdout, stderr = process.communicate()
 

--- a/griptape/utils/decorators.py
+++ b/griptape/utils/decorators.py
@@ -9,9 +9,7 @@ CONFIG_SCHEMA = Schema({"description": str, schema.Optional("schema"): Schema})
 def activity(config: dict):
     validated_config = CONFIG_SCHEMA.validate(config)
 
-    validated_config.update(
-        {k: v for k, v in config.items() if k not in validated_config}
-    )
+    validated_config.update({k: v for k, v in config.items() if k not in validated_config})
 
     if not validated_config.get("schema"):
         validated_config["schema"] = None

--- a/griptape/utils/dict_utils.py
+++ b/griptape/utils/dict_utils.py
@@ -1,9 +1,5 @@
 def remove_null_values_in_dict_recursively(d):
     if isinstance(d, dict):
-        return {
-            k: remove_null_values_in_dict_recursively(v)
-            for k, v in d.items()
-            if v is not None
-        }
+        return {k: remove_null_values_in_dict_recursively(v) for k, v in d.items() if v is not None}
     else:
         return d

--- a/griptape/utils/futures.py
+++ b/griptape/utils/futures.py
@@ -5,8 +5,6 @@ T = TypeVar("T")
 
 
 def execute_futures_dict(fs_dict: dict[str, futures.Future[T]]) -> dict[str, T]:
-    futures.wait(
-        fs_dict.values(), timeout=None, return_when=futures.ALL_COMPLETED
-    )
+    futures.wait(fs_dict.values(), timeout=None, return_when=futures.ALL_COMPLETED)
 
     return {key: future.result() for key, future in fs_dict.items()}

--- a/griptape/utils/import_utils.py
+++ b/griptape/utils/import_utils.py
@@ -26,10 +26,7 @@ def import_optional_dependency(name: str) -> Optional[ModuleType]:
     package_name = INSTALL_MAPPING.get(name)
     install_name = package_name if package_name is not None else name
 
-    msg = (
-        f"Missing optional dependency: '{install_name}'. "
-        f"Use poetry or pip to install '{install_name}'."
-    )
+    msg = f"Missing optional dependency: '{install_name}'. " f"Use poetry or pip to install '{install_name}'."
     try:
         module = import_module(name)
     except ImportError:

--- a/griptape/utils/j2.py
+++ b/griptape/utils/j2.py
@@ -10,22 +10,14 @@ class J2:
     templates_dir: str = field(default=abs_path("templates"), kw_only=True)
     environment: Environment = field(
         default=Factory(
-            lambda self: Environment(
-                loader=FileSystemLoader(self.templates_dir),
-                trim_blocks=True,
-                lstrip_blocks=True,
-            ),
+            lambda self: Environment(loader=FileSystemLoader(self.templates_dir), trim_blocks=True, lstrip_blocks=True),
             takes_self=True,
         ),
         kw_only=True,
     )
 
     def render(self, **kwargs) -> str:
-        return (
-            self.environment.get_template(self.template_name)
-            .render(kwargs)
-            .rstrip()
-        )
+        return self.environment.get_template(self.template_name).render(kwargs).rstrip()
 
     def render_from_string(self, value: str, **kwargs) -> str:
         return self.environment.from_string(value).render(kwargs)

--- a/griptape/utils/manifest_validator.py
+++ b/griptape/utils/manifest_validator.py
@@ -6,12 +6,4 @@ class ManifestValidator:
         return self.schema().validate(manifest)
 
     def schema(self) -> Schema:
-        return Schema(
-            {
-                "version": "v1",
-                "name": str,
-                "description": str,
-                "contact_email": str,
-                "legal_info_url": str,
-            }
-        )
+        return Schema({"version": "v1", "name": str, "description": str, "contact_email": str, "legal_info_url": str})

--- a/griptape/utils/paths.py
+++ b/griptape/utils/paths.py
@@ -2,8 +2,4 @@ import os
 
 
 def abs_path(path: str) -> str:
-    return os.path.abspath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), os.pardir, path
-        )
-    )
+    return os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, path))

--- a/griptape/utils/prompt_stack.py
+++ b/griptape/utils/prompt_stack.py
@@ -50,9 +50,7 @@ class PromptStack:
     def add_assistant_input(self, content: str) -> Input:
         return self.add_input(content, self.ASSISTANT_ROLE)
 
-    def add_conversation_memory(
-        self, memory: ConversationMemory, index: Optional[int] = None
-    ) -> list[Input]:
+    def add_conversation_memory(self, memory: ConversationMemory, index: Optional[int] = None) -> list[Input]:
         """Add the Conversation Memory runs to the Prompt Stack.
 
         If autoprune is enabled, this will fit as many Conversation Memory runs into the Prompt Stack
@@ -78,16 +76,12 @@ class PromptStack:
                 # Add n runs from Conversation Memory.
                 # Where we insert into the Prompt Stack doesn't matter here
                 # since we only care about the total token count.
-                memory_inputs = memory.to_prompt_stack(
-                    num_runs_to_fit_in_prompt
-                ).inputs
+                memory_inputs = memory.to_prompt_stack(num_runs_to_fit_in_prompt).inputs
                 temp_stack.inputs.extend(memory_inputs)
 
                 # Convert the prompt stack into tokens left.
                 prompt_string = prompt_driver.prompt_stack_to_string(temp_stack)
-                tokens_left = prompt_driver.tokenizer.count_tokens_left(
-                    prompt_string
-                )
+                tokens_left = prompt_driver.tokenizer.count_tokens_left(prompt_string)
                 if tokens_left > 0:
                     # There are still tokens left, no need to prune.
                     should_prune = False
@@ -96,9 +90,7 @@ class PromptStack:
                     num_runs_to_fit_in_prompt -= 1
 
         if num_runs_to_fit_in_prompt:
-            memory_inputs = memory.to_prompt_stack(
-                num_runs_to_fit_in_prompt
-            ).inputs
+            memory_inputs = memory.to_prompt_stack(num_runs_to_fit_in_prompt).inputs
             if index:
                 self.inputs[index:index] = memory_inputs
             else:

--- a/griptape/utils/python_runner.py
+++ b/griptape/utils/python_runner.py
@@ -17,11 +17,7 @@ class PythonRunner:
                 imported_lib = importlib.import_module(lib)
                 globals()[alias] = imported_lib
 
-            exec(
-                f"print({code})",
-                {},
-                {alias: eval(alias) for alias in self.libs.values()},
-            )
+            exec(f"print({code})", {}, {alias: eval(alias) for alias in self.libs.values()})
 
             output = local_stdout.getvalue()
         except Exception as e:

--- a/griptape/utils/stream.py
+++ b/griptape/utils/stream.py
@@ -30,9 +30,7 @@ class Stream:
     @structure.validator
     def validate_structure(self, _, structure: Structure):
         if structure and not structure.prompt_driver.stream:
-            raise ValueError(
-                "prompt driver does not have streaming enabled, enable with stream=True"
-            )
+            raise ValueError("prompt driver does not have streaming enabled, enable with stream=True")
 
     _event_queue: Queue[BaseEvent] = field(default=Factory(lambda: Queue()))
 
@@ -53,8 +51,7 @@ class Stream:
             self._event_queue.put(event)
 
         stream_event_listener = EventListener(
-            event_handler,
-            event_types=[CompletionChunkEvent, FinishStructureRunEvent],
+            event_handler, event_types=[CompletionChunkEvent, FinishStructureRunEvent]
         )
         self.structure.add_event_listener(stream_event_listener)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,98 +2,98 @@
 
 [[package]]
 name = "aiohttp"
-version = "3.8.6"
+version = "3.8.5"
 description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "aiohttp-3.8.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41d55fc043954cddbbd82503d9cc3f4814a40bcef30b3569bc7b5e34130718c1"},
-    {file = "aiohttp-3.8.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1d84166673694841d8953f0a8d0c90e1087739d24632fe86b1a08819168b4566"},
-    {file = "aiohttp-3.8.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:253bf92b744b3170eb4c4ca2fa58f9c4b87aeb1df42f71d4e78815e6e8b73c9e"},
-    {file = "aiohttp-3.8.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fd194939b1f764d6bb05490987bfe104287bbf51b8d862261ccf66f48fb4096"},
-    {file = "aiohttp-3.8.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c5f938d199a6fdbdc10bbb9447496561c3a9a565b43be564648d81e1102ac22"},
-    {file = "aiohttp-3.8.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2817b2f66ca82ee699acd90e05c95e79bbf1dc986abb62b61ec8aaf851e81c93"},
-    {file = "aiohttp-3.8.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fa375b3d34e71ccccf172cab401cd94a72de7a8cc01847a7b3386204093bb47"},
-    {file = "aiohttp-3.8.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9de50a199b7710fa2904be5a4a9b51af587ab24c8e540a7243ab737b45844543"},
-    {file = "aiohttp-3.8.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e1d8cb0b56b3587c5c01de3bf2f600f186da7e7b5f7353d1bf26a8ddca57f965"},
-    {file = "aiohttp-3.8.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8e31e9db1bee8b4f407b77fd2507337a0a80665ad7b6c749d08df595d88f1cf5"},
-    {file = "aiohttp-3.8.6-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7bc88fc494b1f0311d67f29fee6fd636606f4697e8cc793a2d912ac5b19aa38d"},
-    {file = "aiohttp-3.8.6-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:ec00c3305788e04bf6d29d42e504560e159ccaf0be30c09203b468a6c1ccd3b2"},
-    {file = "aiohttp-3.8.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ad1407db8f2f49329729564f71685557157bfa42b48f4b93e53721a16eb813ed"},
-    {file = "aiohttp-3.8.6-cp310-cp310-win32.whl", hash = "sha256:ccc360e87341ad47c777f5723f68adbb52b37ab450c8bc3ca9ca1f3e849e5fe2"},
-    {file = "aiohttp-3.8.6-cp310-cp310-win_amd64.whl", hash = "sha256:93c15c8e48e5e7b89d5cb4613479d144fda8344e2d886cf694fd36db4cc86865"},
-    {file = "aiohttp-3.8.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e2f9cc8e5328f829f6e1fb74a0a3a939b14e67e80832975e01929e320386b34"},
-    {file = "aiohttp-3.8.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e6a00ffcc173e765e200ceefb06399ba09c06db97f401f920513a10c803604ca"},
-    {file = "aiohttp-3.8.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:41bdc2ba359032e36c0e9de5a3bd00d6fb7ea558a6ce6b70acedf0da86458321"},
-    {file = "aiohttp-3.8.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14cd52ccf40006c7a6cd34a0f8663734e5363fd981807173faf3a017e202fec9"},
-    {file = "aiohttp-3.8.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2d5b785c792802e7b275c420d84f3397668e9d49ab1cb52bd916b3b3ffcf09ad"},
-    {file = "aiohttp-3.8.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1bed815f3dc3d915c5c1e556c397c8667826fbc1b935d95b0ad680787896a358"},
-    {file = "aiohttp-3.8.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96603a562b546632441926cd1293cfcb5b69f0b4159e6077f7c7dbdfb686af4d"},
-    {file = "aiohttp-3.8.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d76e8b13161a202d14c9584590c4df4d068c9567c99506497bdd67eaedf36403"},
-    {file = "aiohttp-3.8.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e3f1e3f1a1751bb62b4a1b7f4e435afcdade6c17a4fd9b9d43607cebd242924a"},
-    {file = "aiohttp-3.8.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:76b36b3124f0223903609944a3c8bf28a599b2cc0ce0be60b45211c8e9be97f8"},
-    {file = "aiohttp-3.8.6-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a2ece4af1f3c967a4390c284797ab595a9f1bc1130ef8b01828915a05a6ae684"},
-    {file = "aiohttp-3.8.6-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:16d330b3b9db87c3883e565340d292638a878236418b23cc8b9b11a054aaa887"},
-    {file = "aiohttp-3.8.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:42c89579f82e49db436b69c938ab3e1559e5a4409eb8639eb4143989bc390f2f"},
-    {file = "aiohttp-3.8.6-cp311-cp311-win32.whl", hash = "sha256:efd2fcf7e7b9d7ab16e6b7d54205beded0a9c8566cb30f09c1abe42b4e22bdcb"},
-    {file = "aiohttp-3.8.6-cp311-cp311-win_amd64.whl", hash = "sha256:3b2ab182fc28e7a81f6c70bfbd829045d9480063f5ab06f6e601a3eddbbd49a0"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fdee8405931b0615220e5ddf8cd7edd8592c606a8e4ca2a00704883c396e4479"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d25036d161c4fe2225d1abff2bd52c34ed0b1099f02c208cd34d8c05729882f0"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d791245a894be071d5ab04bbb4850534261a7d4fd363b094a7b9963e8cdbd31"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0cccd1de239afa866e4ce5c789b3032442f19c261c7d8a01183fd956b1935349"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f13f60d78224f0dace220d8ab4ef1dbc37115eeeab8c06804fec11bec2bbd07"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a9b5a0606faca4f6cc0d338359d6fa137104c337f489cd135bb7fbdbccb1e39"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:13da35c9ceb847732bf5c6c5781dcf4780e14392e5d3b3c689f6d22f8e15ae31"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:4d4cbe4ffa9d05f46a28252efc5941e0462792930caa370a6efaf491f412bc66"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:229852e147f44da0241954fc6cb910ba074e597f06789c867cb7fb0621e0ba7a"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:713103a8bdde61d13490adf47171a1039fd880113981e55401a0f7b42c37d071"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:45ad816b2c8e3b60b510f30dbd37fe74fd4a772248a52bb021f6fd65dff809b6"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-win32.whl", hash = "sha256:2b8d4e166e600dcfbff51919c7a3789ff6ca8b3ecce16e1d9c96d95dd569eb4c"},
-    {file = "aiohttp-3.8.6-cp36-cp36m-win_amd64.whl", hash = "sha256:0912ed87fee967940aacc5306d3aa8ba3a459fcd12add0b407081fbefc931e53"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e2a988a0c673c2e12084f5e6ba3392d76c75ddb8ebc6c7e9ead68248101cd446"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebf3fd9f141700b510d4b190094db0ce37ac6361a6806c153c161dc6c041ccda"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3161ce82ab85acd267c8f4b14aa226047a6bee1e4e6adb74b798bd42c6ae1f80"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95fc1bf33a9a81469aa760617b5971331cdd74370d1214f0b3109272c0e1e3c"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c43ecfef7deaf0617cee936836518e7424ee12cb709883f2c9a1adda63cc460"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca80e1b90a05a4f476547f904992ae81eda5c2c85c66ee4195bb8f9c5fb47f28"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:90c72ebb7cb3a08a7f40061079817133f502a160561d0675b0a6adf231382c92"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bb54c54510e47a8c7c8e63454a6acc817519337b2b78606c4e840871a3e15349"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:de6a1c9f6803b90e20869e6b99c2c18cef5cc691363954c93cb9adeb26d9f3ae"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:a3628b6c7b880b181a3ae0a0683698513874df63783fd89de99b7b7539e3e8a8"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:fc37e9aef10a696a5a4474802930079ccfc14d9f9c10b4662169671ff034b7df"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-win32.whl", hash = "sha256:f8ef51e459eb2ad8e7a66c1d6440c808485840ad55ecc3cafefadea47d1b1ba2"},
-    {file = "aiohttp-3.8.6-cp37-cp37m-win_amd64.whl", hash = "sha256:b2fe42e523be344124c6c8ef32a011444e869dc5f883c591ed87f84339de5976"},
-    {file = "aiohttp-3.8.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:9e2ee0ac5a1f5c7dd3197de309adfb99ac4617ff02b0603fd1e65b07dc772e4b"},
-    {file = "aiohttp-3.8.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:01770d8c04bd8db568abb636c1fdd4f7140b284b8b3e0b4584f070180c1e5c62"},
-    {file = "aiohttp-3.8.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3c68330a59506254b556b99a91857428cab98b2f84061260a67865f7f52899f5"},
-    {file = "aiohttp-3.8.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89341b2c19fb5eac30c341133ae2cc3544d40d9b1892749cdd25892bbc6ac951"},
-    {file = "aiohttp-3.8.6-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71783b0b6455ac8f34b5ec99d83e686892c50498d5d00b8e56d47f41b38fbe04"},
-    {file = "aiohttp-3.8.6-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f628dbf3c91e12f4d6c8b3f092069567d8eb17814aebba3d7d60c149391aee3a"},
-    {file = "aiohttp-3.8.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b04691bc6601ef47c88f0255043df6f570ada1a9ebef99c34bd0b72866c217ae"},
-    {file = "aiohttp-3.8.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ee912f7e78287516df155f69da575a0ba33b02dd7c1d6614dbc9463f43066e3"},
-    {file = "aiohttp-3.8.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9c19b26acdd08dd239e0d3669a3dddafd600902e37881f13fbd8a53943079dbc"},
-    {file = "aiohttp-3.8.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:99c5ac4ad492b4a19fc132306cd57075c28446ec2ed970973bbf036bcda1bcc6"},
-    {file = "aiohttp-3.8.6-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:f0f03211fd14a6a0aed2997d4b1c013d49fb7b50eeb9ffdf5e51f23cfe2c77fa"},
-    {file = "aiohttp-3.8.6-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:8d399dade330c53b4106160f75f55407e9ae7505263ea86f2ccca6bfcbdb4921"},
-    {file = "aiohttp-3.8.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ec4fd86658c6a8964d75426517dc01cbf840bbf32d055ce64a9e63a40fd7b771"},
-    {file = "aiohttp-3.8.6-cp38-cp38-win32.whl", hash = "sha256:33164093be11fcef3ce2571a0dccd9041c9a93fa3bde86569d7b03120d276c6f"},
-    {file = "aiohttp-3.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:bdf70bfe5a1414ba9afb9d49f0c912dc524cf60141102f3a11143ba3d291870f"},
-    {file = "aiohttp-3.8.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d52d5dc7c6682b720280f9d9db41d36ebe4791622c842e258c9206232251ab2b"},
-    {file = "aiohttp-3.8.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ac39027011414dbd3d87f7edb31680e1f430834c8cef029f11c66dad0670aa5"},
-    {file = "aiohttp-3.8.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3f5c7ce535a1d2429a634310e308fb7d718905487257060e5d4598e29dc17f0b"},
-    {file = "aiohttp-3.8.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b30e963f9e0d52c28f284d554a9469af073030030cef8693106d918b2ca92f54"},
-    {file = "aiohttp-3.8.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:918810ef188f84152af6b938254911055a72e0f935b5fbc4c1a4ed0b0584aed1"},
-    {file = "aiohttp-3.8.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:002f23e6ea8d3dd8d149e569fd580c999232b5fbc601c48d55398fbc2e582e8c"},
-    {file = "aiohttp-3.8.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fcf3eabd3fd1a5e6092d1242295fa37d0354b2eb2077e6eb670accad78e40e1"},
-    {file = "aiohttp-3.8.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:255ba9d6d5ff1a382bb9a578cd563605aa69bec845680e21c44afc2670607a95"},
-    {file = "aiohttp-3.8.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d67f8baed00870aa390ea2590798766256f31dc5ed3ecc737debb6e97e2ede78"},
-    {file = "aiohttp-3.8.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:86f20cee0f0a317c76573b627b954c412ea766d6ada1a9fcf1b805763ae7feeb"},
-    {file = "aiohttp-3.8.6-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:39a312d0e991690ccc1a61f1e9e42daa519dcc34ad03eb6f826d94c1190190dd"},
-    {file = "aiohttp-3.8.6-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:e827d48cf802de06d9c935088c2924e3c7e7533377d66b6f31ed175c1620e05e"},
-    {file = "aiohttp-3.8.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bd111d7fc5591ddf377a408ed9067045259ff2770f37e2d94e6478d0f3fc0c17"},
-    {file = "aiohttp-3.8.6-cp39-cp39-win32.whl", hash = "sha256:caf486ac1e689dda3502567eb89ffe02876546599bbf915ec94b1fa424eeffd4"},
-    {file = "aiohttp-3.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:3f0e27e5b733803333bb2371249f41cf42bae8884863e8e8965ec69bebe53132"},
-    {file = "aiohttp-3.8.6.tar.gz", hash = "sha256:b0cf2a4501bff9330a8a5248b4ce951851e415bdcce9dc158e76cfd55e15085c"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a94159871304770da4dd371f4291b20cac04e8c94f11bdea1c3478e557fbe0d8"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:13bf85afc99ce6f9ee3567b04501f18f9f8dbbb2ea11ed1a2e079670403a7c84"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ce2ac5708501afc4847221a521f7e4b245abf5178cf5ddae9d5b3856ddb2f3a"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96943e5dcc37a6529d18766597c491798b7eb7a61d48878611298afc1fca946c"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ad5c3c4590bb3cc28b4382f031f3783f25ec223557124c68754a2231d989e2b"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c413c633d0512df4dc7fd2373ec06cc6a815b7b6d6c2f208ada7e9e93a5061d"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df72ac063b97837a80d80dec8d54c241af059cc9bb42c4de68bd5b61ceb37caa"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c48c5c0271149cfe467c0ff8eb941279fd6e3f65c9a388c984e0e6cf57538e14"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:368a42363c4d70ab52c2c6420a57f190ed3dfaca6a1b19afda8165ee16416a82"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7607ec3ce4993464368505888af5beb446845a014bc676d349efec0e05085905"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:0d21c684808288a98914e5aaf2a7c6a3179d4df11d249799c32d1808e79503b5"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:312fcfbacc7880a8da0ae8b6abc6cc7d752e9caa0051a53d217a650b25e9a691"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ad093e823df03bb3fd37e7dec9d4670c34f9e24aeace76808fc20a507cace825"},
+    {file = "aiohttp-3.8.5-cp310-cp310-win32.whl", hash = "sha256:33279701c04351a2914e1100b62b2a7fdb9a25995c4a104259f9a5ead7ed4802"},
+    {file = "aiohttp-3.8.5-cp310-cp310-win_amd64.whl", hash = "sha256:6e4a280e4b975a2e7745573e3fc9c9ba0d1194a3738ce1cbaa80626cc9b4f4df"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae871a964e1987a943d83d6709d20ec6103ca1eaf52f7e0d36ee1b5bebb8b9b9"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:461908b2578955045efde733719d62f2b649c404189a09a632d245b445c9c975"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72a860c215e26192379f57cae5ab12b168b75db8271f111019509a1196dfc780"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc14be025665dba6202b6a71cfcdb53210cc498e50068bc088076624471f8bb9"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8af740fc2711ad85f1a5c034a435782fbd5b5f8314c9a3ef071424a8158d7f6b"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:841cd8233cbd2111a0ef0a522ce016357c5e3aff8a8ce92bcfa14cef890d698f"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed1c46fb119f1b59304b5ec89f834f07124cd23ae5b74288e364477641060ff"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84f8ae3e09a34f35c18fa57f015cc394bd1389bce02503fb30c394d04ee6b938"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:62360cb771707cb70a6fd114b9871d20d7dd2163a0feafe43fd115cfe4fe845e"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:23fb25a9f0a1ca1f24c0a371523546366bb642397c94ab45ad3aedf2941cec6a"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b0ba0d15164eae3d878260d4c4df859bbdc6466e9e6689c344a13334f988bb53"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:5d20003b635fc6ae3f96d7260281dfaf1894fc3aa24d1888a9b2628e97c241e5"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0175d745d9e85c40dcc51c8f88c74bfbaef9e7afeeeb9d03c37977270303064c"},
+    {file = "aiohttp-3.8.5-cp311-cp311-win32.whl", hash = "sha256:2e1b1e51b0774408f091d268648e3d57f7260c1682e7d3a63cb00d22d71bb945"},
+    {file = "aiohttp-3.8.5-cp311-cp311-win_amd64.whl", hash = "sha256:043d2299f6dfdc92f0ac5e995dfc56668e1587cea7f9aa9d8a78a1b6554e5755"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cae533195e8122584ec87531d6df000ad07737eaa3c81209e85c928854d2195c"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f21e83f355643c345177a5d1d8079f9f28b5133bcd154193b799d380331d5d3"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7a75ef35f2df54ad55dbf4b73fe1da96f370e51b10c91f08b19603c64004acc"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2e2e9839e14dd5308ee773c97115f1e0a1cb1d75cbeeee9f33824fa5144c7634"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44e65da1de4403d0576473e2344828ef9c4c6244d65cf4b75549bb46d40b8dd"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d847e4cde6ecc19125ccbc9bfac4a7ab37c234dd88fbb3c5c524e8e14da543"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:c7a815258e5895d8900aec4454f38dca9aed71085f227537208057853f9d13f2"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:8b929b9bd7cd7c3939f8bcfffa92fae7480bd1aa425279d51a89327d600c704d"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:5db3a5b833764280ed7618393832e0853e40f3d3e9aa128ac0ba0f8278d08649"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:a0215ce6041d501f3155dc219712bc41252d0ab76474615b9700d63d4d9292af"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:fd1ed388ea7fbed22c4968dd64bab0198de60750a25fe8c0c9d4bef5abe13824"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-win32.whl", hash = "sha256:6e6783bcc45f397fdebc118d772103d751b54cddf5b60fbcc958382d7dd64f3e"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-win_amd64.whl", hash = "sha256:b5411d82cddd212644cf9360879eb5080f0d5f7d809d03262c50dad02f01421a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:01d4c0c874aa4ddfb8098e85d10b5e875a70adc63db91f1ae65a4b04d3344cda"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5980a746d547a6ba173fd5ee85ce9077e72d118758db05d229044b469d9029a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a482e6da906d5e6e653be079b29bc173a48e381600161c9932d89dfae5942ef"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80bd372b8d0715c66c974cf57fe363621a02f359f1ec81cba97366948c7fc873"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1161b345c0a444ebcf46bf0a740ba5dcf50612fd3d0528883fdc0eff578006a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd56db019015b6acfaaf92e1ac40eb8434847d9bf88b4be4efe5bfd260aee692"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:153c2549f6c004d2754cc60603d4668899c9895b8a89397444a9c4efa282aaf4"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4a01951fabc4ce26ab791da5f3f24dca6d9a6f24121746eb19756416ff2d881b"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bfb9162dcf01f615462b995a516ba03e769de0789de1cadc0f916265c257e5d8"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:7dde0009408969a43b04c16cbbe252c4f5ef4574ac226bc8815cd7342d2028b6"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4149d34c32f9638f38f544b3977a4c24052042affa895352d3636fa8bffd030a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-win32.whl", hash = "sha256:68c5a82c8779bdfc6367c967a4a1b2aa52cd3595388bf5961a62158ee8a59e22"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2cf57fb50be5f52bda004b8893e63b48530ed9f0d6c96c84620dc92fe3cd9b9d"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:eca4bf3734c541dc4f374ad6010a68ff6c6748f00451707f39857f429ca36ced"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1274477e4c71ce8cfe6c1ec2f806d57c015ebf84d83373676036e256bc55d690"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:28c543e54710d6158fc6f439296c7865b29e0b616629767e685a7185fab4a6b9"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:910bec0c49637d213f5d9877105d26e0c4a4de2f8b1b29405ff37e9fc0ad52b8"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5443910d662db951b2e58eb70b0fbe6b6e2ae613477129a5805d0b66c54b6cb7"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2e460be6978fc24e3df83193dc0cc4de46c9909ed92dd47d349a452ef49325b7"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb1558def481d84f03b45888473fc5a1f35747b5f334ef4e7a571bc0dfcb11f8"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34dd0c107799dcbbf7d48b53be761a013c0adf5571bf50c4ecad5643fe9cfcd0"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aa1990247f02a54185dc0dff92a6904521172a22664c863a03ff64c42f9b5410"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0e584a10f204a617d71d359fe383406305a4b595b333721fa50b867b4a0a1548"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:a3cf433f127efa43fee6b90ea4c6edf6c4a17109d1d037d1a52abec84d8f2e42"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:c11f5b099adafb18e65c2c997d57108b5bbeaa9eeee64a84302c0978b1ec948b"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:84de26ddf621d7ac4c975dbea4c945860e08cccde492269db4e1538a6a6f3c35"},
+    {file = "aiohttp-3.8.5-cp38-cp38-win32.whl", hash = "sha256:ab88bafedc57dd0aab55fa728ea10c1911f7e4d8b43e1d838a1739f33712921c"},
+    {file = "aiohttp-3.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:5798a9aad1879f626589f3df0f8b79b3608a92e9beab10e5fda02c8a2c60db2e"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a6ce61195c6a19c785df04e71a4537e29eaa2c50fe745b732aa937c0c77169f3"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:773dd01706d4db536335fcfae6ea2440a70ceb03dd3e7378f3e815b03c97ab51"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f83a552443a526ea38d064588613aca983d0ee0038801bc93c0c916428310c28"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f7372f7341fcc16f57b2caded43e81ddd18df53320b6f9f042acad41f8e049a"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea353162f249c8097ea63c2169dd1aa55de1e8fecbe63412a9bc50816e87b761"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d47ae48db0b2dcf70bc8a3bc72b3de86e2a590fc299fdbbb15af320d2659de"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d827176898a2b0b09694fbd1088c7a31836d1a505c243811c87ae53a3f6273c1"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3562b06567c06439d8b447037bb655ef69786c590b1de86c7ab81efe1c9c15d8"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4e874cbf8caf8959d2adf572a78bba17cb0e9d7e51bb83d86a3697b686a0ab4d"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6809a00deaf3810e38c628e9a33271892f815b853605a936e2e9e5129762356c"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:33776e945d89b29251b33a7e7d006ce86447b2cfd66db5e5ded4e5cd0340585c"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:eaeed7abfb5d64c539e2db173f63631455f1196c37d9d8d873fc316470dfbacd"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e91d635961bec2d8f19dfeb41a539eb94bd073f075ca6dae6c8dc0ee89ad6f91"},
+    {file = "aiohttp-3.8.5-cp39-cp39-win32.whl", hash = "sha256:00ad4b6f185ec67f3e6562e8a1d2b69660be43070bd0ef6fcec5211154c7df67"},
+    {file = "aiohttp-3.8.5-cp39-cp39-win_amd64.whl", hash = "sha256:c0a9034379a37ae42dea7ac1e048352d96286626251862e448933c0f59cbd79c"},
+    {file = "aiohttp-3.8.5.tar.gz", hash = "sha256:b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc"},
 ]
 
 [package.dependencies]
@@ -215,29 +215,33 @@ files = [
 
 [[package]]
 name = "black"
-version = "23.10.1"
+version = "23.9.1"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:ec3f8e6234c4e46ff9e16d9ae96f4ef69fa328bb4ad08198c8cee45bb1f08c69"},
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:1b917a2aa020ca600483a7b340c165970b26e9029067f019e3755b56e8dd5916"},
-    {file = "black-23.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c74de4c77b849e6359c6f01987e94873c707098322b91490d24296f66d067dc"},
-    {file = "black-23.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:7b4d10b0f016616a0d93d24a448100adf1699712fb7a4efd0e2c32bbb219b173"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b15b75fc53a2fbcac8a87d3e20f69874d161beef13954747e053bca7a1ce53a0"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:e293e4c2f4a992b980032bbd62df07c1bcff82d6964d6c9496f2cd726e246ace"},
-    {file = "black-23.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d56124b7a61d092cb52cce34182a5280e160e6aff3137172a68c2c2c4b76bcb"},
-    {file = "black-23.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:3f157a8945a7b2d424da3335f7ace89c14a3b0625e6593d21139c2d8214d55ce"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:cfcce6f0a384d0da692119f2d72d79ed07c7159879d0bb1bb32d2e443382bf3a"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:33d40f5b06be80c1bbce17b173cda17994fbad096ce60eb22054da021bf933d1"},
-    {file = "black-23.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:840015166dbdfbc47992871325799fd2dc0dcf9395e401ada6d88fe11498abad"},
-    {file = "black-23.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:037e9b4664cafda5f025a1728c50a9e9aedb99a759c89f760bd83730e76ba884"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:7cb5936e686e782fddb1c73f8aa6f459e1ad38a6a7b0e54b403f1f05a1507ee9"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:7670242e90dc129c539e9ca17665e39a146a761e681805c54fbd86015c7c84f7"},
-    {file = "black-23.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed45ac9a613fb52dad3b61c8dea2ec9510bf3108d4db88422bacc7d1ba1243d"},
-    {file = "black-23.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:6d23d7822140e3fef190734216cefb262521789367fbdc0b3f22af6744058982"},
-    {file = "black-23.10.1-py3-none-any.whl", hash = "sha256:d431e6739f727bb2e0495df64a6c7a5310758e87505f5f8cde9ff6c0f2d7e4fe"},
-    {file = "black-23.10.1.tar.gz", hash = "sha256:1f8ce316753428ff68749c65a5f7844631aa18c8679dfd3ca9dc1a289979c258"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71"},
+    {file = "black-23.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7"},
+    {file = "black-23.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186"},
+    {file = "black-23.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f"},
+    {file = "black-23.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204"},
+    {file = "black-23.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377"},
+    {file = "black-23.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393"},
+    {file = "black-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9"},
+    {file = "black-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f"},
+    {file = "black-23.9.1-py3-none-any.whl", hash = "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9"},
+    {file = "black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d"},
 ]
 
 [package.dependencies]
@@ -257,17 +261,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.28.78"
+version = "1.28.57"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.78-py3-none-any.whl", hash = "sha256:ff8df4bb5aeb69acc64959a74b31042bfc52d64ca77dbe845a72c8062c48d179"},
-    {file = "boto3-1.28.78.tar.gz", hash = "sha256:aa970b1571321846543a6e615848352fe7621f1cb96b4454e919421924af95f7"},
+    {file = "boto3-1.28.57-py3-none-any.whl", hash = "sha256:5ddf24cf52c7fb6aaa332eaa08ae8c2afc8f2d1e8860680728533dd573904e32"},
+    {file = "boto3-1.28.57.tar.gz", hash = "sha256:e2d2824ba6459b330d097e94039a9c4f96ae3f4bcdc731d620589ad79dcd16d3"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.78,<1.32.0"
+botocore = ">=1.31.57,<1.32.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.7.0,<0.8.0"
 
@@ -276,22 +280,19 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.78"
+version = "1.31.57"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.78-py3-none-any.whl", hash = "sha256:a9ca8deeb3f47a10a25637859fee8d81cac2db37ace819d24471279e44879547"},
-    {file = "botocore-1.31.78.tar.gz", hash = "sha256:320c70bc412157813c2cf60217a592b4b345f8e97e4bf3b1ce49b6be69ed8965"},
+    {file = "botocore-1.31.57-py3-none-any.whl", hash = "sha256:af006248276ff8e19e3ec7214478f6257035eb40aed865e405486500471ae71b"},
+    {file = "botocore-1.31.57.tar.gz", hash = "sha256:301436174635bec739b225b840fc365ca00e5c1a63e5b2a19ee679d204e01b78"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
-]
+urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
 crt = ["awscrt (==0.16.26)"]
@@ -372,102 +373,98 @@ files = [
 pycparser = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+description = "Validate configuration and produce human readable error messages."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
+    {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
 name = "charset-normalizer"
-version = "3.3.2"
+version = "3.2.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
-    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
+    {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win32.whl", hash = "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win32.whl", hash = "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win32.whl", hash = "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win32.whl", hash = "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win32.whl", hash = "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80"},
+    {file = "charset_normalizer-3.2.0-py3-none-any.whl", hash = "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6"},
 ]
 
 [[package]]
@@ -486,13 +483,13 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cohere"
-version = "4.32"
+version = "4.27"
 description = ""
 optional = true
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "cohere-4.32-py3-none-any.whl", hash = "sha256:b5ab3509a34c20d51b246e38eb64adc839c8bc131c41ed92ec3613998df9a8e0"},
-    {file = "cohere-4.32.tar.gz", hash = "sha256:3807747be984f211dce911c1335bd713af2ac2b70f729678381e6ff6e450e681"},
+    {file = "cohere-4.27-py3-none-any.whl", hash = "sha256:a2b977867a247bf44b2eba1b947acfe44e5881b15cacc40469fbdb117a7f1f55"},
+    {file = "cohere-4.27.tar.gz", hash = "sha256:5d61eaca698dcf7f5b0b7cccca269d448e341314fedd921a0cc7c7bbf05f8181"},
 ]
 
 [package.dependencies]
@@ -543,63 +540,63 @@ urllib3 = {version = ">=1.26,<3", markers = "python_version >= \"3.7\""}
 
 [[package]]
 name = "coverage"
-version = "7.3.2"
+version = "7.3.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d872145f3a3231a5f20fd48500274d7df222e291d90baa2026cc5152b7ce86bf"},
-    {file = "coverage-7.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:310b3bb9c91ea66d59c53fa4989f57d2436e08f18fb2f421a1b0b6b8cc7fffda"},
-    {file = "coverage-7.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f47d39359e2c3779c5331fc740cf4bce6d9d680a7b4b4ead97056a0ae07cb49a"},
-    {file = "coverage-7.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa72dbaf2c2068404b9870d93436e6d23addd8bbe9295f49cbca83f6e278179c"},
-    {file = "coverage-7.3.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:beaa5c1b4777f03fc63dfd2a6bd820f73f036bfb10e925fce067b00a340d0f3f"},
-    {file = "coverage-7.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:dbc1b46b92186cc8074fee9d9fbb97a9dd06c6cbbef391c2f59d80eabdf0faa6"},
-    {file = "coverage-7.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:315a989e861031334d7bee1f9113c8770472db2ac484e5b8c3173428360a9148"},
-    {file = "coverage-7.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d1bc430677773397f64a5c88cb522ea43175ff16f8bfcc89d467d974cb2274f9"},
-    {file = "coverage-7.3.2-cp310-cp310-win32.whl", hash = "sha256:a889ae02f43aa45032afe364c8ae84ad3c54828c2faa44f3bfcafecb5c96b02f"},
-    {file = "coverage-7.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:c0ba320de3fb8c6ec16e0be17ee1d3d69adcda99406c43c0409cb5c41788a611"},
-    {file = "coverage-7.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ac8c802fa29843a72d32ec56d0ca792ad15a302b28ca6203389afe21f8fa062c"},
-    {file = "coverage-7.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:89a937174104339e3a3ffcf9f446c00e3a806c28b1841c63edb2b369310fd074"},
-    {file = "coverage-7.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e267e9e2b574a176ddb983399dec325a80dbe161f1a32715c780b5d14b5f583a"},
-    {file = "coverage-7.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2443cbda35df0d35dcfb9bf8f3c02c57c1d6111169e3c85fc1fcc05e0c9f39a3"},
-    {file = "coverage-7.3.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4175e10cc8dda0265653e8714b3174430b07c1dca8957f4966cbd6c2b1b8065a"},
-    {file = "coverage-7.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0cbf38419fb1a347aaf63481c00f0bdc86889d9fbf3f25109cf96c26b403fda1"},
-    {file = "coverage-7.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5c913b556a116b8d5f6ef834038ba983834d887d82187c8f73dec21049abd65c"},
-    {file = "coverage-7.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1981f785239e4e39e6444c63a98da3a1db8e971cb9ceb50a945ba6296b43f312"},
-    {file = "coverage-7.3.2-cp311-cp311-win32.whl", hash = "sha256:43668cabd5ca8258f5954f27a3aaf78757e6acf13c17604d89648ecc0cc66640"},
-    {file = "coverage-7.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10c39c0452bf6e694511c901426d6b5ac005acc0f78ff265dbe36bf81f808a2"},
-    {file = "coverage-7.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4cbae1051ab791debecc4a5dcc4a1ff45fc27b91b9aee165c8a27514dd160836"},
-    {file = "coverage-7.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12d15ab5833a997716d76f2ac1e4b4d536814fc213c85ca72756c19e5a6b3d63"},
-    {file = "coverage-7.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c7bba973ebee5e56fe9251300c00f1579652587a9f4a5ed8404b15a0471f216"},
-    {file = "coverage-7.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe494faa90ce6381770746077243231e0b83ff3f17069d748f645617cefe19d4"},
-    {file = "coverage-7.3.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6e9589bd04d0461a417562649522575d8752904d35c12907d8c9dfeba588faf"},
-    {file = "coverage-7.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d51ac2a26f71da1b57f2dc81d0e108b6ab177e7d30e774db90675467c847bbdf"},
-    {file = "coverage-7.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:99b89d9f76070237975b315b3d5f4d6956ae354a4c92ac2388a5695516e47c84"},
-    {file = "coverage-7.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fa28e909776dc69efb6ed975a63691bc8172b64ff357e663a1bb06ff3c9b589a"},
-    {file = "coverage-7.3.2-cp312-cp312-win32.whl", hash = "sha256:289fe43bf45a575e3ab10b26d7b6f2ddb9ee2dba447499f5401cfb5ecb8196bb"},
-    {file = "coverage-7.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dbc3ed60e8659bc59b6b304b43ff9c3ed858da2839c78b804973f613d3e92ed"},
-    {file = "coverage-7.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f94b734214ea6a36fe16e96a70d941af80ff3bfd716c141300d95ebc85339738"},
-    {file = "coverage-7.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:af3d828d2c1cbae52d34bdbb22fcd94d1ce715d95f1a012354a75e5913f1bda2"},
-    {file = "coverage-7.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:630b13e3036e13c7adc480ca42fa7afc2a5d938081d28e20903cf7fd687872e2"},
-    {file = "coverage-7.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9eacf273e885b02a0273bb3a2170f30e2d53a6d53b72dbe02d6701b5296101c"},
-    {file = "coverage-7.3.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8f17966e861ff97305e0801134e69db33b143bbfb36436efb9cfff6ec7b2fd9"},
-    {file = "coverage-7.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b4275802d16882cf9c8b3d057a0839acb07ee9379fa2749eca54efbce1535b82"},
-    {file = "coverage-7.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:72c0cfa5250f483181e677ebc97133ea1ab3eb68645e494775deb6a7f6f83901"},
-    {file = "coverage-7.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cb536f0dcd14149425996821a168f6e269d7dcd2c273a8bff8201e79f5104e76"},
-    {file = "coverage-7.3.2-cp38-cp38-win32.whl", hash = "sha256:307adb8bd3abe389a471e649038a71b4eb13bfd6b7dd9a129fa856f5c695cf92"},
-    {file = "coverage-7.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:88ed2c30a49ea81ea3b7f172e0269c182a44c236eb394718f976239892c0a27a"},
-    {file = "coverage-7.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b631c92dfe601adf8f5ebc7fc13ced6bb6e9609b19d9a8cd59fa47c4186ad1ce"},
-    {file = "coverage-7.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d3d9df4051c4a7d13036524b66ecf7a7537d14c18a384043f30a303b146164e9"},
-    {file = "coverage-7.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f7363d3b6a1119ef05015959ca24a9afc0ea8a02c687fe7e2d557705375c01f"},
-    {file = "coverage-7.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f11cc3c967a09d3695d2a6f03fb3e6236622b93be7a4b5dc09166a861be6d25"},
-    {file = "coverage-7.3.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:149de1d2401ae4655c436a3dced6dd153f4c3309f599c3d4bd97ab172eaf02d9"},
-    {file = "coverage-7.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3a4006916aa6fee7cd38db3bfc95aa9c54ebb4ffbfc47c677c8bba949ceba0a6"},
-    {file = "coverage-7.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9028a3871280110d6e1aa2df1afd5ef003bab5fb1ef421d6dc748ae1c8ef2ebc"},
-    {file = "coverage-7.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9f805d62aec8eb92bab5b61c0f07329275b6f41c97d80e847b03eb894f38d083"},
-    {file = "coverage-7.3.2-cp39-cp39-win32.whl", hash = "sha256:d1c88ec1a7ff4ebca0219f5b1ef863451d828cccf889c173e1253aa84b1e07ce"},
-    {file = "coverage-7.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b4767da59464bb593c07afceaddea61b154136300881844768037fd5e859353f"},
-    {file = "coverage-7.3.2-pp38.pp39.pp310-none-any.whl", hash = "sha256:ae97af89f0fbf373400970c0a21eef5aa941ffeed90aee43650b81f7d7f47637"},
-    {file = "coverage-7.3.2.tar.gz", hash = "sha256:be32ad29341b0170e795ca590e1c07e81fc061cb5b10c74ce7203491484404ef"},
+    {file = "coverage-7.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd0f7429ecfd1ff597389907045ff209c8fdb5b013d38cfa7c60728cb484b6e3"},
+    {file = "coverage-7.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:966f10df9b2b2115da87f50f6a248e313c72a668248be1b9060ce935c871f276"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0575c37e207bb9b98b6cf72fdaaa18ac909fb3d153083400c2d48e2e6d28bd8e"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:245c5a99254e83875c7fed8b8b2536f040997a9b76ac4c1da5bff398c06e860f"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c96dd7798d83b960afc6c1feb9e5af537fc4908852ef025600374ff1a017392"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:de30c1aa80f30af0f6b2058a91505ea6e36d6535d437520067f525f7df123887"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:50dd1e2dd13dbbd856ffef69196781edff26c800a74f070d3b3e3389cab2600d"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9c0c19f70d30219113b18fe07e372b244fb2a773d4afde29d5a2f7930765136"},
+    {file = "coverage-7.3.1-cp310-cp310-win32.whl", hash = "sha256:770f143980cc16eb601ccfd571846e89a5fe4c03b4193f2e485268f224ab602f"},
+    {file = "coverage-7.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:cdd088c00c39a27cfa5329349cc763a48761fdc785879220d54eb785c8a38520"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74bb470399dc1989b535cb41f5ca7ab2af561e40def22d7e188e0a445e7639e3"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:025ded371f1ca280c035d91b43252adbb04d2aea4c7105252d3cbc227f03b375"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6191b3a6ad3e09b6cfd75b45c6aeeffe7e3b0ad46b268345d159b8df8d835f9"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb0b188f30e41ddd659a529e385470aa6782f3b412f860ce22b2491c89b8593"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c8f0df9dfd8ff745bccff75867d63ef336e57cc22b2908ee725cc552689ec8"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7eb3cd48d54b9bd0e73026dedce44773214064be93611deab0b6a43158c3d5a0"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ac3c5b7e75acac31e490b7851595212ed951889918d398b7afa12736c85e13ce"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5b4ee7080878077af0afa7238df1b967f00dc10763f6e1b66f5cced4abebb0a3"},
+    {file = "coverage-7.3.1-cp311-cp311-win32.whl", hash = "sha256:229c0dd2ccf956bf5aeede7e3131ca48b65beacde2029f0361b54bf93d36f45a"},
+    {file = "coverage-7.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6f55d38818ca9596dc9019eae19a47410d5322408140d9a0076001a3dcb938c"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5289490dd1c3bb86de4730a92261ae66ea8d44b79ed3cc26464f4c2cde581fbc"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ca833941ec701fda15414be400c3259479bfde7ae6d806b69e63b3dc423b1832"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd694e19c031733e446c8024dedd12a00cda87e1c10bd7b8539a87963685e969"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aab8e9464c00da5cb9c536150b7fbcd8850d376d1151741dd0d16dfe1ba4fd26"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87d38444efffd5b056fcc026c1e8d862191881143c3aa80bb11fcf9dca9ae204"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8a07b692129b8a14ad7a37941a3029c291254feb7a4237f245cfae2de78de037"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:2829c65c8faaf55b868ed7af3c7477b76b1c6ebeee99a28f59a2cb5907a45760"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f111a7d85658ea52ffad7084088277135ec5f368457275fc57f11cebb15607f"},
+    {file = "coverage-7.3.1-cp312-cp312-win32.whl", hash = "sha256:c397c70cd20f6df7d2a52283857af622d5f23300c4ca8e5bd8c7a543825baa5a"},
+    {file = "coverage-7.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:5ae4c6da8b3d123500f9525b50bf0168023313963e0e2e814badf9000dd6ef92"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ca70466ca3a17460e8fc9cea7123c8cbef5ada4be3140a1ef8f7b63f2f37108f"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f2781fd3cabc28278dc982a352f50c81c09a1a500cc2086dc4249853ea96b981"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6407424621f40205bbe6325686417e5e552f6b2dba3535dd1f90afc88a61d465"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04312b036580ec505f2b77cbbdfb15137d5efdfade09156961f5277149f5e344"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9ad38204887349853d7c313f53a7b1c210ce138c73859e925bc4e5d8fc18e7"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:53669b79f3d599da95a0afbef039ac0fadbb236532feb042c534fbb81b1a4e40"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:614f1f98b84eb256e4f35e726bfe5ca82349f8dfa576faabf8a49ca09e630086"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f1a317fdf5c122ad642db8a97964733ab7c3cf6009e1a8ae8821089993f175ff"},
+    {file = "coverage-7.3.1-cp38-cp38-win32.whl", hash = "sha256:defbbb51121189722420a208957e26e49809feafca6afeef325df66c39c4fdb3"},
+    {file = "coverage-7.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:f4f456590eefb6e1b3c9ea6328c1e9fa0f1006e7481179d749b3376fc793478e"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f12d8b11a54f32688b165fd1a788c408f927b0960984b899be7e4c190ae758f1"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f09195dda68d94a53123883de75bb97b0e35f5f6f9f3aa5bf6e496da718f0cb6"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6601a60318f9c3945be6ea0f2a80571f4299b6801716f8a6e4846892737ebe4"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07d156269718670d00a3b06db2288b48527fc5f36859425ff7cec07c6b367745"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:636a8ac0b044cfeccae76a36f3b18264edcc810a76a49884b96dd744613ec0b7"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5d991e13ad2ed3aced177f524e4d670f304c8233edad3210e02c465351f785a0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:586649ada7cf139445da386ab6f8ef00e6172f11a939fc3b2b7e7c9082052fa0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4aba512a15a3e1e4fdbfed2f5392ec221434a614cc68100ca99dcad7af29f3f8"},
+    {file = "coverage-7.3.1-cp39-cp39-win32.whl", hash = "sha256:6bc6f3f4692d806831c136c5acad5ccedd0262aa44c087c46b7101c77e139140"},
+    {file = "coverage-7.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:553d7094cb27db58ea91332e8b5681bac107e7242c23f7629ab1316ee73c4981"},
+    {file = "coverage-7.3.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:220eb51f5fb38dfdb7e5d54284ca4d0cd70ddac047d750111a68ab1798945194"},
+    {file = "coverage-7.3.1.tar.gz", hash = "sha256:6cb7fe1581deb67b782c153136541e20901aa312ceedaf1467dcb35255787952"},
 ]
 
 [package.dependencies]
@@ -610,34 +607,34 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "41.0.5"
+version = "41.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-41.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:da6a0ff8f1016ccc7477e6339e1d50ce5f59b88905585f77193ebd5068f1e797"},
-    {file = "cryptography-41.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b948e09fe5fb18517d99994184854ebd50b57248736fd4c720ad540560174ec5"},
-    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d38e6031e113b7421db1de0c1b1f7739564a88f1684c6b89234fbf6c11b75147"},
-    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e270c04f4d9b5671ebcc792b3ba5d4488bf7c42c3c241a3748e2599776f29696"},
-    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ec3b055ff8f1dce8e6ef28f626e0972981475173d7973d63f271b29c8a2897da"},
-    {file = "cryptography-41.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7d208c21e47940369accfc9e85f0de7693d9a5d843c2509b3846b2db170dfd20"},
-    {file = "cryptography-41.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:8254962e6ba1f4d2090c44daf50a547cd5f0bf446dc658a8e5f8156cae0d8548"},
-    {file = "cryptography-41.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a48e74dad1fb349f3dc1d449ed88e0017d792997a7ad2ec9587ed17405667e6d"},
-    {file = "cryptography-41.0.5-cp37-abi3-win32.whl", hash = "sha256:d3977f0e276f6f5bf245c403156673db103283266601405376f075c849a0b936"},
-    {file = "cryptography-41.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:73801ac9736741f220e20435f84ecec75ed70eda90f781a148f1bad546963d81"},
-    {file = "cryptography-41.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3be3ca726e1572517d2bef99a818378bbcf7d7799d5372a46c79c29eb8d166c1"},
-    {file = "cryptography-41.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e886098619d3815e0ad5790c973afeee2c0e6e04b4da90b88e6bd06e2a0b1b72"},
-    {file = "cryptography-41.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:573eb7128cbca75f9157dcde974781209463ce56b5804983e11a1c462f0f4e88"},
-    {file = "cryptography-41.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0c327cac00f082013c7c9fb6c46b7cc9fa3c288ca702c74773968173bda421bf"},
-    {file = "cryptography-41.0.5-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:227ec057cd32a41c6651701abc0328135e472ed450f47c2766f23267b792a88e"},
-    {file = "cryptography-41.0.5-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:22892cc830d8b2c89ea60148227631bb96a7da0c1b722f2aac8824b1b7c0b6b8"},
-    {file = "cryptography-41.0.5-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5a70187954ba7292c7876734183e810b728b4f3965fbe571421cb2434d279179"},
-    {file = "cryptography-41.0.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:88417bff20162f635f24f849ab182b092697922088b477a7abd6664ddd82291d"},
-    {file = "cryptography-41.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c707f7afd813478e2019ae32a7c49cd932dd60ab2d2a93e796f68236b7e1fbf1"},
-    {file = "cryptography-41.0.5-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:580afc7b7216deeb87a098ef0674d6ee34ab55993140838b14c9b83312b37b86"},
-    {file = "cryptography-41.0.5-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fba1e91467c65fe64a82c689dc6cf58151158993b13eb7a7f3f4b7f395636723"},
-    {file = "cryptography-41.0.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0d2a6a598847c46e3e321a7aef8af1436f11c27f1254933746304ff014664d84"},
-    {file = "cryptography-41.0.5.tar.gz", hash = "sha256:392cb88b597247177172e02da6b7a63deeff1937fa6fec3bbf902ebd75d97ec7"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860"},
+    {file = "cryptography-41.0.4-cp37-abi3-win32.whl", hash = "sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd"},
+    {file = "cryptography-41.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311"},
+    {file = "cryptography-41.0.4.tar.gz", hash = "sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a"},
 ]
 
 [package.dependencies]
@@ -674,6 +671,17 @@ tzlocal = "*"
 calendars = ["convertdate", "hijri-converter"]
 fasttext = ["fasttext"]
 langdetect = ["langdetect"]
+
+[[package]]
+name = "distlib"
+version = "0.3.7"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
+    {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
+]
 
 [[package]]
 name = "distro"
@@ -807,19 +815,19 @@ zstandard = ["zstandard"]
 
 [[package]]
 name = "filelock"
-version = "3.13.1"
+version = "3.12.4"
 description = "A platform independent file lock."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
-    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+    {file = "filelock-3.12.4-py3-none-any.whl", hash = "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4"},
+    {file = "filelock-3.12.4.tar.gz", hash = "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
-typing = ["typing-extensions (>=4.8)"]
+docs = ["furo (>=2023.7.26)", "sphinx (>=7.1.2)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3)", "diff-cover (>=7.7)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "pytest-timeout (>=2.1)"]
+typing = ["typing-extensions (>=4.7.1)"]
 
 [[package]]
 name = "frozenlist"
@@ -893,13 +901,13 @@ files = [
 
 [[package]]
 name = "fsspec"
-version = "2023.10.0"
+version = "2023.9.2"
 description = "File-system specification"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "fsspec-2023.10.0-py3-none-any.whl", hash = "sha256:346a8f024efeb749d2a5fca7ba8854474b1ff9af7c3faaf636a4548781136529"},
-    {file = "fsspec-2023.10.0.tar.gz", hash = "sha256:330c66757591df346ad3091a53bd907e15348c2ba17d63fd54f5c39c4457d2a5"},
+    {file = "fsspec-2023.9.2-py3-none-any.whl", hash = "sha256:603dbc52c75b84da501b9b2ec8c11e1f61c25984c4a0dda1f129ef391fbfc9b4"},
+    {file = "fsspec-2023.9.2.tar.gz", hash = "sha256:80bfb8c70cc27b2178cc62a935ecf242fc6e8c3fb801f9c571fc01b1e715ba7d"},
 ]
 
 [package.extras]
@@ -942,72 +950,79 @@ speedup = ["python-levenshtein (>=0.12)"]
 
 [[package]]
 name = "greenlet"
-version = "3.0.1"
+version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 files = [
-    {file = "greenlet-3.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f89e21afe925fcfa655965ca8ea10f24773a1791400989ff32f467badfe4a064"},
-    {file = "greenlet-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28e89e232c7593d33cac35425b58950789962011cc274aa43ef8865f2e11f46d"},
-    {file = "greenlet-3.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b8ba29306c5de7717b5761b9ea74f9c72b9e2b834e24aa984da99cbfc70157fd"},
-    {file = "greenlet-3.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19bbdf1cce0346ef7341705d71e2ecf6f41a35c311137f29b8a2dc2341374565"},
-    {file = "greenlet-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:599daf06ea59bfedbec564b1692b0166a0045f32b6f0933b0dd4df59a854caf2"},
-    {file = "greenlet-3.0.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b641161c302efbb860ae6b081f406839a8b7d5573f20a455539823802c655f63"},
-    {file = "greenlet-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d57e20ba591727da0c230ab2c3f200ac9d6d333860d85348816e1dca4cc4792e"},
-    {file = "greenlet-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5805e71e5b570d490938d55552f5a9e10f477c19400c38bf1d5190d760691846"},
-    {file = "greenlet-3.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:52e93b28db27ae7d208748f45d2db8a7b6a380e0d703f099c949d0f0d80b70e9"},
-    {file = "greenlet-3.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f7bfb769f7efa0eefcd039dd19d843a4fbfbac52f1878b1da2ed5793ec9b1a65"},
-    {file = "greenlet-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91e6c7db42638dc45cf2e13c73be16bf83179f7859b07cfc139518941320be96"},
-    {file = "greenlet-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1757936efea16e3f03db20efd0cd50a1c86b06734f9f7338a90c4ba85ec2ad5a"},
-    {file = "greenlet-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19075157a10055759066854a973b3d1325d964d498a805bb68a1f9af4aaef8ec"},
-    {file = "greenlet-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9d21aaa84557d64209af04ff48e0ad5e28c5cca67ce43444e939579d085da72"},
-    {file = "greenlet-3.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2847e5d7beedb8d614186962c3d774d40d3374d580d2cbdab7f184580a39d234"},
-    {file = "greenlet-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:97e7ac860d64e2dcba5c5944cfc8fa9ea185cd84061c623536154d5a89237884"},
-    {file = "greenlet-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b2c02d2ad98116e914d4f3155ffc905fd0c025d901ead3f6ed07385e19122c94"},
-    {file = "greenlet-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:22f79120a24aeeae2b4471c711dcf4f8c736a2bb2fabad2a67ac9a55ea72523c"},
-    {file = "greenlet-3.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:100f78a29707ca1525ea47388cec8a049405147719f47ebf3895e7509c6446aa"},
-    {file = "greenlet-3.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60d5772e8195f4e9ebf74046a9121bbb90090f6550f81d8956a05387ba139353"},
-    {file = "greenlet-3.0.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:daa7197b43c707462f06d2c693ffdbb5991cbb8b80b5b984007de431493a319c"},
-    {file = "greenlet-3.0.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea6b8aa9e08eea388c5f7a276fabb1d4b6b9d6e4ceb12cc477c3d352001768a9"},
-    {file = "greenlet-3.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d11ebbd679e927593978aa44c10fc2092bc454b7d13fdc958d3e9d508aba7d0"},
-    {file = "greenlet-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dbd4c177afb8a8d9ba348d925b0b67246147af806f0b104af4d24f144d461cd5"},
-    {file = "greenlet-3.0.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20107edf7c2c3644c67c12205dc60b1bb11d26b2610b276f97d666110d1b511d"},
-    {file = "greenlet-3.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8bef097455dea90ffe855286926ae02d8faa335ed8e4067326257cb571fc1445"},
-    {file = "greenlet-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:b2d3337dcfaa99698aa2377c81c9ca72fcd89c07e7eb62ece3f23a3fe89b2ce4"},
-    {file = "greenlet-3.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80ac992f25d10aaebe1ee15df45ca0d7571d0f70b645c08ec68733fb7a020206"},
-    {file = "greenlet-3.0.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:337322096d92808f76ad26061a8f5fccb22b0809bea39212cd6c406f6a7060d2"},
-    {file = "greenlet-3.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9934adbd0f6e476f0ecff3c94626529f344f57b38c9a541f87098710b18af0a"},
-    {file = "greenlet-3.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc4d815b794fd8868c4d67602692c21bf5293a75e4b607bb92a11e821e2b859a"},
-    {file = "greenlet-3.0.1-cp37-cp37m-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41bdeeb552d814bcd7fb52172b304898a35818107cc8778b5101423c9017b3de"},
-    {file = "greenlet-3.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6e6061bf1e9565c29002e3c601cf68569c450be7fc3f7336671af7ddb4657166"},
-    {file = "greenlet-3.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:fa24255ae3c0ab67e613556375a4341af04a084bd58764731972bcbc8baeba36"},
-    {file = "greenlet-3.0.1-cp37-cp37m-win32.whl", hash = "sha256:b489c36d1327868d207002391f662a1d163bdc8daf10ab2e5f6e41b9b96de3b1"},
-    {file = "greenlet-3.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f33f3258aae89da191c6ebaa3bc517c6c4cbc9b9f689e5d8452f7aedbb913fa8"},
-    {file = "greenlet-3.0.1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:d2905ce1df400360463c772b55d8e2518d0e488a87cdea13dd2c71dcb2a1fa16"},
-    {file = "greenlet-3.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a02d259510b3630f330c86557331a3b0e0c79dac3d166e449a39363beaae174"},
-    {file = "greenlet-3.0.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55d62807f1c5a1682075c62436702aaba941daa316e9161e4b6ccebbbf38bda3"},
-    {file = "greenlet-3.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3fcc780ae8edbb1d050d920ab44790201f027d59fdbd21362340a85c79066a74"},
-    {file = "greenlet-3.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4eddd98afc726f8aee1948858aed9e6feeb1758889dfd869072d4465973f6bfd"},
-    {file = "greenlet-3.0.1-cp38-cp38-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eabe7090db68c981fca689299c2d116400b553f4b713266b130cfc9e2aa9c5a9"},
-    {file = "greenlet-3.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f2f6d303f3dee132b322a14cd8765287b8f86cdc10d2cb6a6fae234ea488888e"},
-    {file = "greenlet-3.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d923ff276f1c1f9680d32832f8d6c040fe9306cbfb5d161b0911e9634be9ef0a"},
-    {file = "greenlet-3.0.1-cp38-cp38-win32.whl", hash = "sha256:0b6f9f8ca7093fd4433472fd99b5650f8a26dcd8ba410e14094c1e44cd3ceddd"},
-    {file = "greenlet-3.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:990066bff27c4fcf3b69382b86f4c99b3652bab2a7e685d968cd4d0cfc6f67c6"},
-    {file = "greenlet-3.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ce85c43ae54845272f6f9cd8320d034d7a946e9773c693b27d620edec825e376"},
-    {file = "greenlet-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ee2e967bd7ff85d84a2de09df10e021c9b38c7d91dead95b406ed6350c6997"},
-    {file = "greenlet-3.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87c8ceb0cf8a5a51b8008b643844b7f4a8264a2c13fcbcd8a8316161725383fe"},
-    {file = "greenlet-3.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d6a8c9d4f8692917a3dc7eb25a6fb337bff86909febe2f793ec1928cd97bedfc"},
-    {file = "greenlet-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fbc5b8f3dfe24784cee8ce0be3da2d8a79e46a276593db6868382d9c50d97b1"},
-    {file = "greenlet-3.0.1-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85d2b77e7c9382f004b41d9c72c85537fac834fb141b0296942d52bf03fe4a3d"},
-    {file = "greenlet-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:696d8e7d82398e810f2b3622b24e87906763b6ebfd90e361e88eb85b0e554dc8"},
-    {file = "greenlet-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:329c5a2e5a0ee942f2992c5e3ff40be03e75f745f48847f118a3cfece7a28546"},
-    {file = "greenlet-3.0.1-cp39-cp39-win32.whl", hash = "sha256:cf868e08690cb89360eebc73ba4be7fb461cfbc6168dd88e2fbbe6f31812cd57"},
-    {file = "greenlet-3.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:ac4a39d1abae48184d420aa8e5e63efd1b75c8444dd95daa3e03f6c6310e9619"},
-    {file = "greenlet-3.0.1.tar.gz", hash = "sha256:816bd9488a94cba78d93e1abb58000e8266fa9cc2aa9ccdd6eb0696acb24005b"},
+    {file = "greenlet-2.0.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d"},
+    {file = "greenlet-2.0.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9d14b83fab60d5e8abe587d51c75b252bcc21683f24699ada8fb275d7712f5a9"},
+    {file = "greenlet-2.0.2-cp27-cp27m-win32.whl", hash = "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74"},
+    {file = "greenlet-2.0.2-cp27-cp27m-win_amd64.whl", hash = "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343"},
+    {file = "greenlet-2.0.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470"},
+    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a"},
+    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
+    {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
+    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:eff4eb9b7eb3e4d0cae3d28c283dc16d9bed6b193c2e1ace3ed86ce48ea8df19"},
+    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5454276c07d27a740c5892f4907c86327b632127dd9abec42ee62e12427ff7e3"},
+    {file = "greenlet-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5"},
+    {file = "greenlet-2.0.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6"},
+    {file = "greenlet-2.0.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43"},
+    {file = "greenlet-2.0.2-cp35-cp35m-win32.whl", hash = "sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a"},
+    {file = "greenlet-2.0.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4b58adb399c4d61d912c4c331984d60eb66565175cdf4a34792cd9600f21b394"},
+    {file = "greenlet-2.0.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:703f18f3fda276b9a916f0934d2fb6d989bf0b4fb5a64825260eb9bfd52d78f0"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:32e5b64b148966d9cccc2c8d35a671409e45f195864560829f395a54226408d3"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dd11f291565a81d71dab10b7033395b7a3a5456e637cf997a6f33ebdf06f8db"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0f72c9ddb8cd28532185f54cc1453f2c16fb417a08b53a855c4e6a418edd099"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd021c754b162c0fb55ad5d6b9d960db667faad0fa2ff25bb6e1301b0b6e6a75"},
+    {file = "greenlet-2.0.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:3c9b12575734155d0c09d6c3e10dbd81665d5c18e1a7c6597df72fd05990c8cf"},
+    {file = "greenlet-2.0.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b9ec052b06a0524f0e35bd8790686a1da006bd911dd1ef7d50b77bfbad74e292"},
+    {file = "greenlet-2.0.2-cp36-cp36m-win32.whl", hash = "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9"},
+    {file = "greenlet-2.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:9f35ec95538f50292f6d8f2c9c9f8a3c6540bbfec21c9e5b4b751e0a7c20864f"},
+    {file = "greenlet-2.0.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2780572ec463d44c1d3ae850239508dbeb9fed38e294c68d19a24d925d9223ca"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937e9020b514ceedb9c830c55d5c9872abc90f4b5862f89c0887033ae33c6f73"},
+    {file = "greenlet-2.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:36abbf031e1c0f79dd5d596bfaf8e921c41df2bdf54ee1eed921ce1f52999a86"},
+    {file = "greenlet-2.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33"},
+    {file = "greenlet-2.0.2-cp37-cp37m-win32.whl", hash = "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7"},
+    {file = "greenlet-2.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acd2162a36d3de67ee896c43effcd5ee3de247eb00354db411feb025aa319857"},
+    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a"},
+    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
+    {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
+    {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c817e84245513926588caf1152e3b559ff794d505555211ca041f032abbb6b"},
+    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8"},
+    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9"},
+    {file = "greenlet-2.0.2-cp39-cp39-win32.whl", hash = "sha256:ea9872c80c132f4663822dd2a08d404073a5a9b5ba6155bea72fb2a79d1093b5"},
+    {file = "greenlet-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564"},
+    {file = "greenlet-2.0.2.tar.gz", hash = "sha256:e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0"},
 ]
 
 [package.extras]
-docs = ["Sphinx"]
+docs = ["Sphinx", "docutils (<0.18)"]
 test = ["objgraph", "psutil"]
 
 [[package]]
@@ -1023,17 +1038,17 @@ files = [
 
 [[package]]
 name = "htmldate"
-version = "1.5.2"
+version = "1.5.1"
 description = "Fast and robust extraction of original and updated publication dates from URLs and web pages."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "htmldate-1.5.2-py3-none-any.whl", hash = "sha256:5b31c901f4a1b7df5a770b471c7390b0e73ea77aaf7373797ff47a4be35871e2"},
-    {file = "htmldate-1.5.2.tar.gz", hash = "sha256:cc8b41c412b21d8a9236981755cfba7dfe25ebaf925a46417058d4902ad77e9b"},
+    {file = "htmldate-1.5.1-py3-none-any.whl", hash = "sha256:d0a9711300cccae5b07e67e27a29a809cc6e3a59f408ab4d787702dced6ddede"},
+    {file = "htmldate-1.5.1.tar.gz", hash = "sha256:00530d34618b6e770df537e6a8be74d8359ffe2cc5ee86e06ef20990049b6db6"},
 ]
 
 [package.dependencies]
-charset-normalizer = {version = ">=3.3.0", markers = "python_version >= \"3.7\""}
+charset-normalizer = {version = ">=3.2.0", markers = "python_version >= \"3.7\""}
 dateparser = ">=1.1.2"
 lxml = [
     {version = ">=4.9.3", markers = "platform_system != \"Darwin\""},
@@ -1048,40 +1063,39 @@ speed = ["backports-datetime-fromisoformat", "cchardet (>=2.1.7)", "faust-cchard
 
 [[package]]
 name = "httpcore"
-version = "1.0.1"
+version = "0.18.0"
 description = "A minimal low-level HTTP client."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.1-py3-none-any.whl", hash = "sha256:c5e97ef177dca2023d0b9aad98e49507ef5423e9f1d94ffe2cfe250aa28e63b0"},
-    {file = "httpcore-1.0.1.tar.gz", hash = "sha256:fce1ddf9b606cfb98132ab58865c3728c52c8e4c3c46e2aabb3674464a186e92"},
+    {file = "httpcore-0.18.0-py3-none-any.whl", hash = "sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced"},
+    {file = "httpcore-0.18.0.tar.gz", hash = "sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9"},
 ]
 
 [package.dependencies]
+anyio = ">=3.0,<5.0"
 certifi = "*"
 h11 = ">=0.13,<0.15"
+sniffio = "==1.*"
 
 [package.extras]
-asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.23.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.25.1"
+version = "0.25.0"
 description = "The next generation HTTP client."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.25.1-py3-none-any.whl", hash = "sha256:fec7d6cc5c27c578a391f7e87b9aa7d3d8fbcd034f6399f9f79b45bcc12a866a"},
-    {file = "httpx-0.25.1.tar.gz", hash = "sha256:ffd96d5cf901e63863d9f1b4b6807861dbea4d301613415d9e6e57ead15fc5d0"},
+    {file = "httpx-0.25.0-py3-none-any.whl", hash = "sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100"},
+    {file = "httpx-0.25.0.tar.gz", hash = "sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875"},
 ]
 
 [package.dependencies]
-anyio = "*"
 certifi = "*"
-httpcore = "*"
+httpcore = ">=0.18.0,<0.19.0"
 idna = "*"
 sniffio = "*"
 
@@ -1093,18 +1107,18 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.18.0"
+version = "0.17.3"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = true
 python-versions = ">=3.8.0"
 files = [
-    {file = "huggingface_hub-0.18.0-py3-none-any.whl", hash = "sha256:ee0b6b68acbf6aeb6d083ea081e981c277a1104b82ab67fdf6780ff5396830af"},
-    {file = "huggingface_hub-0.18.0.tar.gz", hash = "sha256:10eda12b9c1cfa800b4b7c096b3ace8843734c3f28d69d1c243743fb7d7a2e81"},
+    {file = "huggingface_hub-0.17.3-py3-none-any.whl", hash = "sha256:545eb3665f6ac587add946e73984148f2ea5c7877eac2e845549730570c1933a"},
+    {file = "huggingface_hub-0.17.3.tar.gz", hash = "sha256:40439632b211311f788964602bf8b0d9d6b7a2314fba4e8d67b2ce3ecea0e3fd"},
 ]
 
 [package.dependencies]
 filelock = "*"
-fsspec = ">=2023.5.0"
+fsspec = "*"
 packaging = ">=20.9"
 pyyaml = ">=5.1"
 requests = "*"
@@ -1123,6 +1137,20 @@ tensorflow = ["graphviz", "pydot", "tensorflow"]
 testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "numpy", "pydantic (<2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["torch"]
 typing = ["pydantic (<2.0)", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
+
+[[package]]
+name = "identify"
+version = "2.5.31"
+description = "File identification library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "identify-2.5.31-py2.py3-none-any.whl", hash = "sha256:90199cb9e7bd3c5407a9b7e81b4abec4bb9d249991c79439ec8af740afc6293d"},
+    {file = "identify-2.5.31.tar.gz", hash = "sha256:7736b3c7a28233637e3c36550646fc6389bedd74ae84cb788200cc8e2dd60b75"},
+]
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -1228,13 +1256,13 @@ files = [
 
 [[package]]
 name = "jsonschema"
-version = "4.19.2"
+version = "4.19.1"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jsonschema-4.19.2-py3-none-any.whl", hash = "sha256:eee9e502c788e89cb166d4d37f43084e3b64ab405c795c03d343a4dbc2c810fc"},
-    {file = "jsonschema-4.19.2.tar.gz", hash = "sha256:c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392"},
+    {file = "jsonschema-4.19.1-py3-none-any.whl", hash = "sha256:cd5f1f9ed9444e554b38ba003af06c0a8c2868131e56bfbef0550fb450c0330e"},
+    {file = "jsonschema-4.19.1.tar.gz", hash = "sha256:ec84cc37cfa703ef7cd4928db24f9cb31428a5d0fa77747b8b51a847458e0bbf"},
 ]
 
 [package.dependencies]
@@ -1639,13 +1667,13 @@ files = [
 
 [[package]]
 name = "marqo"
-version = "2.0.0"
+version = "1.3.1"
 description = "Tensor search for humans"
 optional = true
 python-versions = ">=3"
 files = [
-    {file = "marqo-2.0.0-py3-none-any.whl", hash = "sha256:3edff6b90e10752d0b4d8321dc60580b9dbe2eb71139e2f55fe86286840ba09c"},
-    {file = "marqo-2.0.0.tar.gz", hash = "sha256:8402d8e16d3d339a973318057080042a4e2efa44655c77eac561f483ef1842bb"},
+    {file = "marqo-1.3.1-py3-none-any.whl", hash = "sha256:32b1eb95dcd53027277b5f9704bb4a1db29f0c113b487df56dfdc63ef5805f47"},
+    {file = "marqo-1.3.1.tar.gz", hash = "sha256:d2bab35df93ee7790d10dac459620dcd1133332d0a693046d0aebf17994cf8ac"},
 ]
 
 [package.dependencies]
@@ -1728,13 +1756,13 @@ files = [
 
 [[package]]
 name = "moto"
-version = "4.2.7"
+version = "4.2.4"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "moto-4.2.7-py2.py3-none-any.whl", hash = "sha256:3e0ef388900448485cd6eff18e9f7fcaa6cf4560b6fb536ba2e2e1278a5ecc59"},
-    {file = "moto-4.2.7.tar.gz", hash = "sha256:1298006aaa6996b886658eb194cac0e3a5679c9fcce6cb13e741ccc5a7247abb"},
+    {file = "moto-4.2.4-py2.py3-none-any.whl", hash = "sha256:3516f55405015e4516c549d875c7a93e7daa1622d6342af335e63cf7bfe442fd"},
+    {file = "moto-4.2.4.tar.gz", hash = "sha256:eea3c5b29987e8b12816b355dfdcca5d7a815a9d9f17208af31fa32acbe8b389"},
 ]
 
 [package.dependencies]
@@ -1743,7 +1771,7 @@ botocore = ">=1.12.201"
 cryptography = ">=3.3.1"
 docker = {version = ">=3.0.0", optional = true, markers = "extra == \"dynamodb\""}
 Jinja2 = ">=2.10.1"
-py-partiql-parser = {version = "0.4.1", optional = true, markers = "extra == \"dynamodb\""}
+py-partiql-parser = {version = "0.3.7", optional = true, markers = "extra == \"dynamodb\""}
 python-dateutil = ">=2.1,<3.0.0"
 requests = ">=2.5"
 responses = ">=0.13.0"
@@ -1751,29 +1779,28 @@ werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
 xmltodict = "*"
 
 [package.extras]
-all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
-apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.5.0)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.7)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.2.8)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
 apigatewayv2 = ["PyYAML (>=5.1)"]
 appsync = ["graphql-core"]
 awslambda = ["docker (>=3.0.0)"]
 batch = ["docker (>=3.0.0)"]
-cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.7)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
 ds = ["sshpubkeys (>=3.1.0)"]
-dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.4.1)"]
-dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.4.1)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.7)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.7)"]
 ebs = ["sshpubkeys (>=3.1.0)"]
 ec2 = ["sshpubkeys (>=3.1.0)"]
 efs = ["sshpubkeys (>=3.1.0)"]
 eks = ["sshpubkeys (>=3.1.0)"]
 glue = ["pyparsing (>=3.0.7)"]
 iotdata = ["jsondiff (>=1.1.2)"]
-proxy = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
-resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "sshpubkeys (>=3.1.0)"]
+resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.7)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "sshpubkeys (>=3.1.0)"]
 route53resolver = ["sshpubkeys (>=3.1.0)"]
-s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.4.1)"]
-s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.4.1)"]
-server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.1)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.3.7)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.3.7)"]
+server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.7)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 ssm = ["PyYAML (>=5.1)"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
@@ -1912,43 +1939,36 @@ setuptools = "*"
 
 [[package]]
 name = "numpy"
-version = "1.26.1"
+version = "1.25.2"
 description = "Fundamental package for array computing in Python"
 optional = false
-python-versions = "<3.13,>=3.9"
+python-versions = ">=3.9"
 files = [
-    {file = "numpy-1.26.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:82e871307a6331b5f09efda3c22e03c095d957f04bf6bc1804f30048d0e5e7af"},
-    {file = "numpy-1.26.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdd9ec98f0063d93baeb01aad472a1a0840dee302842a2746a7a8e92968f9575"},
-    {file = "numpy-1.26.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d78f269e0c4fd365fc2992c00353e4530d274ba68f15e968d8bc3c69ce5f5244"},
-    {file = "numpy-1.26.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ab9163ca8aeb7fd32fe93866490654d2f7dda4e61bc6297bf72ce07fdc02f67"},
-    {file = "numpy-1.26.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:78ca54b2f9daffa5f323f34cdf21e1d9779a54073f0018a3094ab907938331a2"},
-    {file = "numpy-1.26.1-cp310-cp310-win32.whl", hash = "sha256:d1cfc92db6af1fd37a7bb58e55c8383b4aa1ba23d012bdbba26b4bcca45ac297"},
-    {file = "numpy-1.26.1-cp310-cp310-win_amd64.whl", hash = "sha256:d2984cb6caaf05294b8466966627e80bf6c7afd273279077679cb010acb0e5ab"},
-    {file = "numpy-1.26.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cd7837b2b734ca72959a1caf3309457a318c934abef7a43a14bb984e574bbb9a"},
-    {file = "numpy-1.26.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c59c046c31a43310ad0199d6299e59f57a289e22f0f36951ced1c9eac3665b9"},
-    {file = "numpy-1.26.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d58e8c51a7cf43090d124d5073bc29ab2755822181fcad978b12e144e5e5a4b3"},
-    {file = "numpy-1.26.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6081aed64714a18c72b168a9276095ef9155dd7888b9e74b5987808f0dd0a974"},
-    {file = "numpy-1.26.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:97e5d6a9f0702c2863aaabf19f0d1b6c2628fbe476438ce0b5ce06e83085064c"},
-    {file = "numpy-1.26.1-cp311-cp311-win32.whl", hash = "sha256:b9d45d1dbb9de84894cc50efece5b09939752a2d75aab3a8b0cef6f3a35ecd6b"},
-    {file = "numpy-1.26.1-cp311-cp311-win_amd64.whl", hash = "sha256:3649d566e2fc067597125428db15d60eb42a4e0897fc48d28cb75dc2e0454e53"},
-    {file = "numpy-1.26.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1d1bd82d539607951cac963388534da3b7ea0e18b149a53cf883d8f699178c0f"},
-    {file = "numpy-1.26.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd5ced4e5a96dac6725daeb5242a35494243f2239244fad10a90ce58b071d24"},
-    {file = "numpy-1.26.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03fb25610ef560a6201ff06df4f8105292ba56e7cdd196ea350d123fc32e24e"},
-    {file = "numpy-1.26.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcfaf015b79d1f9f9c9fd0731a907407dc3e45769262d657d754c3a028586124"},
-    {file = "numpy-1.26.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e509cbc488c735b43b5ffea175235cec24bbc57b227ef1acc691725beb230d1c"},
-    {file = "numpy-1.26.1-cp312-cp312-win32.whl", hash = "sha256:af22f3d8e228d84d1c0c44c1fbdeb80f97a15a0abe4f080960393a00db733b66"},
-    {file = "numpy-1.26.1-cp312-cp312-win_amd64.whl", hash = "sha256:9f42284ebf91bdf32fafac29d29d4c07e5e9d1af862ea73686581773ef9e73a7"},
-    {file = "numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e"},
-    {file = "numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617"},
-    {file = "numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e"},
-    {file = "numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908"},
-    {file = "numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5"},
-    {file = "numpy-1.26.1-cp39-cp39-win32.whl", hash = "sha256:d1d2c6b7dd618c41e202c59c1413ef9b2c8e8a15f5039e344af64195459e3104"},
-    {file = "numpy-1.26.1-cp39-cp39-win_amd64.whl", hash = "sha256:59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2"},
-    {file = "numpy-1.26.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:06934e1a22c54636a059215d6da99e23286424f316fddd979f5071093b648668"},
-    {file = "numpy-1.26.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76ff661a867d9272cd2a99eed002470f46dbe0943a5ffd140f49be84f68ffc42"},
-    {file = "numpy-1.26.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f"},
-    {file = "numpy-1.26.1.tar.gz", hash = "sha256:c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe"},
+    {file = "numpy-1.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db3ccc4e37a6873045580d413fe79b68e47a681af8db2e046f1dacfa11f86eb3"},
+    {file = "numpy-1.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:90319e4f002795ccfc9050110bbbaa16c944b1c37c0baeea43c5fb881693ae1f"},
+    {file = "numpy-1.25.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfe4a913e29b418d096e696ddd422d8a5d13ffba4ea91f9f60440a3b759b0187"},
+    {file = "numpy-1.25.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08f2e037bba04e707eebf4bc934f1972a315c883a9e0ebfa8a7756eabf9e357"},
+    {file = "numpy-1.25.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bec1e7213c7cb00d67093247f8c4db156fd03075f49876957dca4711306d39c9"},
+    {file = "numpy-1.25.2-cp310-cp310-win32.whl", hash = "sha256:7dc869c0c75988e1c693d0e2d5b26034644399dd929bc049db55395b1379e044"},
+    {file = "numpy-1.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:834b386f2b8210dca38c71a6e0f4fd6922f7d3fcff935dbe3a570945acb1b545"},
+    {file = "numpy-1.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c5462d19336db4560041517dbb7759c21d181a67cb01b36ca109b2ae37d32418"},
+    {file = "numpy-1.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5652ea24d33585ea39eb6a6a15dac87a1206a692719ff45d53c5282e66d4a8f"},
+    {file = "numpy-1.25.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d60fbae8e0019865fc4784745814cff1c421df5afee233db6d88ab4f14655a2"},
+    {file = "numpy-1.25.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60e7f0f7f6d0eee8364b9a6304c2845b9c491ac706048c7e8cf47b83123b8dbf"},
+    {file = "numpy-1.25.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bb33d5a1cf360304754913a350edda36d5b8c5331a8237268c48f91253c3a364"},
+    {file = "numpy-1.25.2-cp311-cp311-win32.whl", hash = "sha256:5883c06bb92f2e6c8181df7b39971a5fb436288db58b5a1c3967702d4278691d"},
+    {file = "numpy-1.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:5c97325a0ba6f9d041feb9390924614b60b99209a71a69c876f71052521d42a4"},
+    {file = "numpy-1.25.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b79e513d7aac42ae918db3ad1341a015488530d0bb2a6abcbdd10a3a829ccfd3"},
+    {file = "numpy-1.25.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eb942bfb6f84df5ce05dbf4b46673ffed0d3da59f13635ea9b926af3deb76926"},
+    {file = "numpy-1.25.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e0746410e73384e70d286f93abf2520035250aad8c5714240b0492a7302fdca"},
+    {file = "numpy-1.25.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7806500e4f5bdd04095e849265e55de20d8cc4b661b038957354327f6d9b295"},
+    {file = "numpy-1.25.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8b77775f4b7df768967a7c8b3567e309f617dd5e99aeb886fa14dc1a0791141f"},
+    {file = "numpy-1.25.2-cp39-cp39-win32.whl", hash = "sha256:2792d23d62ec51e50ce4d4b7d73de8f67a2fd3ea710dcbc8563a51a03fb07b01"},
+    {file = "numpy-1.25.2-cp39-cp39-win_amd64.whl", hash = "sha256:76b4115d42a7dfc5d485d358728cdd8719be33cc5ec6ec08632a5d6fca2ed380"},
+    {file = "numpy-1.25.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1a1329e26f46230bf77b02cc19e900db9b52f398d6722ca853349a782d4cff55"},
+    {file = "numpy-1.25.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c3abc71e8b6edba80a01a52e66d83c5d14433cbcd26a40c329ec7ed09f37901"},
+    {file = "numpy-1.25.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1b9735c27cea5d995496f46a8b1cd7b408b3f34b6d50459d9ac8fe3a20cc17bf"},
+    {file = "numpy-1.25.2.tar.gz", hash = "sha256:fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760"},
 ]
 
 [[package]]
@@ -1975,13 +1995,13 @@ wandb = ["numpy", "openpyxl (>=3.0.7)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1
 
 [[package]]
 name = "opensearch-py"
-version = "2.3.2"
+version = "2.3.1"
 description = "Python client for OpenSearch"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 files = [
-    {file = "opensearch-py-2.3.2.tar.gz", hash = "sha256:96e470b55107fd5bfd873722dc9808c333360eacfa174341f5cc2d021aa30448"},
-    {file = "opensearch_py-2.3.2-py2.py3-none-any.whl", hash = "sha256:b1d6607380c8f19d90c142470939d051f0bac96069ce0ac25970b3c39c431f8b"},
+    {file = "opensearch-py-2.3.1.tar.gz", hash = "sha256:f82a2e914835f7d645a632777de9a62d0c0de60ffd2f8cdae2ccfa4cfc40a185"},
+    {file = "opensearch_py-2.3.1-py2.py3-none-any.whl", hash = "sha256:eafbc5d56a7ca696afba7d77bcda1bbb849050cbf9265d57d8476576cb576395"},
 ]
 
 [package.dependencies]
@@ -1989,7 +2009,7 @@ certifi = ">=2022.12.07"
 python-dateutil = "*"
 requests = ">=2.4.0,<3.0.0"
 six = "*"
-urllib3 = ">=1.26.9"
+urllib3 = ">=1.21.1,<2"
 
 [package.extras]
 async = ["aiohttp (>=3,<4)"]
@@ -1998,54 +2018,68 @@ docs = ["myst-parser", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
 kerberos = ["requests-kerberos"]
 
 [[package]]
+name = "oscrypto"
+version = "1.3.0"
+description = "TLS (SSL) sockets, key generation, encryption, decryption, signing, verification and KDFs using the OS crypto libraries. Does not require a compiler, and relies on the OS for patching. Works on Windows, OS X and Linux/BSD."
+optional = true
+python-versions = "*"
+files = [
+    {file = "oscrypto-1.3.0-py2.py3-none-any.whl", hash = "sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085"},
+    {file = "oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4"},
+]
+
+[package.dependencies]
+asn1crypto = ">=1.5.1"
+
+[[package]]
 name = "packaging"
-version = "23.2"
+version = "23.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 
 [[package]]
 name = "pandas"
-version = "2.1.2"
+version = "2.1.1"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pandas-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:24057459f19db9ebb02984c6fdd164a970b31a95f38e4a49cf7615b36a1b532c"},
-    {file = "pandas-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6cf8fcc8a63d333970b950a7331a30544cf59b1a97baf0a7409e09eafc1ac38"},
-    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ae6ffbd9d614c20d028c7117ee911fc4e266b4dca2065d5c5909e401f8ff683"},
-    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff794eeb7883c5aefb1ed572e7ff533ae779f6c6277849eab9e77986e352688"},
-    {file = "pandas-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02954e285e8e2f4006b6f22be6f0df1f1c3c97adbb7ed211c6b483426f20d5c8"},
-    {file = "pandas-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:5b40c9f494e1f27588c369b9e4a6ca19cd924b3a0e1ef9ef1a8e30a07a438f43"},
-    {file = "pandas-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08d287b68fd28906a94564f15118a7ca8c242e50ae7f8bd91130c362b2108a81"},
-    {file = "pandas-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bbd98dcdcd32f408947afdb3f7434fade6edd408c3077bbce7bd840d654d92c6"},
-    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e90c95abb3285d06f6e4feedafc134306a8eced93cb78e08cf50e224d5ce22e2"},
-    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52867d69a54e71666cd184b04e839cff7dfc8ed0cd6b936995117fdae8790b69"},
-    {file = "pandas-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8d0382645ede2fde352da2a885aac28ec37d38587864c0689b4b2361d17b1d4c"},
-    {file = "pandas-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:65177d1c519b55e5b7f094c660ed357bb7d86e799686bb71653b8a4803d8ff0d"},
-    {file = "pandas-2.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5aa6b86802e8cf7716bf4b4b5a3c99b12d34e9c6a9d06dad254447a620437931"},
-    {file = "pandas-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d594e2ce51b8e0b4074e6644758865dc2bb13fd654450c1eae51201260a539f1"},
-    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3223f997b6d2ebf9c010260cf3d889848a93f5d22bb4d14cd32638b3d8bba7ad"},
-    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4944dc004ca6cc701dfa19afb8bdb26ad36b9bed5bcec617d2a11e9cae6902"},
-    {file = "pandas-2.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3f76280ce8ec216dde336e55b2b82e883401cf466da0fe3be317c03fb8ee7c7d"},
-    {file = "pandas-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:7ad20d24acf3a0042512b7e8d8fdc2e827126ed519d6bd1ed8e6c14ec8a2c813"},
-    {file = "pandas-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:021f09c15e1381e202d95d4a21ece8e7f2bf1388b6d7e9cae09dfe27bd2043d1"},
-    {file = "pandas-2.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7f12b2de0060b0b858cfec0016e7d980ae5bae455a1746bfcc70929100ee633"},
-    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c166b9bb27c1715bed94495d9598a7f02950b4749dba9349c1dd2cbf10729d"},
-    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25c9976c17311388fcd953cb3d0697999b2205333f4e11e669d90ff8d830d429"},
-    {file = "pandas-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:851b5afbb0d62f6129ae891b533aa508cc357d5892c240c91933d945fff15731"},
-    {file = "pandas-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:e78507adcc730533619de07bfdd1c62b2918a68cd4419ea386e28abf7f6a1e5c"},
-    {file = "pandas-2.1.2.tar.gz", hash = "sha256:52897edc2774d2779fbeb6880d2cfb305daa0b1a29c16b91f531a18918a6e0f3"},
+    {file = "pandas-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:58d997dbee0d4b64f3cb881a24f918b5f25dd64ddf31f467bb9b67ae4c63a1e4"},
+    {file = "pandas-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02304e11582c5d090e5a52aec726f31fe3f42895d6bfc1f28738f9b64b6f0614"},
+    {file = "pandas-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffa8f0966de2c22de408d0e322db2faed6f6e74265aa0856f3824813cf124363"},
+    {file = "pandas-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1f84c144dee086fe4f04a472b5cd51e680f061adf75c1ae4fc3a9275560f8f4"},
+    {file = "pandas-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ce97667d06d69396d72be074f0556698c7f662029322027c226fd7a26965cb"},
+    {file = "pandas-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:4c3f32fd7c4dccd035f71734df39231ac1a6ff95e8bdab8d891167197b7018d2"},
+    {file = "pandas-2.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9e2959720b70e106bb1d8b6eadd8ecd7c8e99ccdbe03ee03260877184bb2877d"},
+    {file = "pandas-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25e8474a8eb258e391e30c288eecec565bfed3e026f312b0cbd709a63906b6f8"},
+    {file = "pandas-2.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8bd1685556f3374520466998929bade3076aeae77c3e67ada5ed2b90b4de7f0"},
+    {file = "pandas-2.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc3657869c7902810f32bd072f0740487f9e030c1a3ab03e0af093db35a9d14e"},
+    {file = "pandas-2.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:05674536bd477af36aa2effd4ec8f71b92234ce0cc174de34fd21e2ee99adbc2"},
+    {file = "pandas-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:b407381258a667df49d58a1b637be33e514b07f9285feb27769cedb3ab3d0b3a"},
+    {file = "pandas-2.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c747793c4e9dcece7bb20156179529898abf505fe32cb40c4052107a3c620b49"},
+    {file = "pandas-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3bcad1e6fb34b727b016775bea407311f7721db87e5b409e6542f4546a4951ea"},
+    {file = "pandas-2.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5ec7740f9ccb90aec64edd71434711f58ee0ea7f5ed4ac48be11cfa9abf7317"},
+    {file = "pandas-2.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29deb61de5a8a93bdd033df328441a79fcf8dd3c12d5ed0b41a395eef9cd76f0"},
+    {file = "pandas-2.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4f99bebf19b7e03cf80a4e770a3e65eee9dd4e2679039f542d7c1ace7b7b1daa"},
+    {file = "pandas-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:84e7e910096416adec68075dc87b986ff202920fb8704e6d9c8c9897fe7332d6"},
+    {file = "pandas-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:366da7b0e540d1b908886d4feb3d951f2f1e572e655c1160f5fde28ad4abb750"},
+    {file = "pandas-2.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e50e72b667415a816ac27dfcfe686dc5a0b02202e06196b943d54c4f9c7693e"},
+    {file = "pandas-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc1ab6a25da197f03ebe6d8fa17273126120874386b4ac11c1d687df288542dd"},
+    {file = "pandas-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0dbfea0dd3901ad4ce2306575c54348d98499c95be01b8d885a2737fe4d7a98"},
+    {file = "pandas-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0489b0e6aa3d907e909aef92975edae89b1ee1654db5eafb9be633b0124abe97"},
+    {file = "pandas-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:4cdb0fab0400c2cb46dafcf1a0fe084c8bb2480a1fa8d81e19d15e12e6d4ded2"},
+    {file = "pandas-2.1.1.tar.gz", hash = "sha256:fecb198dc389429be557cde50a2d46da8434a17fe37d7d41ff102e3987fd947b"},
 ]
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2140,13 +2174,13 @@ testing = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "3.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
+    {file = "platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
 ]
 
 [package.extras]
@@ -2167,6 +2201,24 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "3.5.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pre_commit-3.5.0-py2.py3-none-any.whl", hash = "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"},
+    {file = "pre_commit-3.5.0.tar.gz", hash = "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "psycopg2-binary"
@@ -2248,13 +2300,13 @@ files = [
 
 [[package]]
 name = "py-partiql-parser"
-version = "0.4.1"
+version = "0.3.7"
 description = "Pure Python PartiQL Parser"
 optional = false
 python-versions = "*"
 files = [
-    {file = "py-partiql-parser-0.4.1.tar.gz", hash = "sha256:e0640ee913812bbf5cd126accc0b09eebd0e68df769a9bfbaef9a5e74a0c6d55"},
-    {file = "py_partiql_parser-0.4.1-py3-none-any.whl", hash = "sha256:6357ec3215f4ceabe4aa1926e4a0f808b9ebc9f7fd438e7f22dbdc3d6efb2eae"},
+    {file = "py-partiql-parser-0.3.7.tar.gz", hash = "sha256:5341f1adc3bdd5dbe7c980fc17b3a4a6353c9052e5b5dd70f6aff9306fb8cbb2"},
+    {file = "py_partiql_parser-0.3.7-py3-none-any.whl", hash = "sha256:e18696b40b9733b1e4b312969f8210fcde24e0766e2a0da799e8f70a5594d6ab"},
 ]
 
 [package.extras]
@@ -2269,6 +2321,47 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.19.0"
+description = "Cryptographic library for Python"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ff64fd720def623bf64d8776f8d0deada1cc1bf1ec3c1f9d6f5bb5bd098d034f"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:61056a1fd3254f6f863de94c233b30dd33bc02f8c935b2000269705f1eeeffa4"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:258c4233a3fe5a6341780306a36c6fb072ef38ce676a6d41eec3e591347919e8"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e45bb4635b3c4e0a00ca9df75ef6295838c85c2ac44ad882410cb631ed1eeaa"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-musllinux_1_1_aarch64.whl", hash = "sha256:a12144d785518f6491ad334c75ccdc6ad52ea49230b4237f319dbb7cef26f464"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-win32.whl", hash = "sha256:1789d89f61f70a4cd5483d4dfa8df7032efab1118f8b9894faae03c967707865"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27m-win_amd64.whl", hash = "sha256:eb2fc0ec241bf5e5ef56c8fbec4a2634d631e4c4f616a59b567947a0f35ad83c"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:c9a68a2f7bd091ccea54ad3be3e9d65eded813e6d79fdf4cc3604e26cdd6384f"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:8df69e41f7e7015a90b94d1096ec3d8e0182e73449487306709ec27379fff761"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27mu-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:917033016ecc23c8933205585a0ab73e20020fdf671b7cd1be788a5c4039840b"},
+    {file = "pycryptodomex-3.19.0-cp27-cp27mu-musllinux_1_1_aarch64.whl", hash = "sha256:e8e5ecbd4da4157889fce8ba49da74764dd86c891410bfd6b24969fa46edda51"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:a77b79852175064c822b047fee7cf5a1f434f06ad075cc9986aa1c19a0c53eb0"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5b883e1439ab63af976656446fb4839d566bb096f15fc3c06b5a99cde4927188"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3866d68e2fc345162b1b9b83ef80686acfe5cec0d134337f3b03950a0a8bf56"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c74eb1f73f788facece7979ce91594dc177e1a9b5d5e3e64697dd58299e5cb4d"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7cb51096a6a8d400724104db8a7e4f2206041a1f23e58924aa3d8d96bcb48338"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a588a1cb7781da9d5e1c84affd98c32aff9c89771eac8eaa659d2760666f7139"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:d4dd3b381ff5a5907a3eb98f5f6d32c64d319a840278ceea1dcfcc65063856f3"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:263de9a96d2fcbc9f5bd3a279f14ea0d5f072adb68ebd324987576ec25da084d"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-win32.whl", hash = "sha256:67c8eb79ab33d0fbcb56842992298ddb56eb6505a72369c20f60bc1d2b6fb002"},
+    {file = "pycryptodomex-3.19.0-cp35-abi3-win_amd64.whl", hash = "sha256:09c9401dc06fb3d94cb1ec23b4ea067a25d1f4c6b7b118ff5631d0b5daaab3cc"},
+    {file = "pycryptodomex-3.19.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:edbe083c299835de7e02c8aa0885cb904a75087d35e7bab75ebe5ed336e8c3e2"},
+    {file = "pycryptodomex-3.19.0-pp27-pypy_73-win32.whl", hash = "sha256:136b284e9246b4ccf4f752d435c80f2c44fc2321c198505de1d43a95a3453b3c"},
+    {file = "pycryptodomex-3.19.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5d73e9fa3fe830e7b6b42afc49d8329b07a049a47d12e0ef9225f2fd220f19b2"},
+    {file = "pycryptodomex-3.19.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b2f1982c5bc311f0aab8c293524b861b485d76f7c9ab2c3ac9a25b6f7655975"},
+    {file = "pycryptodomex-3.19.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb040b5dda1dff1e197d2ef71927bd6b8bfcb9793bc4dfe0bb6df1e691eaacb"},
+    {file = "pycryptodomex-3.19.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:800a2b05cfb83654df80266692f7092eeefe2a314fa7901dcefab255934faeec"},
+    {file = "pycryptodomex-3.19.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c01678aee8ac0c1a461cbc38ad496f953f9efcb1fa19f5637cbeba7544792a53"},
+    {file = "pycryptodomex-3.19.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2126bc54beccbede6eade00e647106b4f4c21e5201d2b0a73e9e816a01c50905"},
+    {file = "pycryptodomex-3.19.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b801216c48c0886742abf286a9a6b117e248ca144d8ceec1f931ce2dd0c9cb40"},
+    {file = "pycryptodomex-3.19.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:50cb18d4dd87571006fd2447ccec85e6cec0136632a550aa29226ba075c80644"},
+    {file = "pycryptodomex-3.19.0.tar.gz", hash = "sha256:af83a554b3f077564229865c45af0791be008ac6469ef0098152139e6bd4b5b6"},
 ]
 
 [[package]]
@@ -2356,92 +2449,92 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymongo"
-version = "4.6.0"
+version = "4.5.0"
 description = "Python driver for MongoDB <http://www.mongodb.org>"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "pymongo-4.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c011bd5ad03cc096f99ffcfdd18a1817354132c1331bed7a837a25226659845f"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux1_i686.whl", hash = "sha256:5e63146dbdb1eac207464f6e0cfcdb640c9c5ff0f57b754fa96fe252314a1dc6"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:2972dd1f1285866aba027eff2f4a2bbf8aa98563c2ced14cb34ee5602b36afdf"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux2014_i686.whl", hash = "sha256:a0be99b599da95b7a90a918dd927b20c434bea5e1c9b3efc6a3c6cd67c23f813"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux2014_ppc64le.whl", hash = "sha256:9b0f98481ad5dc4cb430a60bbb8869f05505283b9ae1c62bdb65eb5e020ee8e3"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux2014_s390x.whl", hash = "sha256:256c503a75bd71cf7fb9ebf889e7e222d49c6036a48aad5a619f98a0adf0e0d7"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:b4ad70d7cac4ca0c7b31444a0148bd3af01a2662fa12b1ad6f57cd4a04e21766"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5717a308a703dda2886a5796a07489c698b442f5e409cf7dc2ac93de8d61d764"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8f7f9feecae53fa18d6a3ea7c75f9e9a1d4d20e5c3f9ce3fba83f07bcc4eee2"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:128b1485753106c54af481789cdfea12b90a228afca0b11fb3828309a907e10e"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3077a31633beef77d057c6523f5de7271ddef7bde5e019285b00c0cc9cac1e3"},
-    {file = "pymongo-4.6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ebf02c32afa6b67e5861a27183dd98ed88419a94a2ab843cc145fb0bafcc5b28"},
-    {file = "pymongo-4.6.0-cp310-cp310-win32.whl", hash = "sha256:b14dd73f595199f4275bed4fb509277470d9b9059310537e3b3daba12b30c157"},
-    {file = "pymongo-4.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:8adf014f2779992eba3b513e060d06f075f0ab2fb3ad956f413a102312f65cdf"},
-    {file = "pymongo-4.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ba51129fcc510824b6ca6e2ce1c27e3e4d048b6e35d3ae6f7e517bed1b8b25ce"},
-    {file = "pymongo-4.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2973f113e079fb98515722cd728e1820282721ec9fd52830e4b73cabdbf1eb28"},
-    {file = "pymongo-4.6.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af425f323fce1b07755edd783581e7283557296946212f5b1a934441718e7528"},
-    {file = "pymongo-4.6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ec71ac633b126c0775ed4604ca8f56c3540f5c21a1220639f299e7a544b55f9"},
-    {file = "pymongo-4.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ec6c20385c5a58e16b1ea60c5e4993ea060540671d7d12664f385f2fb32fe79"},
-    {file = "pymongo-4.6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:85f2cdc400ee87f5952ebf2a117488f2525a3fb2e23863a8efe3e4ee9e54e4d1"},
-    {file = "pymongo-4.6.0-cp311-cp311-win32.whl", hash = "sha256:7fc2bb8a74dcfcdd32f89528e38dcbf70a3a6594963d60dc9595e3b35b66e414"},
-    {file = "pymongo-4.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:6695d7136a435c1305b261a9ddb9b3ecec9863e05aab3935b96038145fd3a977"},
-    {file = "pymongo-4.6.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:d603edea1ff7408638b2504905c032193b7dcee7af269802dbb35bc8c3310ed5"},
-    {file = "pymongo-4.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79f41576b3022c2fe9780ae3e44202b2438128a25284a8ddfa038f0785d87019"},
-    {file = "pymongo-4.6.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49f2af6cf82509b15093ce3569229e0d53c90ad8ae2eef940652d4cf1f81e045"},
-    {file = "pymongo-4.6.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecd9e1fa97aa11bf67472220285775fa15e896da108f425e55d23d7540a712ce"},
-    {file = "pymongo-4.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d2be5c9c3488fa8a70f83ed925940f488eac2837a996708d98a0e54a861f212"},
-    {file = "pymongo-4.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab6bcc8e424e07c1d4ba6df96f7fb963bcb48f590b9456de9ebd03b88084fe8"},
-    {file = "pymongo-4.6.0-cp312-cp312-win32.whl", hash = "sha256:47aa128be2e66abd9d1a9b0437c62499d812d291f17b55185cb4aa33a5f710a4"},
-    {file = "pymongo-4.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:014e7049dd019a6663747ca7dae328943e14f7261f7c1381045dfc26a04fa330"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:288c21ab9531b037f7efa4e467b33176bc73a0c27223c141b822ab4a0e66ff2a"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:747c84f4e690fbe6999c90ac97246c95d31460d890510e4a3fa61b7d2b87aa34"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:055f5c266e2767a88bb585d01137d9c7f778b0195d3dbf4a487ef0638be9b651"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:82e620842e12e8cb4050d2643a81c8149361cd82c0a920fa5a15dc4ca8a4000f"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:6b18276f14b4b6d92e707ab6db19b938e112bd2f1dc3f9f1a628df58e4fd3f0d"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:680fa0fc719e1a3dcb81130858368f51d83667d431924d0bcf249644bce8f303"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:3919708594b86d0f5cdc713eb6fccd3f9b9532af09ea7a5d843c933825ef56c4"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db082f728160369d9a6ed2e722438291558fc15ce06d0a7d696a8dad735c236b"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e4ed21029d80c4f62605ab16398fe1ce093fff4b5f22d114055e7d9fbc4adb0"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bea9138b0fc6e2218147e9c6ce1ff76ff8e29dc00bb1b64842bd1ca107aee9f"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a0269811661ba93c472c8a60ea82640e838c2eb148d252720a09b5123f2c2fe"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d6a1b1361f118e7fefa17ae3114e77f10ee1b228b20d50c47c9f351346180c8"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7e3b0127b260d4abae7b62203c4c7ef0874c901b55155692353db19de4b18bc4"},
-    {file = "pymongo-4.6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a49aca4d961823b2846b739380c847e8964ff7ae0f0a683992b9d926054f0d6d"},
-    {file = "pymongo-4.6.0-cp37-cp37m-win32.whl", hash = "sha256:09c7de516b08c57647176b9fc21d929d628e35bcebc7422220c89ae40b62126a"},
-    {file = "pymongo-4.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:81dd1308bd5630d2bb5980f00aa163b986b133f1e9ed66c66ce2a5bc3572e891"},
-    {file = "pymongo-4.6.0-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:2f8c04277d879146eacda920476e93d520eff8bec6c022ac108cfa6280d84348"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5802acc012bbb4bce4dff92973dff76482f30ef35dd4cb8ab5b0e06aa8f08c80"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ccd785fafa1c931deff6a7116e9a0d402d59fabe51644b0d0c268295ff847b25"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fe03bf25fae4b95d8afe40004a321df644400fdcba4c8e5e1a19c1085b740888"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:2ca0ba501898b2ec31e6c3acf90c31910944f01d454ad8e489213a156ccf1bda"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:10a379fb60f1b2406ae57b8899bacfe20567918c8e9d2d545e1b93628fcf2050"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:a4dc1319d0c162919ee7f4ee6face076becae2abbd351cc14f1fe70af5fb20d9"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ddef295aaf80cefb0c1606f1995899efcb17edc6b327eb6589e234e614b87756"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:518c90bdd6e842c446d01a766b9136fec5ec6cc94f3b8c3f8b4a332786ee6b64"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b80a4ee19b3442c57c38afa978adca546521a8822d663310b63ae2a7d7b13f3a"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb438a8bf6b695bf50d57e6a059ff09652a07968b2041178b3744ea785fcef9b"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3db7d833a7c38c317dc95b54e27f1d27012e031b45a7c24e360b53197d5f6e7"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3729b8db02063da50eeb3db88a27670d85953afb9a7f14c213ac9e3dca93034b"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39a1cd5d383b37285641d5a7a86be85274466ae336a61b51117155936529f9b3"},
-    {file = "pymongo-4.6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7b0e6361754ac596cd16bfc6ed49f69ffcd9b60b7bc4bcd3ea65c6a83475e4ff"},
-    {file = "pymongo-4.6.0-cp38-cp38-win32.whl", hash = "sha256:806e094e9e85d8badc978af8c95b69c556077f11844655cb8cd2d1758769e521"},
-    {file = "pymongo-4.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1394c4737b325166a65ae7c145af1ebdb9fb153ebedd37cf91d676313e4a67b8"},
-    {file = "pymongo-4.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a8273e1abbcff1d7d29cbbb1ea7e57d38be72f1af3c597c854168508b91516c2"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:e16ade71c93f6814d095d25cd6d28a90d63511ea396bd96e9ffcb886b278baaa"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:325701ae7b56daa5b0692305b7cb505ca50f80a1288abb32ff420a8a209b01ca"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:cc94f9fea17a5af8cf1a343597711a26b0117c0b812550d99934acb89d526ed2"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:21812453354b151200034750cd30b0140e82ec2a01fd4357390f67714a1bfbde"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:0634994b026336195778e5693583c060418d4ab453eff21530422690a97e1ee8"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ad4f66fbb893b55f96f03020e67dcab49ffde0177c6565ccf9dec4fdf974eb61"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:2703a9f8f5767986b4f51c259ff452cc837c5a83c8ed5f5361f6e49933743b2f"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bafea6061d63059d8bc2ffc545e2f049221c8a4457d236c5cd6a66678673eab"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f28ae33dc5a0b9cee06e95fd420e42155d83271ab75964baf747ce959cac5f52"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d16a534da0e39785687b7295e2fcf9a339f4a20689024983d11afaa4657f8507"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef67fedd863ffffd4adfd46d9d992b0f929c7f61a8307366d664d93517f2c78e"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05c30fd35cc97f14f354916b45feea535d59060ef867446b5c3c7f9b609dd5dc"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1c63e3a2e8fb815c4b1f738c284a4579897e37c3cfd95fdb199229a1ccfb638a"},
-    {file = "pymongo-4.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e5e193f89f4f8c1fe273f9a6e6df915092c9f2af6db2d1afb8bd53855025c11f"},
-    {file = "pymongo-4.6.0-cp39-cp39-win32.whl", hash = "sha256:a09bfb51953930e7e838972ddf646c5d5f984992a66d79da6ba7f6a8d8a890cd"},
-    {file = "pymongo-4.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:107a234dc55affc5802acb3b6d83cbb8c87355b38a9457fcd8806bdeb8bce161"},
-    {file = "pymongo-4.6.0.tar.gz", hash = "sha256:fb1c56d891f9e34303c451998ef62ba52659648bb0d75b03c5e4ac223a3342c2"},
+    {file = "pymongo-4.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2d4fa1b01fa7e5b7bb8d312e3542e211b320eb7a4e3d8dc884327039d93cb9e0"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux1_i686.whl", hash = "sha256:dfcd2b9f510411de615ccedd47462dae80e82fdc09fe9ab0f0f32f11cf57eeb5"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:3e33064f1984db412b34d51496f4ea785a9cff621c67de58e09fb28da6468a52"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux2014_i686.whl", hash = "sha256:33faa786cc907de63f745f587e9879429b46033d7d97a7b84b37f4f8f47b9b32"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux2014_ppc64le.whl", hash = "sha256:76a262c41c1a7cbb84a3b11976578a7eb8e788c4b7bfbd15c005fb6ca88e6e50"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux2014_s390x.whl", hash = "sha256:0f4b125b46fe377984fbaecf2af40ed48b05a4b7676a2ff98999f2016d66b3ec"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:40d5f6e853ece9bfc01e9129b228df446f49316a4252bb1fbfae5c3c9dedebad"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:152259f0f1a60f560323aacf463a3642a65a25557683f49cfa08c8f1ecb2395a"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d64878d1659d2a5bdfd0f0a4d79bafe68653c573681495e424ab40d7b6d6d41"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f1bb3a62395ffe835dbef3a1cbff48fbcce709c78bd1f52e896aee990928432b"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe48f50fb6348511a3268a893bfd4ab5f263f5ac220782449d03cd05964d1ae7"},
+    {file = "pymongo-4.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7591a3beea6a9a4fa3080d27d193b41f631130e3ffa76b88c9ccea123f26dc59"},
+    {file = "pymongo-4.5.0-cp310-cp310-win32.whl", hash = "sha256:3a7166d57dc74d679caa7743b8ecf7dc3a1235a9fd178654dddb2b2a627ae229"},
+    {file = "pymongo-4.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:21b953da14549ff62ea4ae20889c71564328958cbdf880c64a92a48dda4c9c53"},
+    {file = "pymongo-4.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ead4f19d0257a756b21ac2e0e85a37a7245ddec36d3b6008d5bfe416525967dc"},
+    {file = "pymongo-4.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aff6279e405dc953eeb540ab061e72c03cf38119613fce183a8e94f31be608f"},
+    {file = "pymongo-4.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd4c8d6aa91d3e35016847cbe8d73106e3d1c9a4e6578d38e2c346bfe8edb3ca"},
+    {file = "pymongo-4.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08819da7864f9b8d4a95729b2bea5fffed08b63d3b9c15b4fea47de655766cf5"},
+    {file = "pymongo-4.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a253b765b7cbc4209f1d8ee16c7287c4268d3243070bf72d7eec5aa9dfe2a2c2"},
+    {file = "pymongo-4.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8027c9063579083746147cf401a7072a9fb6829678076cd3deff28bb0e0f50c8"},
+    {file = "pymongo-4.5.0-cp311-cp311-win32.whl", hash = "sha256:9d2346b00af524757576cc2406414562cced1d4349c92166a0ee377a2a483a80"},
+    {file = "pymongo-4.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:c3c3525ea8658ee1192cdddf5faf99b07ebe1eeaa61bf32821126df6d1b8072b"},
+    {file = "pymongo-4.5.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e5a27f348909235a106a3903fc8e70f573d89b41d723a500869c6569a391cff7"},
+    {file = "pymongo-4.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9a9a39b7cac81dca79fca8c2a6479ef4c7b1aab95fad7544cc0e8fd943595a2"},
+    {file = "pymongo-4.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:496c9cbcb4951183d4503a9d7d2c1e3694aab1304262f831d5e1917e60386036"},
+    {file = "pymongo-4.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23cc6d7eb009c688d70da186b8f362d61d5dd1a2c14a45b890bd1e91e9c451f2"},
+    {file = "pymongo-4.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fff7d17d30b2cd45afd654b3fc117755c5d84506ed25fda386494e4e0a3416e1"},
+    {file = "pymongo-4.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6422b6763b016f2ef2beedded0e546d6aa6ba87910f9244d86e0ac7690f75c96"},
+    {file = "pymongo-4.5.0-cp312-cp312-win32.whl", hash = "sha256:77cfff95c1fafd09e940b3fdcb7b65f11442662fad611d0e69b4dd5d17a81c60"},
+    {file = "pymongo-4.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:e57d859b972c75ee44ea2ef4758f12821243e99de814030f69a3decb2aa86807"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2b0176f9233a5927084c79ff80b51bd70bfd57e4f3d564f50f80238e797f0c8a"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:89b3f2da57a27913d15d2a07d58482f33d0a5b28abd20b8e643ab4d625e36257"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:5caee7bd08c3d36ec54617832b44985bd70c4cbd77c5b313de6f7fce0bb34f93"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:1d40ad09d9f5e719bc6f729cc6b17f31c0b055029719406bd31dde2f72fca7e7"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:076afa0a4a96ca9f77fec0e4a0d241200b3b3a1766f8d7be9a905ecf59a7416b"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:3fa3648e4f1e63ddfe53563ee111079ea3ab35c3b09cd25bc22dadc8269a495f"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:44ee985194c426ddf781fa784f31ffa29cb59657b2dba09250a4245431847d73"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b33c17d9e694b66d7e96977e9e56df19d662031483efe121a24772a44ccbbc7e"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d79ae3bb1ff041c0db56f138c88ce1dfb0209f3546d8d6e7c3f74944ecd2439"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d67225f05f6ea27c8dc57f3fa6397c96d09c42af69d46629f71e82e66d33fa4f"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41771b22dd2822540f79a877c391283d4e6368125999a5ec8beee1ce566f3f82"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a1f26bc1f5ce774d99725773901820dfdfd24e875028da4a0252a5b48dcab5c"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3236cf89d69679eaeb9119c840f5c7eb388a2110b57af6bb6baf01a1da387c18"},
+    {file = "pymongo-4.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e1f61355c821e870fb4c17cdb318669cfbcf245a291ce5053b41140870c3e5cc"},
+    {file = "pymongo-4.5.0-cp37-cp37m-win32.whl", hash = "sha256:49dce6957598975d8b8d506329d2a3a6c4aee911fa4bbcf5e52ffc6897122950"},
+    {file = "pymongo-4.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f2227a08b091bd41df5aadee0a5037673f691e2aa000e1968b1ea2342afc6880"},
+    {file = "pymongo-4.5.0-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:435228d3c16a375274ac8ab9c4f9aef40c5e57ddb8296e20ecec9e2461da1017"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8e559116e4128630ad3b7e788e2e5da81cbc2344dee246af44471fa650486a70"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:840eaf30ccac122df260b6005f9dfae4ac287c498ee91e3e90c56781614ca238"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b4fe46b58010115514b842c669a0ed9b6a342017b15905653a5b1724ab80917f"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:a8127437ebc196a6f5e8fddd746bd0903a400dc6b5ae35df672dd1ccc7170a2a"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:2988ef5e6b360b3ff1c6d55c53515499de5f48df31afd9f785d788cdacfbe2d3"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:e249190b018d63c901678053b4a43e797ca78b93fb6d17633e3567d4b3ec6107"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1240edc1a448d4ada4bf1a0e55550b6292420915292408e59159fd8bbdaf8f63"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6d2a56fc2354bb6378f3634402eec788a8f3facf0b3e7d468db5f2b5a78d763"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a0aade2b11dc0c326ccd429ee4134d2d47459ff68d449c6d7e01e74651bd255"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:74c0da07c04d0781490b2915e7514b1adb265ef22af039a947988c331ee7455b"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3754acbd7efc7f1b529039fcffc092a15e1cf045e31f22f6c9c5950c613ec4d"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:631492573a1bef2f74f9ac0f9d84e0ce422c251644cd81207530af4aa2ee1980"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e2654d1278384cff75952682d17c718ecc1ad1d6227bb0068fd826ba47d426a5"},
+    {file = "pymongo-4.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:168172ef7856e20ec024fe2a746bfa895c88b32720138e6438fd765ebd2b62dd"},
+    {file = "pymongo-4.5.0-cp38-cp38-win32.whl", hash = "sha256:b25f7bea162b3dbec6d33c522097ef81df7c19a9300722fa6853f5b495aecb77"},
+    {file = "pymongo-4.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:b520aafc6cb148bac09ccf532f52cbd31d83acf4d3e5070d84efe3c019a1adbf"},
+    {file = "pymongo-4.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8543253adfaa0b802bfa88386db1009c6ebb7d5684d093ee4edc725007553d21"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:bc5d8c3647b8ae28e4312f1492b8f29deebd31479cd3abaa989090fb1d66db83"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:505f8519c4c782a61d94a17b0da50be639ec462128fbd10ab0a34889218fdee3"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:53f2dda54d76a98b43a410498bd12f6034b2a14b6844ca08513733b2b20b7ad8"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:9c04b9560872fa9a91251030c488e0a73bce9321a70f991f830c72b3f8115d0d"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:58a63a26a1e3dc481dd3a18d6d9f8bd1d576cd1ffe0d479ba7dd38b0aeb20066"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:f076b779aa3dc179aa3ed861be063a313ed4e48ae9f6a8370a9b1295d4502111"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:1b1d7d9aabd8629a31d63cd106d56cca0e6420f38e50563278b520f385c0d86e"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37df8f6006286a5896d1cbc3efb8471ced42e3568d38e6cb00857277047b0d63"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:56320c401f544d762fc35766936178fbceb1d9261cd7b24fbfbc8fb6f67aa8a5"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bbd705d5f3c3d1ff2d169e418bb789ff07ab3c70d567cc6ba6b72b04b9143481"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80a167081c75cf66b32f30e2f1eaee9365af935a86dbd76788169911bed9b5d5"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c42748ccc451dfcd9cef6c5447a7ab727351fd9747ad431db5ebb18a9b78a4d"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cf62da7a4cdec9a4b2981fcbd5e08053edffccf20e845c0b6ec1e77eb7fab61d"},
+    {file = "pymongo-4.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b5bbb87fa0511bd313d9a2c90294c88db837667c2bda2ea3fa7a35b59fd93b1f"},
+    {file = "pymongo-4.5.0-cp39-cp39-win32.whl", hash = "sha256:465fd5b040206f8bce7016b01d7e7f79d2fcd7c2b8e41791be9632a9df1b4999"},
+    {file = "pymongo-4.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:63d8019eee119df308a075b8a7bdb06d4720bf791e2b73d5ab0e7473c115d79c"},
+    {file = "pymongo-4.5.0.tar.gz", hash = "sha256:681f252e43b3ef054ca9161635f81b730f4d8cadd28b3f2b2004f5a72f853982"},
 ]
 
 [package.dependencies]
@@ -2453,25 +2546,24 @@ encryption = ["certifi", "pymongo[aws]", "pymongocrypt (>=1.6.0,<2.0.0)"]
 gssapi = ["pykerberos", "winkerberos (>=0.5.0)"]
 ocsp = ["certifi", "cryptography (>=2.5)", "pyopenssl (>=17.2.0)", "requests (<3.0.0)", "service-identity (>=18.1.0)"]
 snappy = ["python-snappy"]
-test = ["pytest (>=7)"]
 zstd = ["zstandard"]
 
 [[package]]
 name = "pyopenssl"
-version = "23.3.0"
+version = "23.2.0"
 description = "Python wrapper module around the OpenSSL library"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "pyOpenSSL-23.3.0-py3-none-any.whl", hash = "sha256:6756834481d9ed5470f4a9393455154bc92fe7a64b7bc6ee2c804e78c52099b2"},
-    {file = "pyOpenSSL-23.3.0.tar.gz", hash = "sha256:6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12"},
+    {file = "pyOpenSSL-23.2.0-py3-none-any.whl", hash = "sha256:24f0dc5227396b3e831f4c7f602b950a5e9833d292c8e4a2e06b709292806ae2"},
+    {file = "pyOpenSSL-23.2.0.tar.gz", hash = "sha256:276f931f55a452e7dea69c7173e984eb2a4407ce413c918aa34b55f82f9b8bac"},
 ]
 
 [package.dependencies]
-cryptography = ">=41.0.5,<42"
+cryptography = ">=38.0.0,<40.0.0 || >40.0.0,<40.0.1 || >40.0.1,<42"
 
 [package.extras]
-docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx-rtd-theme"]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
@@ -2497,13 +2589,13 @@ image = ["Pillow"]
 
 [[package]]
 name = "pyright"
-version = "1.1.334"
+version = "1.1.329"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.334-py3-none-any.whl", hash = "sha256:dcb13e8358e021189672c4d6ebcad192ab061e4c7225036973ec493183c6da68"},
-    {file = "pyright-1.1.334.tar.gz", hash = "sha256:3adaf10f1f4209575dc022f9c897f7ef024639b7ea5b3cbe49302147e6949cd4"},
+    {file = "pyright-1.1.329-py3-none-any.whl", hash = "sha256:c16f88a7ac14ddd0513e62fec56d69c37e3c6b412161ad16aa23a9c7e3dabaf4"},
+    {file = "pyright-1.1.329.tar.gz", hash = "sha256:5baf82ff5ecb8c8b3ac400e8536348efbde0b94a09d83d5b440c0d143fd151a8"},
 ]
 
 [package.dependencies]
@@ -2515,13 +2607,13 @@ dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
+    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
 ]
 
 [package.dependencies]
@@ -2555,13 +2647,13 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtuale
 
 [[package]]
 name = "pytest-mock"
-version = "3.12.0"
+version = "3.11.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-mock-3.12.0.tar.gz", hash = "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"},
-    {file = "pytest_mock-3.12.0-py3-none-any.whl", hash = "sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f"},
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
 ]
 
 [package.dependencies]
@@ -2762,99 +2854,99 @@ rpds-py = ">=0.7.0"
 
 [[package]]
 name = "regex"
-version = "2023.10.3"
+version = "2023.8.8"
 description = "Alternative regular expression module, to replace re."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "regex-2023.10.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4c34d4f73ea738223a094d8e0ffd6d2c1a1b4c175da34d6b0de3d8d69bee6bcc"},
-    {file = "regex-2023.10.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a8f4e49fc3ce020f65411432183e6775f24e02dff617281094ba6ab079ef0915"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cd1bccf99d3ef1ab6ba835308ad85be040e6a11b0977ef7ea8c8005f01a3c29"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81dce2ddc9f6e8f543d94b05d56e70d03a0774d32f6cca53e978dc01e4fc75b8"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c6b4d23c04831e3ab61717a707a5d763b300213db49ca680edf8bf13ab5d91b"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c15ad0aee158a15e17e0495e1e18741573d04eb6da06d8b84af726cfc1ed02ee"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6239d4e2e0b52c8bd38c51b760cd870069f0bdf99700a62cd509d7a031749a55"},
-    {file = "regex-2023.10.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4a8bf76e3182797c6b1afa5b822d1d5802ff30284abe4599e1247be4fd6b03be"},
-    {file = "regex-2023.10.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d9c727bbcf0065cbb20f39d2b4f932f8fa1631c3e01fcedc979bd4f51fe051c5"},
-    {file = "regex-2023.10.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3ccf2716add72f80714b9a63899b67fa711b654be3fcdd34fa391d2d274ce767"},
-    {file = "regex-2023.10.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:107ac60d1bfdc3edb53be75e2a52aff7481b92817cfdddd9b4519ccf0e54a6ff"},
-    {file = "regex-2023.10.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:00ba3c9818e33f1fa974693fb55d24cdc8ebafcb2e4207680669d8f8d7cca79a"},
-    {file = "regex-2023.10.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f0a47efb1dbef13af9c9a54a94a0b814902e547b7f21acb29434504d18f36e3a"},
-    {file = "regex-2023.10.3-cp310-cp310-win32.whl", hash = "sha256:36362386b813fa6c9146da6149a001b7bd063dabc4d49522a1f7aa65b725c7ec"},
-    {file = "regex-2023.10.3-cp310-cp310-win_amd64.whl", hash = "sha256:c65a3b5330b54103e7d21cac3f6bf3900d46f6d50138d73343d9e5b2900b2353"},
-    {file = "regex-2023.10.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90a79bce019c442604662d17bf69df99090e24cdc6ad95b18b6725c2988a490e"},
-    {file = "regex-2023.10.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c7964c2183c3e6cce3f497e3a9f49d182e969f2dc3aeeadfa18945ff7bdd7051"},
-    {file = "regex-2023.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ef80829117a8061f974b2fda8ec799717242353bff55f8a29411794d635d964"},
-    {file = "regex-2023.10.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5addc9d0209a9afca5fc070f93b726bf7003bd63a427f65ef797a931782e7edc"},
-    {file = "regex-2023.10.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c148bec483cc4b421562b4bcedb8e28a3b84fcc8f0aa4418e10898f3c2c0eb9b"},
-    {file = "regex-2023.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d1f21af4c1539051049796a0f50aa342f9a27cde57318f2fc41ed50b0dbc4ac"},
-    {file = "regex-2023.10.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b9ac09853b2a3e0d0082104036579809679e7715671cfbf89d83c1cb2a30f58"},
-    {file = "regex-2023.10.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ebedc192abbc7fd13c5ee800e83a6df252bec691eb2c4bedc9f8b2e2903f5e2a"},
-    {file = "regex-2023.10.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d8a993c0a0ffd5f2d3bda23d0cd75e7086736f8f8268de8a82fbc4bd0ac6791e"},
-    {file = "regex-2023.10.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:be6b7b8d42d3090b6c80793524fa66c57ad7ee3fe9722b258aec6d0672543fd0"},
-    {file = "regex-2023.10.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4023e2efc35a30e66e938de5aef42b520c20e7eda7bb5fb12c35e5d09a4c43f6"},
-    {file = "regex-2023.10.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d47840dc05e0ba04fe2e26f15126de7c755496d5a8aae4a08bda4dd8d646c54"},
-    {file = "regex-2023.10.3-cp311-cp311-win32.whl", hash = "sha256:9145f092b5d1977ec8c0ab46e7b3381b2fd069957b9862a43bd383e5c01d18c2"},
-    {file = "regex-2023.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:b6104f9a46bd8743e4f738afef69b153c4b8b592d35ae46db07fc28ae3d5fb7c"},
-    {file = "regex-2023.10.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bff507ae210371d4b1fe316d03433ac099f184d570a1a611e541923f78f05037"},
-    {file = "regex-2023.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be5e22bbb67924dea15039c3282fa4cc6cdfbe0cbbd1c0515f9223186fc2ec5f"},
-    {file = "regex-2023.10.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a992f702c9be9c72fa46f01ca6e18d131906a7180950958f766c2aa294d4b41"},
-    {file = "regex-2023.10.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7434a61b158be563c1362d9071358f8ab91b8d928728cd2882af060481244c9e"},
-    {file = "regex-2023.10.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c2169b2dcabf4e608416f7f9468737583ce5f0a6e8677c4efbf795ce81109d7c"},
-    {file = "regex-2023.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9e908ef5889cda4de038892b9accc36d33d72fb3e12c747e2799a0e806ec841"},
-    {file = "regex-2023.10.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12bd4bc2c632742c7ce20db48e0d99afdc05e03f0b4c1af90542e05b809a03d9"},
-    {file = "regex-2023.10.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bc72c231f5449d86d6c7d9cc7cd819b6eb30134bb770b8cfdc0765e48ef9c420"},
-    {file = "regex-2023.10.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bce8814b076f0ce5766dc87d5a056b0e9437b8e0cd351b9a6c4e1134a7dfbda9"},
-    {file = "regex-2023.10.3-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:ba7cd6dc4d585ea544c1412019921570ebd8a597fabf475acc4528210d7c4a6f"},
-    {file = "regex-2023.10.3-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b0c7d2f698e83f15228ba41c135501cfe7d5740181d5903e250e47f617eb4292"},
-    {file = "regex-2023.10.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5a8f91c64f390ecee09ff793319f30a0f32492e99f5dc1c72bc361f23ccd0a9a"},
-    {file = "regex-2023.10.3-cp312-cp312-win32.whl", hash = "sha256:ad08a69728ff3c79866d729b095872afe1e0557251da4abb2c5faff15a91d19a"},
-    {file = "regex-2023.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:39cdf8d141d6d44e8d5a12a8569d5a227f645c87df4f92179bd06e2e2705e76b"},
-    {file = "regex-2023.10.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4a3ee019a9befe84fa3e917a2dd378807e423d013377a884c1970a3c2792d293"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76066d7ff61ba6bf3cb5efe2428fc82aac91802844c022d849a1f0f53820502d"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfe50b61bab1b1ec260fa7cd91106fa9fece57e6beba05630afe27c71259c59b"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fd88f373cb71e6b59b7fa597e47e518282455c2734fd4306a05ca219a1991b0"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3ab05a182c7937fb374f7e946f04fb23a0c0699c0450e9fb02ef567412d2fa3"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dac37cf08fcf2094159922edc7a2784cfcc5c70f8354469f79ed085f0328ebdf"},
-    {file = "regex-2023.10.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e54ddd0bb8fb626aa1f9ba7b36629564544954fff9669b15da3610c22b9a0991"},
-    {file = "regex-2023.10.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3367007ad1951fde612bf65b0dffc8fd681a4ab98ac86957d16491400d661302"},
-    {file = "regex-2023.10.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:16f8740eb6dbacc7113e3097b0a36065a02e37b47c936b551805d40340fb9971"},
-    {file = "regex-2023.10.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:f4f2ca6df64cbdd27f27b34f35adb640b5d2d77264228554e68deda54456eb11"},
-    {file = "regex-2023.10.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:39807cbcbe406efca2a233884e169d056c35aa7e9f343d4e78665246a332f597"},
-    {file = "regex-2023.10.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7eece6fbd3eae4a92d7c748ae825cbc1ee41a89bb1c3db05b5578ed3cfcfd7cb"},
-    {file = "regex-2023.10.3-cp37-cp37m-win32.whl", hash = "sha256:ce615c92d90df8373d9e13acddd154152645c0dc060871abf6bd43809673d20a"},
-    {file = "regex-2023.10.3-cp37-cp37m-win_amd64.whl", hash = "sha256:0f649fa32fe734c4abdfd4edbb8381c74abf5f34bc0b3271ce687b23729299ed"},
-    {file = "regex-2023.10.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9b98b7681a9437262947f41c7fac567c7e1f6eddd94b0483596d320092004533"},
-    {file = "regex-2023.10.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:91dc1d531f80c862441d7b66c4505cd6ea9d312f01fb2f4654f40c6fdf5cc37a"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82fcc1f1cc3ff1ab8a57ba619b149b907072e750815c5ba63e7aa2e1163384a4"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7979b834ec7a33aafae34a90aad9f914c41fd6eaa8474e66953f3f6f7cbd4368"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef71561f82a89af6cfcbee47f0fabfdb6e63788a9258e913955d89fdd96902ab"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd829712de97753367153ed84f2de752b86cd1f7a88b55a3a775eb52eafe8a94"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00e871d83a45eee2f8688d7e6849609c2ca2a04a6d48fba3dff4deef35d14f07"},
-    {file = "regex-2023.10.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:706e7b739fdd17cb89e1fbf712d9dc21311fc2333f6d435eac2d4ee81985098c"},
-    {file = "regex-2023.10.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cc3f1c053b73f20c7ad88b0d1d23be7e7b3901229ce89f5000a8399746a6e039"},
-    {file = "regex-2023.10.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6f85739e80d13644b981a88f529d79c5bdf646b460ba190bffcaf6d57b2a9863"},
-    {file = "regex-2023.10.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:741ba2f511cc9626b7561a440f87d658aabb3d6b744a86a3c025f866b4d19e7f"},
-    {file = "regex-2023.10.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e77c90ab5997e85901da85131fd36acd0ed2221368199b65f0d11bca44549711"},
-    {file = "regex-2023.10.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:979c24cbefaf2420c4e377ecd1f165ea08cc3d1fbb44bdc51bccbbf7c66a2cb4"},
-    {file = "regex-2023.10.3-cp38-cp38-win32.whl", hash = "sha256:58837f9d221744d4c92d2cf7201c6acd19623b50c643b56992cbd2b745485d3d"},
-    {file = "regex-2023.10.3-cp38-cp38-win_amd64.whl", hash = "sha256:c55853684fe08d4897c37dfc5faeff70607a5f1806c8be148f1695be4a63414b"},
-    {file = "regex-2023.10.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2c54e23836650bdf2c18222c87f6f840d4943944146ca479858404fedeb9f9af"},
-    {file = "regex-2023.10.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:69c0771ca5653c7d4b65203cbfc5e66db9375f1078689459fe196fe08b7b4930"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ac965a998e1388e6ff2e9781f499ad1eaa41e962a40d11c7823c9952c77123e"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c0e8fae5b27caa34177bdfa5a960c46ff2f78ee2d45c6db15ae3f64ecadde14"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6c56c3d47da04f921b73ff9415fbaa939f684d47293f071aa9cbb13c94afc17d"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ef1e014eed78ab650bef9a6a9cbe50b052c0aebe553fb2881e0453717573f52"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d29338556a59423d9ff7b6eb0cb89ead2b0875e08fe522f3e068b955c3e7b59b"},
-    {file = "regex-2023.10.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9c6d0ced3c06d0f183b73d3c5920727268d2201aa0fe6d55c60d68c792ff3588"},
-    {file = "regex-2023.10.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:994645a46c6a740ee8ce8df7911d4aee458d9b1bc5639bc968226763d07f00fa"},
-    {file = "regex-2023.10.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:66e2fe786ef28da2b28e222c89502b2af984858091675044d93cb50e6f46d7af"},
-    {file = "regex-2023.10.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:11175910f62b2b8c055f2b089e0fedd694fe2be3941b3e2633653bc51064c528"},
-    {file = "regex-2023.10.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:06e9abc0e4c9ab4779c74ad99c3fc10d3967d03114449acc2c2762ad4472b8ca"},
-    {file = "regex-2023.10.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:fb02e4257376ae25c6dd95a5aec377f9b18c09be6ebdefa7ad209b9137b73d48"},
-    {file = "regex-2023.10.3-cp39-cp39-win32.whl", hash = "sha256:3b2c3502603fab52d7619b882c25a6850b766ebd1b18de3df23b2f939360e1bd"},
-    {file = "regex-2023.10.3-cp39-cp39-win_amd64.whl", hash = "sha256:adbccd17dcaff65704c856bd29951c58a1bd4b2b0f8ad6b826dbd543fe740988"},
-    {file = "regex-2023.10.3.tar.gz", hash = "sha256:3fef4f844d2290ee0ba57addcec17eec9e3df73f10a2748485dfd6a3a188cc0f"},
+    {file = "regex-2023.8.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:88900f521c645f784260a8d346e12a1590f79e96403971241e64c3a265c8ecdb"},
+    {file = "regex-2023.8.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3611576aff55918af2697410ff0293d6071b7e00f4b09e005d614686ac4cd57c"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8a0ccc8f2698f120e9e5742f4b38dc944c38744d4bdfc427616f3a163dd9de5"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c662a4cbdd6280ee56f841f14620787215a171c4e2d1744c9528bed8f5816c96"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cf0633e4a1b667bfe0bb10b5e53fe0d5f34a6243ea2530eb342491f1adf4f739"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:551ad543fa19e94943c5b2cebc54c73353ffff08228ee5f3376bd27b3d5b9800"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54de2619f5ea58474f2ac211ceea6b615af2d7e4306220d4f3fe690c91988a61"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5ec4b3f0aebbbe2fc0134ee30a791af522a92ad9f164858805a77442d7d18570"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3ae646c35cb9f820491760ac62c25b6d6b496757fda2d51be429e0e7b67ae0ab"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ca339088839582d01654e6f83a637a4b8194d0960477b9769d2ff2cfa0fa36d2"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:d9b6627408021452dcd0d2cdf8da0534e19d93d070bfa8b6b4176f99711e7f90"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:bd3366aceedf274f765a3a4bc95d6cd97b130d1dda524d8f25225d14123c01db"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7aed90a72fc3654fba9bc4b7f851571dcc368120432ad68b226bd593f3f6c0b7"},
+    {file = "regex-2023.8.8-cp310-cp310-win32.whl", hash = "sha256:80b80b889cb767cc47f31d2b2f3dec2db8126fbcd0cff31b3925b4dc6609dcdb"},
+    {file = "regex-2023.8.8-cp310-cp310-win_amd64.whl", hash = "sha256:b82edc98d107cbc7357da7a5a695901b47d6eb0420e587256ba3ad24b80b7d0b"},
+    {file = "regex-2023.8.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1e7d84d64c84ad97bf06f3c8cb5e48941f135ace28f450d86af6b6512f1c9a71"},
+    {file = "regex-2023.8.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce0f9fbe7d295f9922c0424a3637b88c6c472b75eafeaff6f910494a1fa719ef"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06c57e14ac723b04458df5956cfb7e2d9caa6e9d353c0b4c7d5d54fcb1325c46"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7a9aaa5a1267125eef22cef3b63484c3241aaec6f48949b366d26c7250e0357"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b7408511fca48a82a119d78a77c2f5eb1b22fe88b0d2450ed0756d194fe7a9a"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14dc6f2d88192a67d708341f3085df6a4f5a0c7b03dec08d763ca2cd86e9f559"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48c640b99213643d141550326f34f0502fedb1798adb3c9eb79650b1ecb2f177"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0085da0f6c6393428bf0d9c08d8b1874d805bb55e17cb1dfa5ddb7cfb11140bf"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:964b16dcc10c79a4a2be9f1273fcc2684a9eedb3906439720598029a797b46e6"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7ce606c14bb195b0e5108544b540e2c5faed6843367e4ab3deb5c6aa5e681208"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:40f029d73b10fac448c73d6eb33d57b34607f40116e9f6e9f0d32e9229b147d7"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3b8e6ea6be6d64104d8e9afc34c151926f8182f84e7ac290a93925c0db004bfd"},
+    {file = "regex-2023.8.8-cp311-cp311-win32.whl", hash = "sha256:942f8b1f3b223638b02df7df79140646c03938d488fbfb771824f3d05fc083a8"},
+    {file = "regex-2023.8.8-cp311-cp311-win_amd64.whl", hash = "sha256:51d8ea2a3a1a8fe4f67de21b8b93757005213e8ac3917567872f2865185fa7fb"},
+    {file = "regex-2023.8.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e951d1a8e9963ea51efd7f150450803e3b95db5939f994ad3d5edac2b6f6e2b4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:704f63b774218207b8ccc6c47fcef5340741e5d839d11d606f70af93ee78e4d4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22283c769a7b01c8ac355d5be0715bf6929b6267619505e289f792b01304d898"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91129ff1bb0619bc1f4ad19485718cc623a2dc433dff95baadbf89405c7f6b57"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de35342190deb7b866ad6ba5cbcccb2d22c0487ee0cbb251efef0843d705f0d4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b993b6f524d1e274a5062488a43e3f9f8764ee9745ccd8e8193df743dbe5ee61"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3026cbcf11d79095a32d9a13bbc572a458727bd5b1ca332df4a79faecd45281c"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:293352710172239bf579c90a9864d0df57340b6fd21272345222fb6371bf82b3"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d909b5a3fff619dc7e48b6b1bedc2f30ec43033ba7af32f936c10839e81b9217"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:3d370ff652323c5307d9c8e4c62efd1956fb08051b0e9210212bc51168b4ff56"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:b076da1ed19dc37788f6a934c60adf97bd02c7eea461b73730513921a85d4235"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e9941a4ada58f6218694f382e43fdd256e97615db9da135e77359da257a7168b"},
+    {file = "regex-2023.8.8-cp36-cp36m-win32.whl", hash = "sha256:a8c65c17aed7e15a0c824cdc63a6b104dfc530f6fa8cb6ac51c437af52b481c7"},
+    {file = "regex-2023.8.8-cp36-cp36m-win_amd64.whl", hash = "sha256:aadf28046e77a72f30dcc1ab185639e8de7f4104b8cb5c6dfa5d8ed860e57236"},
+    {file = "regex-2023.8.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:423adfa872b4908843ac3e7a30f957f5d5282944b81ca0a3b8a7ccbbfaa06103"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ae594c66f4a7e1ea67232a0846649a7c94c188d6c071ac0210c3e86a5f92109"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e51c80c168074faa793685656c38eb7a06cbad7774c8cbc3ea05552d615393d8"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09b7f4c66aa9d1522b06e31a54f15581c37286237208df1345108fcf4e050c18"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e73e5243af12d9cd6a9d6a45a43570dbe2e5b1cdfc862f5ae2b031e44dd95a8"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:941460db8fe3bd613db52f05259c9336f5a47ccae7d7def44cc277184030a116"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f0ccf3e01afeb412a1a9993049cb160d0352dba635bbca7762b2dc722aa5742a"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:2e9216e0d2cdce7dbc9be48cb3eacb962740a09b011a116fd7af8c832ab116ca"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5cd9cd7170459b9223c5e592ac036e0704bee765706445c353d96f2890e816c8"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:4873ef92e03a4309b3ccd8281454801b291b689f6ad45ef8c3658b6fa761d7ac"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:239c3c2a339d3b3ddd51c2daef10874410917cd2b998f043c13e2084cb191684"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:1005c60ed7037be0d9dea1f9c53cc42f836188227366370867222bda4c3c6bd7"},
+    {file = "regex-2023.8.8-cp37-cp37m-win32.whl", hash = "sha256:e6bd1e9b95bc5614a7a9c9c44fde9539cba1c823b43a9f7bc11266446dd568e3"},
+    {file = "regex-2023.8.8-cp37-cp37m-win_amd64.whl", hash = "sha256:9a96edd79661e93327cfeac4edec72a4046e14550a1d22aa0dd2e3ca52aec921"},
+    {file = "regex-2023.8.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2181c20ef18747d5f4a7ea513e09ea03bdd50884a11ce46066bb90fe4213675"},
+    {file = "regex-2023.8.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a2ad5add903eb7cdde2b7c64aaca405f3957ab34f16594d2b78d53b8b1a6a7d6"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9233ac249b354c54146e392e8a451e465dd2d967fc773690811d3a8c240ac601"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:920974009fb37b20d32afcdf0227a2e707eb83fe418713f7a8b7de038b870d0b"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2b6c5dfe0929b6c23dde9624483380b170b6e34ed79054ad131b20203a1a63"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96979d753b1dc3b2169003e1854dc67bfc86edf93c01e84757927f810b8c3c93"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ae54a338191e1356253e7883d9d19f8679b6143703086245fb14d1f20196be9"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2162ae2eb8b079622176a81b65d486ba50b888271302190870b8cc488587d280"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c884d1a59e69e03b93cf0dfee8794c63d7de0ee8f7ffb76e5f75be8131b6400a"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf9273e96f3ee2ac89ffcb17627a78f78e7516b08f94dc435844ae72576a276e"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:83215147121e15d5f3a45d99abeed9cf1fe16869d5c233b08c56cdf75f43a504"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3f7454aa427b8ab9101f3787eb178057c5250478e39b99540cfc2b889c7d0586"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0640913d2c1044d97e30d7c41728195fc37e54d190c5385eacb52115127b882"},
+    {file = "regex-2023.8.8-cp38-cp38-win32.whl", hash = "sha256:0c59122ceccb905a941fb23b087b8eafc5290bf983ebcb14d2301febcbe199c7"},
+    {file = "regex-2023.8.8-cp38-cp38-win_amd64.whl", hash = "sha256:c12f6f67495ea05c3d542d119d270007090bad5b843f642d418eb601ec0fa7be"},
+    {file = "regex-2023.8.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:82cd0a69cd28f6cc3789cc6adeb1027f79526b1ab50b1f6062bbc3a0ccb2dbc3"},
+    {file = "regex-2023.8.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bb34d1605f96a245fc39790a117ac1bac8de84ab7691637b26ab2c5efb8f228c"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:987b9ac04d0b38ef4f89fbc035e84a7efad9cdd5f1e29024f9289182c8d99e09"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9dd6082f4e2aec9b6a0927202c85bc1b09dcab113f97265127c1dc20e2e32495"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7eb95fe8222932c10d4436e7a6f7c99991e3fdd9f36c949eff16a69246dee2dc"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7098c524ba9f20717a56a8d551d2ed491ea89cbf37e540759ed3b776a4f8d6eb"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b694430b3f00eb02c594ff5a16db30e054c1b9589a043fe9174584c6efa8033"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b2aeab3895d778155054abea5238d0eb9a72e9242bd4b43f42fd911ef9a13470"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:988631b9d78b546e284478c2ec15c8a85960e262e247b35ca5eaf7ee22f6050a"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:67ecd894e56a0c6108ec5ab1d8fa8418ec0cff45844a855966b875d1039a2e34"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:14898830f0a0eb67cae2bbbc787c1a7d6e34ecc06fbd39d3af5fe29a4468e2c9"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:f2200e00b62568cfd920127782c61bc1c546062a879cdc741cfcc6976668dfcf"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9691a549c19c22d26a4f3b948071e93517bdf86e41b81d8c6ac8a964bb71e5a6"},
+    {file = "regex-2023.8.8-cp39-cp39-win32.whl", hash = "sha256:6ab2ed84bf0137927846b37e882745a827458689eb969028af8032b1b3dac78e"},
+    {file = "regex-2023.8.8-cp39-cp39-win_amd64.whl", hash = "sha256:5543c055d8ec7801901e1193a51570643d6a6ab8751b1f7dd9af71af467538bb"},
+    {file = "regex-2023.8.8.tar.gz", hash = "sha256:fcbdc5f2b0f1cd0f6a56cdb46fe41d2cce1e644e3b68832f3eeebc5fb0f7712e"},
 ]
 
 [[package]]
@@ -2912,22 +3004,23 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "responses"
-version = "0.24.0"
+version = "0.23.3"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "responses-0.24.0-py3-none-any.whl", hash = "sha256:060be153c270c06fa4d22c1ef8865fdef43902eb595204deeef736cddb62d353"},
-    {file = "responses-0.24.0.tar.gz", hash = "sha256:3df82f7d4dcd3e5f61498181aadb4381f291da25c7506c47fe8cb68ce29203e7"},
+    {file = "responses-0.23.3-py3-none-any.whl", hash = "sha256:e6fbcf5d82172fecc0aa1860fd91e58cbfd96cee5e96da5b63fa6eb3caa10dd3"},
+    {file = "responses-0.23.3.tar.gz", hash = "sha256:205029e1cb334c21cb4ec64fc7599be48b859a0fd381a42443cdd600bfe8b16a"},
 ]
 
 [package.dependencies]
 pyyaml = "*"
 requests = ">=2.30.0,<3.0"
+types-PyYAML = "*"
 urllib3 = ">=1.25.10,<3.0"
 
 [package.extras]
-tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-requests"]
 
 [[package]]
 name = "rfc3986"
@@ -2945,13 +3038,13 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rich"
-version = "13.6.0"
+version = "13.5.3"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.6.0-py3-none-any.whl", hash = "sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245"},
-    {file = "rich-13.6.0.tar.gz", hash = "sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"},
+    {file = "rich-13.5.3-py3-none-any.whl", hash = "sha256:9257b468badc3d347e146a4faa268ff229039d4c2d176ab0cffb4c4fbc73d5d9"},
+    {file = "rich-13.5.3.tar.gz", hash = "sha256:87b43e0543149efa1253f485cd845bb7ee54df16c9617b8a893650ab84b4acb6"},
 ]
 
 [package.dependencies]
@@ -2963,110 +3056,108 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "rpds-py"
-version = "0.12.0"
+version = "0.10.3"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "rpds_py-0.12.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:c694bee70ece3b232df4678448fdda245fd3b1bb4ba481fb6cd20e13bb784c46"},
-    {file = "rpds_py-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30e5ce9f501fb1f970e4a59098028cf20676dee64fc496d55c33e04bbbee097d"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d72a4315514e5a0b9837a086cb433b004eea630afb0cc129de76d77654a9606f"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eebaf8c76c39604d52852366249ab807fe6f7a3ffb0dd5484b9944917244cdbe"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a239303acb0315091d54c7ff36712dba24554993b9a93941cf301391d8a997ee"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ced40cdbb6dd47a032725a038896cceae9ce267d340f59508b23537f05455431"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c8c0226c71bd0ce9892eaf6afa77ae8f43a3d9313124a03df0b389c01f832de"},
-    {file = "rpds_py-0.12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b8e11715178f3608874508f08e990d3771e0b8c66c73eb4e183038d600a9b274"},
-    {file = "rpds_py-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5210a0018c7e09c75fa788648617ebba861ae242944111d3079034e14498223f"},
-    {file = "rpds_py-0.12.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:171d9a159f1b2f42a42a64a985e4ba46fc7268c78299272ceba970743a67ee50"},
-    {file = "rpds_py-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:57ec6baec231bb19bb5fd5fc7bae21231860a1605174b11585660236627e390e"},
-    {file = "rpds_py-0.12.0-cp310-none-win32.whl", hash = "sha256:7188ddc1a8887194f984fa4110d5a3d5b9b5cd35f6bafdff1b649049cbc0ce29"},
-    {file = "rpds_py-0.12.0-cp310-none-win_amd64.whl", hash = "sha256:1e04581c6117ad9479b6cfae313e212fe0dfa226ac727755f0d539cd54792963"},
-    {file = "rpds_py-0.12.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:0a38612d07a36138507d69646c470aedbfe2b75b43a4643f7bd8e51e52779624"},
-    {file = "rpds_py-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f12d69d568f5647ec503b64932874dade5a20255736c89936bf690951a5e79f5"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8a1d990dc198a6c68ec3d9a637ba1ce489b38cbfb65440a27901afbc5df575"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8c567c664fc2f44130a20edac73e0a867f8e012bf7370276f15c6adc3586c37c"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0e9e976e0dbed4f51c56db10831c9623d0fd67aac02853fe5476262e5a22acb7"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efddca2d02254a52078c35cadad34762adbae3ff01c6b0c7787b59d038b63e0d"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9e7f29c00577aff6b318681e730a519b235af292732a149337f6aaa4d1c5e31"},
-    {file = "rpds_py-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:389c0e38358fdc4e38e9995e7291269a3aead7acfcf8942010ee7bc5baee091c"},
-    {file = "rpds_py-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33ab498f9ac30598b6406e2be1b45fd231195b83d948ebd4bd77f337cb6a2bff"},
-    {file = "rpds_py-0.12.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d56b1cd606ba4cedd64bb43479d56580e147c6ef3f5d1c5e64203a1adab784a2"},
-    {file = "rpds_py-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fa73ed22c40a1bec98d7c93b5659cd35abcfa5a0a95ce876b91adbda170537c"},
-    {file = "rpds_py-0.12.0-cp311-none-win32.whl", hash = "sha256:dbc25baa6abb205766fb8606f8263b02c3503a55957fcb4576a6bb0a59d37d10"},
-    {file = "rpds_py-0.12.0-cp311-none-win_amd64.whl", hash = "sha256:c6b52b7028b547866c2413f614ee306c2d4eafdd444b1ff656bf3295bf1484aa"},
-    {file = "rpds_py-0.12.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:9620650c364c01ed5b497dcae7c3d4b948daeae6e1883ae185fef1c927b6b534"},
-    {file = "rpds_py-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2124f9e645a94ab7c853bc0a3644e0ca8ffbe5bb2d72db49aef8f9ec1c285733"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:281c8b219d4f4b3581b918b816764098d04964915b2f272d1476654143801aa2"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:27ccc93c7457ef890b0dd31564d2a05e1aca330623c942b7e818e9e7c2669ee4"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1c562a9bb72244fa767d1c1ab55ca1d92dd5f7c4d77878fee5483a22ffac808"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e57919c32ee295a2fca458bb73e4b20b05c115627f96f95a10f9f5acbd61172d"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa35ad36440aaf1ac8332b4a4a433d4acd28f1613f0d480995f5cfd3580e90b7"},
-    {file = "rpds_py-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e6aea5c0eb5b0faf52c7b5c4a47c8bb64437173be97227c819ffa31801fa4e34"},
-    {file = "rpds_py-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:81cf9d306c04df1b45971c13167dc3bad625808aa01281d55f3cf852dde0e206"},
-    {file = "rpds_py-0.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:08e6e7ff286254016b945e1ab632ee843e43d45e40683b66dd12b73791366dd1"},
-    {file = "rpds_py-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4d0a675a7acbbc16179188d8c6d0afb8628604fc1241faf41007255957335a0b"},
-    {file = "rpds_py-0.12.0-cp312-none-win32.whl", hash = "sha256:b2287c09482949e0ca0c0eb68b2aca6cf57f8af8c6dfd29dcd3bc45f17b57978"},
-    {file = "rpds_py-0.12.0-cp312-none-win_amd64.whl", hash = "sha256:8015835494b21aa7abd3b43fdea0614ee35ef6b03db7ecba9beb58eadf01c24f"},
-    {file = "rpds_py-0.12.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:6174d6ad6b58a6bcf67afbbf1723420a53d06c4b89f4c50763d6fa0a6ac9afd2"},
-    {file = "rpds_py-0.12.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a689e1ded7137552bea36305a7a16ad2b40be511740b80748d3140614993db98"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f45321224144c25a62052035ce96cbcf264667bcb0d81823b1bbc22c4addd194"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa32205358a76bf578854bf31698a86dc8b2cb591fd1d79a833283f4a403f04b"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91bd2b7cf0f4d252eec8b7046fa6a43cee17e8acdfc00eaa8b3dbf2f9a59d061"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3acadbab8b59f63b87b518e09c4c64b142e7286b9ca7a208107d6f9f4c393c5c"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:429349a510da82c85431f0f3e66212d83efe9fd2850f50f339341b6532c62fe4"},
-    {file = "rpds_py-0.12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05942656cb2cb4989cd50ced52df16be94d344eae5097e8583966a1d27da73a5"},
-    {file = "rpds_py-0.12.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:0c5441b7626c29dbd54a3f6f3713ec8e956b009f419ffdaaa3c80eaf98ddb523"},
-    {file = "rpds_py-0.12.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:b6b0e17d39d21698185097652c611f9cf30f7c56ccec189789920e3e7f1cee56"},
-    {file = "rpds_py-0.12.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3b7a64d43e2a1fa2dd46b678e00cabd9a49ebb123b339ce799204c44a593ae1c"},
-    {file = "rpds_py-0.12.0-cp38-none-win32.whl", hash = "sha256:e5bbe011a2cea9060fef1bb3d668a2fd8432b8888e6d92e74c9c794d3c101595"},
-    {file = "rpds_py-0.12.0-cp38-none-win_amd64.whl", hash = "sha256:bec29b801b4adbf388314c0d050e851d53762ab424af22657021ce4b6eb41543"},
-    {file = "rpds_py-0.12.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:1096ca0bf2d3426cbe79d4ccc91dc5aaa73629b08ea2d8467375fad8447ce11a"},
-    {file = "rpds_py-0.12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48aa98987d54a46e13e6954880056c204700c65616af4395d1f0639eba11764b"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7979d90ee2190d000129598c2b0c82f13053dba432b94e45e68253b09bb1f0f6"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:88857060b690a57d2ea8569bca58758143c8faa4639fb17d745ce60ff84c867e"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4eb74d44776b0fb0782560ea84d986dffec8ddd94947f383eba2284b0f32e35e"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f62581d7e884dd01ee1707b7c21148f61f2febb7de092ae2f108743fcbef5985"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f5dcb658d597410bb7c967c1d24eaf9377b0d621358cbe9d2ff804e5dd12e81"},
-    {file = "rpds_py-0.12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bf9acce44e967a5103fcd820fc7580c7b0ab8583eec4e2051aec560f7b31a63"},
-    {file = "rpds_py-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:240687b5be0f91fbde4936a329c9b7589d9259742766f74de575e1b2046575e4"},
-    {file = "rpds_py-0.12.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:25740fb56e8bd37692ed380e15ec734be44d7c71974d8993f452b4527814601e"},
-    {file = "rpds_py-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a54917b7e9cd3a67e429a630e237a90b096e0ba18897bfb99ee8bd1068a5fea0"},
-    {file = "rpds_py-0.12.0-cp39-none-win32.whl", hash = "sha256:b92aafcfab3d41580d54aca35a8057341f1cfc7c9af9e8bdfc652f83a20ced31"},
-    {file = "rpds_py-0.12.0-cp39-none-win_amd64.whl", hash = "sha256:cd316dbcc74c76266ba94eb021b0cc090b97cca122f50bd7a845f587ff4bf03f"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:0853da3d5e9bc6a07b2486054a410b7b03f34046c123c6561b535bb48cc509e1"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:cb41ad20064e18a900dd427d7cf41cfaec83bcd1184001f3d91a1f76b3fcea4e"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b710bf7e7ae61957d5c4026b486be593ed3ec3dca3e5be15e0f6d8cf5d0a4990"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a952ae3eb460c6712388ac2ec706d24b0e651b9396d90c9a9e0a69eb27737fdc"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0bedd91ae1dd142a4dc15970ed2c729ff6c73f33a40fa84ed0cdbf55de87c777"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:761531076df51309075133a6bc1db02d98ec7f66e22b064b1d513bc909f29743"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2baa6be130e8a00b6cbb9f18a33611ec150b4537f8563bddadb54c1b74b8193"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f05450fa1cd7c525c0b9d1a7916e595d3041ac0afbed2ff6926e5afb6a781b7f"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:81c4d1a3a564775c44732b94135d06e33417e829ff25226c164664f4a1046213"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e888be685fa42d8b8a3d3911d5604d14db87538aa7d0b29b1a7ea80d354c732d"},
-    {file = "rpds_py-0.12.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6f8d7fe73d1816eeb5378409adc658f9525ecbfaf9e1ede1e2d67a338b0c7348"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:0831d3ecdea22e4559cc1793f22e77067c9d8c451d55ae6a75bf1d116a8e7f42"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:513ccbf7420c30e283c25c82d5a8f439d625a838d3ba69e79a110c260c46813f"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:301bd744a1adaa2f6a5e06c98f1ac2b6f8dc31a5c23b838f862d65e32fca0d4b"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8832a4f83d4782a8f5a7b831c47e8ffe164e43c2c148c8160ed9a6d630bc02a"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b2416ed743ec5debcf61e1242e012652a4348de14ecc7df3512da072b074440"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35585a8cb5917161f42c2104567bb83a1d96194095fc54a543113ed5df9fa436"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d389ff1e95b6e46ebedccf7fd1fadd10559add595ac6a7c2ea730268325f832c"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b007c2444705a2dc4a525964fd4dd28c3320b19b3410da6517cab28716f27d3"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:188912b22b6c8225f4c4ffa020a2baa6ad8fabb3c141a12dbe6edbb34e7f1425"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b4cf9ab9a0ae0cb122685209806d3f1dcb63b9fccdf1424fb42a129dc8c2faa"},
-    {file = "rpds_py-0.12.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2d34a5450a402b00d20aeb7632489ffa2556ca7b26f4a63c35f6fccae1977427"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:466030a42724780794dea71eb32db83cc51214d66ab3fb3156edd88b9c8f0d78"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:68172622a5a57deb079a2c78511c40f91193548e8ab342c31e8cb0764d362459"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54cdfcda59251b9c2f87a05d038c2ae02121219a04d4a1e6fc345794295bdc07"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6b75b912a0baa033350367a8a07a8b2d44fd5b90c890bfbd063a8a5f945f644b"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47aeceb4363851d17f63069318ba5721ae695d9da55d599b4d6fb31508595278"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0525847f83f506aa1e28eb2057b696fe38217e12931c8b1b02198cfe6975e142"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efbe0b5e0fd078ed7b005faa0170da4f72666360f66f0bb2d7f73526ecfd99f9"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0fadfdda275c838cba5102c7f90a20f2abd7727bf8f4a2b654a5b617529c5c18"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:56dd500411d03c5e9927a1eb55621e906837a83b02350a9dc401247d0353717c"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:6915fc9fa6b3ec3569566832e1bb03bd801c12cea030200e68663b9a87974e76"},
-    {file = "rpds_py-0.12.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5f1519b080d8ce0a814f17ad9fb49fb3a1d4d7ce5891f5c85fc38631ca3a8dc4"},
-    {file = "rpds_py-0.12.0.tar.gz", hash = "sha256:7036316cc26b93e401cedd781a579be606dad174829e6ad9e9c5a0da6e036f80"},
+    {file = "rpds_py-0.10.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:485747ee62da83366a44fbba963c5fe017860ad408ccd6cd99aa66ea80d32b2e"},
+    {file = "rpds_py-0.10.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c55f9821f88e8bee4b7a72c82cfb5ecd22b6aad04033334f33c329b29bfa4da0"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3b52a67ac66a3a64a7e710ba629f62d1e26ca0504c29ee8cbd99b97df7079a8"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3aed39db2f0ace76faa94f465d4234aac72e2f32b009f15da6492a561b3bbebd"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:271c360fdc464fe6a75f13ea0c08ddf71a321f4c55fc20a3fe62ea3ef09df7d9"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef5fddfb264e89c435be4adb3953cef5d2936fdeb4463b4161a6ba2f22e7b740"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771417c9c06c56c9d53d11a5b084d1de75de82978e23c544270ab25e7c066ff"},
+    {file = "rpds_py-0.10.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:52b5cbc0469328e58180021138207e6ec91d7ca2e037d3549cc9e34e2187330a"},
+    {file = "rpds_py-0.10.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6ac3fefb0d168c7c6cab24fdfc80ec62cd2b4dfd9e65b84bdceb1cb01d385c33"},
+    {file = "rpds_py-0.10.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:8d54bbdf5d56e2c8cf81a1857250f3ea132de77af543d0ba5dce667183b61fec"},
+    {file = "rpds_py-0.10.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cd2163f42868865597d89399a01aa33b7594ce8e2c4a28503127c81a2f17784e"},
+    {file = "rpds_py-0.10.3-cp310-none-win32.whl", hash = "sha256:ea93163472db26ac6043e8f7f93a05d9b59e0505c760da2a3cd22c7dd7111391"},
+    {file = "rpds_py-0.10.3-cp310-none-win_amd64.whl", hash = "sha256:7cd020b1fb41e3ab7716d4d2c3972d4588fdfbab9bfbbb64acc7078eccef8860"},
+    {file = "rpds_py-0.10.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:1d9b5ee46dcb498fa3e46d4dfabcb531e1f2e76b477e0d99ef114f17bbd38453"},
+    {file = "rpds_py-0.10.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:563646d74a4b4456d0cf3b714ca522e725243c603e8254ad85c3b59b7c0c4bf0"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e626b864725680cd3904414d72e7b0bd81c0e5b2b53a5b30b4273034253bb41f"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:485301ee56ce87a51ccb182a4b180d852c5cb2b3cb3a82f7d4714b4141119d8c"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42f712b4668831c0cd85e0a5b5a308700fe068e37dcd24c0062904c4e372b093"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6c9141af27a4e5819d74d67d227d5047a20fa3c7d4d9df43037a955b4c748ec5"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef750a20de1b65657a1425f77c525b0183eac63fe7b8f5ac0dd16f3668d3e64f"},
+    {file = "rpds_py-0.10.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e1a0ffc39f51aa5f5c22114a8f1906b3c17eba68c5babb86c5f77d8b1bba14d1"},
+    {file = "rpds_py-0.10.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f4c179a7aeae10ddf44c6bac87938134c1379c49c884529f090f9bf05566c836"},
+    {file = "rpds_py-0.10.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:176287bb998fd1e9846a9b666e240e58f8d3373e3bf87e7642f15af5405187b8"},
+    {file = "rpds_py-0.10.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6446002739ca29249f0beaaf067fcbc2b5aab4bc7ee8fb941bd194947ce19aff"},
+    {file = "rpds_py-0.10.3-cp311-none-win32.whl", hash = "sha256:c7aed97f2e676561416c927b063802c8a6285e9b55e1b83213dfd99a8f4f9e48"},
+    {file = "rpds_py-0.10.3-cp311-none-win_amd64.whl", hash = "sha256:8bd01ff4032abaed03f2db702fa9a61078bee37add0bd884a6190b05e63b028c"},
+    {file = "rpds_py-0.10.3-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:4cf0855a842c5b5c391dd32ca273b09e86abf8367572073bd1edfc52bc44446b"},
+    {file = "rpds_py-0.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69b857a7d8bd4f5d6e0db4086da8c46309a26e8cefdfc778c0c5cc17d4b11e08"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:975382d9aa90dc59253d6a83a5ca72e07f4ada3ae3d6c0575ced513db322b8ec"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:35fbd23c1c8732cde7a94abe7fb071ec173c2f58c0bd0d7e5b669fdfc80a2c7b"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:106af1653007cc569d5fbb5f08c6648a49fe4de74c2df814e234e282ebc06957"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce5e7504db95b76fc89055c7f41e367eaadef5b1d059e27e1d6eabf2b55ca314"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aca759ada6b1967fcfd4336dcf460d02a8a23e6abe06e90ea7881e5c22c4de6"},
+    {file = "rpds_py-0.10.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b5d4bdd697195f3876d134101c40c7d06d46c6ab25159ed5cbd44105c715278a"},
+    {file = "rpds_py-0.10.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a657250807b6efd19b28f5922520ae002a54cb43c2401e6f3d0230c352564d25"},
+    {file = "rpds_py-0.10.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:177c9dd834cdf4dc39c27436ade6fdf9fe81484758885f2d616d5d03c0a83bd2"},
+    {file = "rpds_py-0.10.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e22491d25f97199fc3581ad8dd8ce198d8c8fdb8dae80dea3512e1ce6d5fa99f"},
+    {file = "rpds_py-0.10.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:2f3e1867dd574014253b4b8f01ba443b9c914e61d45f3674e452a915d6e929a3"},
+    {file = "rpds_py-0.10.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c22211c165166de6683de8136229721f3d5c8606cc2c3d1562da9a3a5058049c"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40bc802a696887b14c002edd43c18082cb7b6f9ee8b838239b03b56574d97f71"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e271dd97c7bb8eefda5cca38cd0b0373a1fea50f71e8071376b46968582af9b"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95cde244e7195b2c07ec9b73fa4c5026d4a27233451485caa1cd0c1b55f26dbd"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08a80cf4884920863623a9ee9a285ee04cef57ebedc1cc87b3e3e0f24c8acfe5"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:763ad59e105fca09705d9f9b29ecffb95ecdc3b0363be3bb56081b2c6de7977a"},
+    {file = "rpds_py-0.10.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:187700668c018a7e76e89424b7c1042f317c8df9161f00c0c903c82b0a8cac5c"},
+    {file = "rpds_py-0.10.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:5267cfda873ad62591b9332fd9472d2409f7cf02a34a9c9cb367e2c0255994bf"},
+    {file = "rpds_py-0.10.3-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:2ed83d53a8c5902ec48b90b2ac045e28e1698c0bea9441af9409fc844dc79496"},
+    {file = "rpds_py-0.10.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:255f1a10ae39b52122cce26ce0781f7a616f502feecce9e616976f6a87992d6b"},
+    {file = "rpds_py-0.10.3-cp38-none-win32.whl", hash = "sha256:a019a344312d0b1f429c00d49c3be62fa273d4a1094e1b224f403716b6d03be1"},
+    {file = "rpds_py-0.10.3-cp38-none-win_amd64.whl", hash = "sha256:efb9ece97e696bb56e31166a9dd7919f8f0c6b31967b454718c6509f29ef6fee"},
+    {file = "rpds_py-0.10.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:570cc326e78ff23dec7f41487aa9c3dffd02e5ee9ab43a8f6ccc3df8f9327623"},
+    {file = "rpds_py-0.10.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cff7351c251c7546407827b6a37bcef6416304fc54d12d44dbfecbb717064717"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:177914f81f66c86c012311f8c7f46887ec375cfcfd2a2f28233a3053ac93a569"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:448a66b8266de0b581246ca7cd6a73b8d98d15100fb7165974535fa3b577340e"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bbac1953c17252f9cc675bb19372444aadf0179b5df575ac4b56faaec9f6294"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dd9d9d9e898b9d30683bdd2b6c1849449158647d1049a125879cb397ee9cd12"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8c71ea77536149e36c4c784f6d420ffd20bea041e3ba21ed021cb40ce58e2c9"},
+    {file = "rpds_py-0.10.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16a472300bc6c83fe4c2072cc22b3972f90d718d56f241adabc7ae509f53f154"},
+    {file = "rpds_py-0.10.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b9255e7165083de7c1d605e818025e8860636348f34a79d84ec533546064f07e"},
+    {file = "rpds_py-0.10.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:53d7a3cd46cdc1689296348cb05ffd4f4280035770aee0c8ead3bbd4d6529acc"},
+    {file = "rpds_py-0.10.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:22da15b902f9f8e267020d1c8bcfc4831ca646fecb60254f7bc71763569f56b1"},
+    {file = "rpds_py-0.10.3-cp39-none-win32.whl", hash = "sha256:850c272e0e0d1a5c5d73b1b7871b0a7c2446b304cec55ccdb3eaac0d792bb065"},
+    {file = "rpds_py-0.10.3-cp39-none-win_amd64.whl", hash = "sha256:de61e424062173b4f70eec07e12469edde7e17fa180019a2a0d75c13a5c5dc57"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:af247fd4f12cca4129c1b82090244ea5a9d5bb089e9a82feb5a2f7c6a9fe181d"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3ad59efe24a4d54c2742929001f2d02803aafc15d6d781c21379e3f7f66ec842"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642ed0a209ced4be3a46f8cb094f2d76f1f479e2a1ceca6de6346a096cd3409d"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:37d0c59548ae56fae01c14998918d04ee0d5d3277363c10208eef8c4e2b68ed6"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aad6ed9e70ddfb34d849b761fb243be58c735be6a9265b9060d6ddb77751e3e8"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8f94fdd756ba1f79f988855d948ae0bad9ddf44df296770d9a58c774cfbcca72"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77076bdc8776a2b029e1e6ffbe6d7056e35f56f5e80d9dc0bad26ad4a024a762"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:87d9b206b1bd7a0523375dc2020a6ce88bca5330682ae2fe25e86fd5d45cea9c"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8efaeb08ede95066da3a3e3c420fcc0a21693fcd0c4396d0585b019613d28515"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:a4d9bfda3f84fc563868fe25ca160c8ff0e69bc4443c5647f960d59400ce6557"},
+    {file = "rpds_py-0.10.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d27aa6bbc1f33be920bb7adbb95581452cdf23005d5611b29a12bb6a3468cc95"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:ed8313809571a5463fd7db43aaca68ecb43ca7a58f5b23b6e6c6c5d02bdc7882"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:e10e6a1ed2b8661201e79dff5531f8ad4cdd83548a0f81c95cf79b3184b20c33"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:015de2ce2af1586ff5dc873e804434185199a15f7d96920ce67e50604592cae9"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae87137951bb3dc08c7d8bfb8988d8c119f3230731b08a71146e84aaa919a7a9"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0bb4f48bd0dd18eebe826395e6a48b7331291078a879295bae4e5d053be50d4c"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09362f86ec201288d5687d1dc476b07bf39c08478cde837cb710b302864e7ec9"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821392559d37759caa67d622d0d2994c7a3f2fb29274948ac799d496d92bca73"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7170cbde4070dc3c77dec82abf86f3b210633d4f89550fa0ad2d4b549a05572a"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:5de11c041486681ce854c814844f4ce3282b6ea1656faae19208ebe09d31c5b8"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:4ed172d0c79f156c1b954e99c03bc2e3033c17efce8dd1a7c781bc4d5793dfac"},
+    {file = "rpds_py-0.10.3-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:11fdd1192240dda8d6c5d18a06146e9045cb7e3ba7c06de6973000ff035df7c6"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:f602881d80ee4228a2355c68da6b296a296cd22bbb91e5418d54577bbf17fa7c"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:691d50c99a937709ac4c4cd570d959a006bd6a6d970a484c84cc99543d4a5bbb"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24cd91a03543a0f8d09cb18d1cb27df80a84b5553d2bd94cba5979ef6af5c6e7"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc2200e79d75b5238c8d69f6a30f8284290c777039d331e7340b6c17cad24a5a"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea65b59882d5fa8c74a23f8960db579e5e341534934f43f3b18ec1839b893e41"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:829e91f3a8574888b73e7a3feb3b1af698e717513597e23136ff4eba0bc8387a"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eab75a8569a095f2ad470b342f2751d9902f7944704f0571c8af46bede438475"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:061c3ff1f51ecec256e916cf71cc01f9975af8fb3af9b94d3c0cc8702cfea637"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:39d05e65f23a0fe897b6ac395f2a8d48c56ac0f583f5d663e0afec1da89b95da"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:4eca20917a06d2fca7628ef3c8b94a8c358f6b43f1a621c9815243462dcccf97"},
+    {file = "rpds_py-0.10.3-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e8d0f0eca087630d58b8c662085529781fd5dc80f0a54eda42d5c9029f812599"},
+    {file = "rpds_py-0.10.3.tar.gz", hash = "sha256:fcc1ebb7561a3e24a6588f7c6ded15d80aec22c66a070c757559b57b17ffd1cb"},
 ]
 
 [[package]]
@@ -3114,122 +3205,82 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "safetensors"
-version = "0.4.0"
-description = ""
+version = "0.3.3"
+description = "Fast and Safe Tensor serialization"
 optional = true
-python-versions = ">=3.7"
+python-versions = "*"
 files = [
-    {file = "safetensors-0.4.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:2289ae6dbe6d027ecee016b28ced13a2e21a0b3a3a757a23033a2d1c0b1bad55"},
-    {file = "safetensors-0.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bf6458959f310f551cbbeef2255527ade5f783f952738e73e4d0136198cc3bfe"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6b60a58a8f7cc7aed3b5b73dce1f5259a53c83d9ba43a76a874e6ad868c1b4d"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:491b3477e4d0d4599bb75d79da4b75af2e6ed9b1f6ec2b715991f0bc927bf09a"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59d2e10b7e0cd18bb73ed7c17c624a5957b003b81345e18159591771c26ee428"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3f667a4c12fb593f5f66ce966cb1b14a7148898b2b1a7f79e0761040ae1e3c51"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f9909512bcb6f712bdd04c296cdfb0d8ff73d258ffc5af884bb62ea02d221e0"},
-    {file = "safetensors-0.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d33d29e846821f0e4f92614022949b09ccf063cb36fe2f9fe099cde1efbfbb87"},
-    {file = "safetensors-0.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4d512525a8e05a045ce6698066ba0c5378c174a83e0b3720a8c7799dc1bb06f3"},
-    {file = "safetensors-0.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0219cea445177f6ad1f9acd3a8d025440c8ff436d70a4a7c7ba9c36066aa9474"},
-    {file = "safetensors-0.4.0-cp310-none-win32.whl", hash = "sha256:67ab171eeaad6972d3971c53d29d53353c67f6743284c6d637b59fa3e54c8a94"},
-    {file = "safetensors-0.4.0-cp310-none-win_amd64.whl", hash = "sha256:7ffc736039f08a9ca1f09816a7481b8e4469c06e8f8a5ffa8cb67ddd79e6d77f"},
-    {file = "safetensors-0.4.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:4fe9e3737b30de458225a23926219ca30b902ee779b6a3df96eaab2b6d625ec2"},
-    {file = "safetensors-0.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7916e814a90008de767b1c164a1d83803693c661ffe9af5a697b22e2752edb0"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc4a4da01143472323c145f3c289e5f6fabde0ac0a3414dabf912a21692fff4"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a54c21654a47669b38e359e8f852af754b786c9da884bb61ad5e9af12bd71ccb"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25cd407955bad5340ba17f9f8ac789a0d751601a311e2f7b2733f9384478c95e"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82e8fc4e3503cd738fd40718a430fe0e5ce6e7ff91a73d6ce628bbb89c41e8ce"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48b92059b1a4ad163024d4f526e0e73ebe2bb3ae70537e15e347820b4de5dc27"},
-    {file = "safetensors-0.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5daa05058f7dce85b5f9f60c4eab483ed7859d63978f08a76e52e78859ff20ca"},
-    {file = "safetensors-0.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a86565a5c112dd855909e20144947b4f53abb78c4de207f36ca71ee63ba5b90d"},
-    {file = "safetensors-0.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:38032078ed9fea52d06584e441bccc73fb475c4581600c6d6166de2fe2deb3d1"},
-    {file = "safetensors-0.4.0-cp311-none-win32.whl", hash = "sha256:2f99d90c91b7c76b40a862acd9085bc77f7974a27dee7cfcebe46149af5a99a1"},
-    {file = "safetensors-0.4.0-cp311-none-win_amd64.whl", hash = "sha256:74e2a448ffe19be188b457b130168190ee73b5a75e45ba96796320c1f5ae35d2"},
-    {file = "safetensors-0.4.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:1e2f9c69b41d03b4826ffb96b29e07444bb6b34a78a7bafd0b88d59e8ec75b8a"},
-    {file = "safetensors-0.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3910fb5bf747413b59f1a34e6d2a993b589fa7d919709518823c70efaaa350bd"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf8fdca709b2470a35a59b1e6dffea75cbe1214b22612b5dd4c93947697aea8b"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2f27b8ef814c5fb43456caeb7f3cbb889b76115180aad1f42402839c14a47c5b"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b2d6101eccc43c7be0cb052f13ceda64288b3d8b344b988ed08d7133cbce2f3"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fdc34027b545a69be3d4220c140b276129523e4e46db06ad1a0b60d6a4cf9214"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db7bb48ca9e90bb9526c71b388d38d8de160c0354f4c5126df23e8701a870dcb"},
-    {file = "safetensors-0.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a78ffc0795d3595cd9e4d453502e35f764276c49e434b25556a15a337db4dafc"},
-    {file = "safetensors-0.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8e735b0f79090f6855b55e205e820b7b595502ffca0009a5c13eef3661ce465b"},
-    {file = "safetensors-0.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f8d2416734e850d5392afffbcb2b8985ea29fb171f1cb197e2ae51b8e35d6438"},
-    {file = "safetensors-0.4.0-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:e853e189ba7d47eaf561094586692ba2bbdd258c096f1755805cac098de0e6ab"},
-    {file = "safetensors-0.4.0-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:4b2aa57b5a4d576f3d1dd6e56980026340f156f8a13c13016bfac4e25295b53f"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b6c1316ffde6cb4bf22c7445bc9fd224b4d1b9dd7320695f5611c89e802e4b6"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:003077ec85261d00061058fa12e3c1d2055366b02ce8f2938929359ffbaff2b8"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bd63d83a92f1437a8b0431779320376030ae43ace980bea5686d515de0784100"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2077801800b4b13301d8d6290c7fb5bd60737320001717153ebc4371776643b5"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7abe0e157a49a75aeeccfbc4f3dac38d8f98512d3cdb35c200f8e628dc5773cf"},
-    {file = "safetensors-0.4.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bfed574f6b1e7e7fe1f17213278875ef6c6e8b1582ab6eda93947db1178cae6"},
-    {file = "safetensors-0.4.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:964ef166a286ce3b023d0d0bd0e21d440a1c8028981c8abdb136bc7872ba9b3d"},
-    {file = "safetensors-0.4.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:44f84373e42183bd56a13a1f2d8acb1db7fedaeffbd83e79cec861477eee1af4"},
-    {file = "safetensors-0.4.0-cp37-none-win32.whl", hash = "sha256:c68132727dd86fb641102e494d445f705efe402f4d5e24b278183a15499ab400"},
-    {file = "safetensors-0.4.0-cp37-none-win_amd64.whl", hash = "sha256:1db87155454c168aef118d5657a403aee48a4cb08d8851a981157f07351ea317"},
-    {file = "safetensors-0.4.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:9e583fa68e5a07cc859c4e13c1ebff12029904aa2e27185cf04a1f57fe9a81c4"},
-    {file = "safetensors-0.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:73e7696dcf3f72f99545eb1abe6106ad65ff1f62381d6ce4b34be3272552897a"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4936096a57c62e84e200f92620a536be067fc5effe46ecc7f230ebb496ecd579"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87b328ee1591adac332543e1f5fc2c2d7f149b745ebb0d58d7850818ff9cee27"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b69554c143336256260eceff1d3c0969172a641b54d4668489a711b05f92a2c0"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ebf6bcece5d5d1bd6416472f94604d2c834ca752ac60ed42dba7157e595a990"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6686ce01b8602d55a7d9903c90d4a6e6f90aeb6ddced7cf4605892d0ba94bcb8"},
-    {file = "safetensors-0.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b8fd6cc2f3bda444a048b541c843c7b7fefc89c4120d7898ea7d5b026e93891"},
-    {file = "safetensors-0.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8a6abfe67692f81b8bdb99c837f28351c17e624ebf136970c850ee989c720446"},
-    {file = "safetensors-0.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:27a24ca8822c469ee452db4c13418ba983315a0d863c018a9af15f2305eac38c"},
-    {file = "safetensors-0.4.0-cp38-none-win32.whl", hash = "sha256:c4a0a47c8640167792d8261ee21b26430bbc39130a7edaad7f4c0bc05669d00e"},
-    {file = "safetensors-0.4.0-cp38-none-win_amd64.whl", hash = "sha256:a738970a367f39249e2abb900d9441a8a86d7ff50083e5eaa6e7760a9f216014"},
-    {file = "safetensors-0.4.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:806379f37e1abd5d302288c4b2f4186dd7ea7143d4c7811f90a8077f0ae8967b"},
-    {file = "safetensors-0.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b9b94133ed2ae9dda0e95dcace7b7556eba023ffa4c4ae6df8f99377f571d6a"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b563a14c43614815a6b524d2e4edeaace50b717f7e7487bb227dd5b68350f5a"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:00a9b157be660fb7ba88fa2eedd05ec93793a5b61e43e783e10cb0b995372802"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c8f194f45ab6aa767993c24f0aeb950af169dbc5d611b94c9021a1d13b8a1a34"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:469360b9451db10bfed3881378d5a71b347ecb1ab4f42367d77b8164a13af70b"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5f75fa97ccf32a3c7af476c6a0e851023197d3c078f6de3612008fff94735f9"},
-    {file = "safetensors-0.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:acf0180283c2efae72f1d8c0a4a7974662091df01be3aa43b5237b1e52ed0a01"},
-    {file = "safetensors-0.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cd02b495ba0814619f40bda46771bb06dbbf1d42524b66fa03b2a736c77e4515"},
-    {file = "safetensors-0.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c42bdea183dbaa99e2f0e6120dc524df79cf4289a6f90f30a534444ef20f49fa"},
-    {file = "safetensors-0.4.0-cp39-none-win32.whl", hash = "sha256:cef7bb5d9feae7146c3c3c7b3aef7d2c8b39ba7f5ff4252d368eb69462a47076"},
-    {file = "safetensors-0.4.0-cp39-none-win_amd64.whl", hash = "sha256:79dd46fb1f19282fd12f544471efb97823ede927cedbf9cf35550d92b349fdd2"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:002301c1afa32909f83745b0c124d002e7ae07e15671f3b43cbebd0ffc5e6037"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:67762d36ae088c73d4a3c96bfc4ea8d31233554f35b6cace3a18533238d462ea"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f45230f20a206e5e4c7f7bbf9342178410c6f8b0af889843aa99045a76f7691"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f2ca939bbd8fb2f4dfa28e39a146dad03bc9325e9fc831b68f7b98f69a5a2f1"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:61a00f281391fae5ce91df70918bb61c12d2d514a493fd8056e12114be729911"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:435fd136a42492b280cb55126f9ce9535b35dd49df2c5d572a5945455a439448"},
-    {file = "safetensors-0.4.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f0daa788273d683258fb1e4a5e16bef4486b2fca536451a2591bc0f4a6488895"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:0620ab0d41e390ccb1c4ea8f63dc00cb5f0b96a5cdd3cd0d64c21765720c074a"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc1fa8d067733cb67f22926689ee808f08afacf7700d2ffb44efae90a0693eb1"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcaa40bc363edda145db75cd030f3b1822e5478d550c3500a42502ecef32c959"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b561fbc044db7beff2ece0ec219a291809d45a38d30c6b38e7cc46482582f4ba"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:79a983b09782dacf9a1adb19bb98f4a8f6c3144108939f572c047b5797e43cf5"},
-    {file = "safetensors-0.4.0-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:10b65cd3ad79f5d0daf281523b4146bc271a34bb7430d4e03212e0de8622dab8"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:114decacc475a6a9e2f9102a00c171d113ddb5d35cb0bda0db2c0c82b2eaa9ce"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:72ddb741dd5fe42521db76a70e012f76995516a12e7e0ef26be03ea9be77802a"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c5556c2ec75f5a6134866eddd7341cb36062e6edaea343478a279591b63ddba"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed50f239b0ce7ae85b078395593b4a351ede7e6f73af25f4873e3392336f64c9"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495dcaea8fbab70b927d2274e2547824462737acbf98ccd851a71124f779a5c6"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3f4d90c79a65ba2fe2ff0876f6140748f0a3ce6a21e27a35190f4f96321803f8"},
-    {file = "safetensors-0.4.0-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:7a524382b5c55b5fbb168e0e9d3f502450c8cf3fb81b93e880018437c206a482"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:9849ea60c7e840bfdd6030ad454d4a6ba837b3398c902f15a30460dd6961c28c"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:6c42623ae7045615d9eaa6877b9df1db4e9cc71ecc14bcc721ea1e475dddd595"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80cb8342f00f3c41b3b93b1a599b84723280d3ac90829bc62262efc03ab28793"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8c4f5ed4ede384dea8c99bae76b0718a828dbf7b2c8ced1f44e3b9b1a124475"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:40d7cf03493bfe75ef62e2c716314474b28d9ba5bf4909763e4b8dd14330c01a"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:232029f0a9fa6fa1f737324eda98a700409811186888536a2333cbbf64e41741"},
-    {file = "safetensors-0.4.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:9ed55f4a20c78ff3e8477efb63c8303c2152cdfb3bfea4d025a80f54d38fd628"},
-    {file = "safetensors-0.4.0.tar.gz", hash = "sha256:b985953c3cf11e942eac4317ef3db3da713e274109cf7cfb6076d877054f013e"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_10_11_x86_64.whl", hash = "sha256:92e4d0c8b2836120fddd134474c5bda8963f322333941f8b9f643e5b24f041eb"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:3dcadb6153c42addc9c625a622ebde9293fabe1973f9ef31ba10fb42c16e8536"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:08f26b61e1b0a14dc959aa9d568776bd038805f611caef1de04a80c468d4a7a4"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:17f41344d9a075f2f21b289a49a62e98baff54b5754240ba896063bce31626bf"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:f1045f798e1a16a6ced98d6a42ec72936d367a2eec81dc5fade6ed54638cd7d2"},
+    {file = "safetensors-0.3.3-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:eaf0e4bc91da13f21ac846a39429eb3f3b7ed06295a32321fa3eb1a59b5c70f3"},
+    {file = "safetensors-0.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25149180d4dc8ca48bac2ac3852a9424b466e36336a39659b35b21b2116f96fc"},
+    {file = "safetensors-0.3.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9e943bf78c39de8865398a71818315e7d5d1af93c7b30d4da3fc852e62ad9bc"},
+    {file = "safetensors-0.3.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cccfcac04a010354e87c7a2fe16a1ff004fc4f6e7ef8efc966ed30122ce00bc7"},
+    {file = "safetensors-0.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a07121f427e646a50d18c1be0fa1a2cbf6398624c31149cd7e6b35486d72189e"},
+    {file = "safetensors-0.3.3-cp310-cp310-win32.whl", hash = "sha256:a85e29cbfddfea86453cc0f4889b4bcc6b9c155be9a60e27be479a34e199e7ef"},
+    {file = "safetensors-0.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:e13adad4a3e591378f71068d14e92343e626cf698ff805f61cdb946e684a218e"},
+    {file = "safetensors-0.3.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cbc3312f134baf07334dd517341a4b470b2931f090bd9284888acb7dfaf4606f"},
+    {file = "safetensors-0.3.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d15030af39d5d30c22bcbc6d180c65405b7ea4c05b7bab14a570eac7d7d43722"},
+    {file = "safetensors-0.3.3-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:f84a74cbe9859b28e3d6d7715ac1dd3097bebf8d772694098f6d42435245860c"},
+    {file = "safetensors-0.3.3-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:10d637423d98ab2e6a4ad96abf4534eb26fcaf8ca3115623e64c00759374e90d"},
+    {file = "safetensors-0.3.3-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:3b46f5de8b44084aff2e480874c550c399c730c84b2e8ad1bddb062c94aa14e9"},
+    {file = "safetensors-0.3.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e76da691a82dfaf752854fa6d17c8eba0c8466370c5ad8cf1bfdf832d3c7ee17"},
+    {file = "safetensors-0.3.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4e342fd54e66aa9512dd13e410f791e47aa4feeb5f4c9a20882c72f3d272f29"},
+    {file = "safetensors-0.3.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:178fd30b5dc73bce14a39187d948cedd0e5698e2f055b7ea16b5a96c9b17438e"},
+    {file = "safetensors-0.3.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e8fdf7407dba44587ed5e79d5de3533d242648e1f2041760b21474bd5ea5c8c"},
+    {file = "safetensors-0.3.3-cp311-cp311-win32.whl", hash = "sha256:7d3b744cee8d7a46ffa68db1a2ff1a1a432488e3f7a5a97856fe69e22139d50c"},
+    {file = "safetensors-0.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f579877d30feec9b6ba409d05fa174633a4fc095675a4a82971d831a8bb60b97"},
+    {file = "safetensors-0.3.3-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:2fff5b19a1b462c17322998b2f4b8bce43c16fe208968174d2f3a1446284ceed"},
+    {file = "safetensors-0.3.3-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:41adb1d39e8aad04b16879e3e0cbcb849315999fad73bc992091a01e379cb058"},
+    {file = "safetensors-0.3.3-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:0f2b404250b3b877b11d34afcc30d80e7035714a1116a3df56acaca6b6c00096"},
+    {file = "safetensors-0.3.3-cp37-cp37m-macosx_13_0_x86_64.whl", hash = "sha256:b43956ef20e9f4f2e648818a9e7b3499edd6b753a0f5526d4f6a6826fbee8446"},
+    {file = "safetensors-0.3.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d61a99b34169981f088ccfbb2c91170843efc869a0a0532f422db7211bf4f474"},
+    {file = "safetensors-0.3.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0008aab36cd20e9a051a68563c6f80d40f238c2611811d7faa5a18bf3fd3984"},
+    {file = "safetensors-0.3.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:93d54166072b143084fdcd214a080a088050c1bb1651016b55942701b31334e4"},
+    {file = "safetensors-0.3.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c32ee08f61cea56a5d62bbf94af95df6040c8ab574afffaeb7b44ae5da1e9e3"},
+    {file = "safetensors-0.3.3-cp37-cp37m-win32.whl", hash = "sha256:351600f367badd59f7bfe86d317bb768dd8c59c1561c6fac43cafbd9c1af7827"},
+    {file = "safetensors-0.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:034717e297849dae1af0a7027a14b8647bd2e272c24106dced64d83e10d468d1"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:8530399666748634bc0b301a6a5523756931b0c2680d188e743d16304afe917a"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:9d741c1f1621e489ba10aa3d135b54202684f6e205df52e219d5eecd673a80c9"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:0c345fd85b4d2093a5109596ff4cd9dfc2e84992e881b4857fbc4a93a3b89ddb"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:69ccee8d05f55cdf76f7e6c87d2bdfb648c16778ef8acfd2ecc495e273e9233e"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_13_0_arm64.whl", hash = "sha256:c08a9a4b7a4ca389232fa8d097aebc20bbd4f61e477abc7065b5c18b8202dede"},
+    {file = "safetensors-0.3.3-cp38-cp38-macosx_13_0_x86_64.whl", hash = "sha256:a002868d2e3f49bbe81bee2655a411c24fa1f8e68b703dec6629cb989d6ae42e"},
+    {file = "safetensors-0.3.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3bd2704cb41faa44d3ec23e8b97330346da0395aec87f8eaf9c9e2c086cdbf13"},
+    {file = "safetensors-0.3.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b2951bf3f0ad63df5e6a95263652bd6c194a6eb36fd4f2d29421cd63424c883"},
+    {file = "safetensors-0.3.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07114cec116253ca2e7230fdea30acf76828f21614afd596d7b5438a2f719bd8"},
+    {file = "safetensors-0.3.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ab43aeeb9eadbb6b460df3568a662e6f1911ecc39387f8752afcb6a7d96c087"},
+    {file = "safetensors-0.3.3-cp38-cp38-win32.whl", hash = "sha256:f2f59fce31dd3429daca7269a6b06f65e6547a0c248f5116976c3f1e9b73f251"},
+    {file = "safetensors-0.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:c31ca0d8610f57799925bf08616856b39518ab772c65093ef1516762e796fde4"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:59a596b3225c96d59af412385981f17dd95314e3fffdf359c7e3f5bb97730a19"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:82a16e92210a6221edd75ab17acdd468dd958ef5023d9c6c1289606cc30d1479"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:98a929e763a581f516373ef31983ed1257d2d0da912a8e05d5cd12e9e441c93a"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:12b83f1986cd16ea0454c636c37b11e819d60dd952c26978310a0835133480b7"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:f439175c827c2f1bbd54df42789c5204a10983a30bc4242bc7deaf854a24f3f0"},
+    {file = "safetensors-0.3.3-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:0085be33b8cbcb13079b3a8e131656e05b0bc5e6970530d4c24150f7afd76d70"},
+    {file = "safetensors-0.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3ec70c87b1e910769034206ad5efc051069b105aac1687f6edcd02526767f4"},
+    {file = "safetensors-0.3.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f490132383e5e490e710608f4acffcb98ed37f91b885c7217d3f9f10aaff9048"},
+    {file = "safetensors-0.3.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:79d1b6c7ed5596baf79c80fbce5198c3cdcc521ae6a157699f427aba1a90082d"},
+    {file = "safetensors-0.3.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad3cc8006e7a86ee7c88bd2813ec59cd7cc75b03e6fa4af89b9c7b235b438d68"},
+    {file = "safetensors-0.3.3-cp39-cp39-win32.whl", hash = "sha256:ab29f54c6b8c301ca05fa014728996bd83aac6e21528f893aaf8945c71f42b6d"},
+    {file = "safetensors-0.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:0fa82004eae1a71e2aa29843ef99de9350e459a0fc2f65fc6ee0da9690933d2d"},
+    {file = "safetensors-0.3.3.tar.gz", hash = "sha256:edb7072d788c4f929d0f5735d3a2fb51e5a27f833587828583b7f5747af1a2b8"},
 ]
 
 [package.extras]
-all = ["safetensors[jax]", "safetensors[numpy]", "safetensors[paddlepaddle]", "safetensors[pinned-tf]", "safetensors[quality]", "safetensors[testing]", "safetensors[torch]"]
-dev = ["safetensors[all]"]
-jax = ["flax (>=0.6.3)", "jax (>=0.3.25)", "jaxlib (>=0.3.25)", "safetensors[numpy]"]
+all = ["black (==22.3)", "click (==8.0.4)", "flake8 (>=3.8.3)", "flax (>=0.6.3)", "h5py (>=3.7.0)", "huggingface-hub (>=0.12.1)", "isort (>=5.5.4)", "jax (>=0.3.25)", "jaxlib (>=0.3.25)", "numpy (>=1.21.6)", "paddlepaddle (>=2.4.1)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "setuptools-rust (>=1.5.2)", "tensorflow (==2.11.0)", "torch (>=1.10)"]
+dev = ["black (==22.3)", "click (==8.0.4)", "flake8 (>=3.8.3)", "flax (>=0.6.3)", "h5py (>=3.7.0)", "huggingface-hub (>=0.12.1)", "isort (>=5.5.4)", "jax (>=0.3.25)", "jaxlib (>=0.3.25)", "numpy (>=1.21.6)", "paddlepaddle (>=2.4.1)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "setuptools-rust (>=1.5.2)", "tensorflow (==2.11.0)", "torch (>=1.10)"]
+jax = ["flax (>=0.6.3)", "jax (>=0.3.25)", "jaxlib (>=0.3.25)", "numpy (>=1.21.6)"]
 numpy = ["numpy (>=1.21.6)"]
-paddlepaddle = ["paddlepaddle (>=2.4.1)", "safetensors[numpy]"]
-pinned-tf = ["safetensors[numpy]", "tensorflow (==2.11.0)"]
+paddlepaddle = ["numpy (>=1.21.6)", "paddlepaddle (>=2.4.1)"]
+pinned-tf = ["tensorflow (==2.11.0)"]
 quality = ["black (==22.3)", "click (==8.0.4)", "flake8 (>=3.8.3)", "isort (>=5.5.4)"]
-tensorflow = ["safetensors[numpy]", "tensorflow (>=2.11.0)"]
-testing = ["h5py (>=3.7.0)", "huggingface_hub (>=0.12.1)", "hypothesis (>=6.70.2)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "safetensors[numpy]", "setuptools_rust (>=1.5.2)"]
-torch = ["safetensors[numpy]", "torch (>=1.10)"]
+tensorflow = ["numpy (>=1.21.6)", "tensorflow (>=2.11.0)"]
+testing = ["h5py (>=3.7.0)", "huggingface-hub (>=0.12.1)", "numpy (>=1.21.6)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "setuptools-rust (>=1.5.2)"]
+torch = ["numpy (>=1.21.6)", "torch (>=1.10)"]
 
 [[package]]
 name = "schema"
@@ -3417,32 +3468,32 @@ files = [
 
 [[package]]
 name = "snowflake-connector-python"
-version = "3.4.0"
+version = "3.2.1"
 description = "Snowflake Connector for Python"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "snowflake-connector-python-3.4.0.tar.gz", hash = "sha256:09939c300d4e40705db1388c9ba596dce7dd9ee4fa8eea0b6fd67b07756597cb"},
-    {file = "snowflake_connector_python-3.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1cfb5de0fdd1f08ce3046bcec31d6aad2de0fb5196e8c1c2ebf0960748f8bfcf"},
-    {file = "snowflake_connector_python-3.4.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:0b4ea9ffac7e8a7ef7f357116f59d2790c07f8bbc0650cf6a717ecaa275440bb"},
-    {file = "snowflake_connector_python-3.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16c3ed32db6c2804413a766a4aa85eb6687f3e5334d5e1238a56be938ab0fe5e"},
-    {file = "snowflake_connector_python-3.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c2683d8e0a0baf05bf946caafe2dcc525f57051869c45f9dcbc5ced5f5433b6"},
-    {file = "snowflake_connector_python-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:389226a12ac56a6b78264a258183580c18c0bd5628ae7c48198d7f239f72fc44"},
-    {file = "snowflake_connector_python-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7ed10a5bad779383e099c6c8124e350718d02f48dc7abb48cd3983687d881132"},
-    {file = "snowflake_connector_python-3.4.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:93145ea700e548a1b5f7612ed9bd597b49dae85d1914fee62be165d1e8a6bb4f"},
-    {file = "snowflake_connector_python-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed168e53cb0ef09c0788095833f22a1590effbb1eb9167ed21edcedeb4c9faeb"},
-    {file = "snowflake_connector_python-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc7a6aa3b205022beb286cdaa157c2ca3017f2536fbd7d5b6bd6750dbd7861d1"},
-    {file = "snowflake_connector_python-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:432a8b4d0c4194e346eea0bc9329747bb5f6e1a771177d0c33f917d2aef7e421"},
-    {file = "snowflake_connector_python-3.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4434d1fd0c49c509c631830ca8abf3a3319e90c6993024702a5835991e97946b"},
-    {file = "snowflake_connector_python-3.4.0-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:dcbeac81489ae6a9aac3eb4d35a05147ae8e346a6d95bd5d740b30bbf5342970"},
-    {file = "snowflake_connector_python-3.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0aea046fb928afb86ccbd80ef8a65398044217172ccf82627f00e63316f10832"},
-    {file = "snowflake_connector_python-3.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1fdc6ce9e6c21969cf4f8365b4aa93cc1622e8b14caf4b26d9d61b5551eda0d"},
-    {file = "snowflake_connector_python-3.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:4d7ed67213b68e21ff87ae39068926a81dfd1a5d1b84fd6707163050a7c98801"},
-    {file = "snowflake_connector_python-3.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9cb928b9e04ab5e3681b4f4aeefe0b68c0137aefb4b7363d204a29cc7e8341de"},
-    {file = "snowflake_connector_python-3.4.0-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:843e74bba8c7e73c5d946b244df3d86ae691bb144ed73f9a9be77cdbb892769b"},
-    {file = "snowflake_connector_python-3.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d71dcd83c9b97216622dc465dca2ed3f0a7e9e736b979d8798daa282f8a53b08"},
-    {file = "snowflake_connector_python-3.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb7281f2481b924192ea3939f49d766122b59f58d4a9339536f1d2c1a8f86bd7"},
-    {file = "snowflake_connector_python-3.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:9488e54f1ac2fea80d2a8d94e10552f19eb88db00a21c67a13e0ac4c79ca9a0b"},
+    {file = "snowflake-connector-python-3.2.1.tar.gz", hash = "sha256:2f92112964e4d36c67dbcf900f0b6c4b56a4ab0b3cf44a0d166d290e867a9d8b"},
+    {file = "snowflake_connector_python-3.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d320bf645cd59afdb6f1c01e1cc818c63da0f3379055ad48f4a3cd2a91219743"},
+    {file = "snowflake_connector_python-3.2.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b1c92af498b77e6ec354465b8f7fb43be3b1140d0e469de4847deb9b9963ebc4"},
+    {file = "snowflake_connector_python-3.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e02fdb99d08ef82b04d43289293ba97e3a92547fa49aa2cb9ae4a9bd00cfeab4"},
+    {file = "snowflake_connector_python-3.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af1f7587f2caf62afb1f5a9bd1e47096d802ba610bb3878aad9694a7f81ddd1c"},
+    {file = "snowflake_connector_python-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e69443088cd510318e7832ea4e48daf56f32ee50045885587fc37e7c6ef71ff"},
+    {file = "snowflake_connector_python-3.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e02de34a03450085fdb974e4122029381d1f78d11aac5a1101284613d229a0e9"},
+    {file = "snowflake_connector_python-3.2.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:4a887eabec98539e453d704b75e58a4a46d49449b885399dd6c593ce344ee89c"},
+    {file = "snowflake_connector_python-3.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bff7ed4f170445af466ceebf0995376420c67aecb6c8bd79ca0173b95574d94"},
+    {file = "snowflake_connector_python-3.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f11dae04f54562efccf809db1d7c67f3100e667be32159973d569ab46482024b"},
+    {file = "snowflake_connector_python-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:726a1015657087f00a451239f57b0fe72e32a3020003d8e60e6f3ae03efc1143"},
+    {file = "snowflake_connector_python-3.2.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5c18161cb5834c63246e911ae83a5939ece09b51c1ca94ec70744e1360bf0485"},
+    {file = "snowflake_connector_python-3.2.1-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:4b216c01fcb7100009d35801f29284ddbbbac7b48e0a90f58a76722c69f6d7c9"},
+    {file = "snowflake_connector_python-3.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10132e1a8796d0d1d883bbd2ead1faf32a82c8635c453a7f9517a56fd913b4f0"},
+    {file = "snowflake_connector_python-3.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:484fbb9ee0727174babaf44e1a1a0791b180ade92c5b3ba88b041295d5f211fc"},
+    {file = "snowflake_connector_python-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:e96d38dc5e07ecfe65dca245474fddef00c9030c35eab37c38323f96ef4fdda5"},
+    {file = "snowflake_connector_python-3.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b6a1518388759b6b34de0f7f4f23e858966fb567a20a326df44cec5edc651e3e"},
+    {file = "snowflake_connector_python-3.2.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:bb3a1a179ecc68c0c8842633640cea1ba02e6f47dc37a412b3872ea02ed20e46"},
+    {file = "snowflake_connector_python-3.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1163dc676c14db571b4ccee9b891e610832f7ce4d555eb84473277d627793b95"},
+    {file = "snowflake_connector_python-3.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:503f8ea6d6e9c43e2a50782e9c241f66ced105e6513ce2f295c31bacb01a664a"},
+    {file = "snowflake_connector_python-3.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:46f13f63b2d6c5a5b858385cce80149611a749dea1e016e4400555230e293b3a"},
 ]
 
 [package.dependencies]
@@ -3453,8 +3504,10 @@ charset-normalizer = ">=2,<4"
 cryptography = ">=3.1.0,<42.0.0"
 filelock = ">=3.5,<4"
 idna = ">=2.5,<4"
+oscrypto = "<2.0.0"
 packaging = "*"
 platformdirs = ">=2.6.0,<4.0.0"
+pycryptodomex = ">=3.2,<3.5.0 || >3.5.0,<4.0.0"
 pyjwt = "<3.0.0"
 pyOpenSSL = ">=16.2.0,<24.0.0"
 pytz = "*"
@@ -3465,19 +3518,19 @@ typing-extensions = ">=4.3,<5"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-development = ["Cython", "coverage", "more-itertools", "numpy (<1.27.0)", "pendulum (!=2.1.1)", "pexpect", "pytest (<7.5.0)", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist", "pytzdata"]
+development = ["Cython", "coverage", "more-itertools", "numpy (<1.26.0)", "pendulum (!=2.1.1)", "pexpect", "pytest (<7.5.0)", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist", "pytzdata"]
 pandas = ["pandas (>=1.0.0,<2.1.0)", "pyarrow (>=10.0.1,<10.1.0)"]
 secure-local-storage = ["keyring (!=16.1.0,<25.0.0)"]
 
 [[package]]
 name = "snowflake-sqlalchemy"
-version = "1.5.1"
+version = "1.5.0"
 description = "Snowflake SQLAlchemy Dialect"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "snowflake-sqlalchemy-1.5.1.tar.gz", hash = "sha256:4f1383402ffc89311974bd810dee22003aef4af0f312a0fdb55778333ad1abf7"},
-    {file = "snowflake_sqlalchemy-1.5.1-py2.py3-none-any.whl", hash = "sha256:df022fb73bc04d68dfb3216ebf7a1bfbd14d22def9c38bbe05275beb258adcd0"},
+    {file = "snowflake-sqlalchemy-1.5.0.tar.gz", hash = "sha256:3ed0f77d09c8a9defd35c605743325a4dc21098e8f1c62ffc0347f42729db05a"},
+    {file = "snowflake_sqlalchemy-1.5.0-py2.py3-none-any.whl", hash = "sha256:e816f64e9b00dc2506b7a52d983263694031cd5ee06bac9fcedea2e47379a42a"},
 ]
 
 [package.dependencies]
@@ -3501,43 +3554,56 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.50"
+version = "1.4.49"
 description = "Database Abstraction Library"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "SQLAlchemy-1.4.50-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d00665725063692c42badfd521d0c4392e83c6c826795d38eb88fb108e5660e5"},
-    {file = "SQLAlchemy-1.4.50-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85292ff52ddf85a39367057c3d7968a12ee1fb84565331a36a8fead346f08796"},
-    {file = "SQLAlchemy-1.4.50-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d0fed0f791d78e7767c2db28d34068649dfeea027b83ed18c45a423f741425cb"},
-    {file = "SQLAlchemy-1.4.50-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db4db3c08ffbb18582f856545f058a7a5e4ab6f17f75795ca90b3c38ee0a8ba4"},
-    {file = "SQLAlchemy-1.4.50-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14b0cacdc8a4759a1e1bd47dc3ee3f5db997129eb091330beda1da5a0e9e5bd7"},
-    {file = "SQLAlchemy-1.4.50-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fb9cb60e0f33040e4f4681e6658a7eb03b5cb4643284172f91410d8c493dace"},
-    {file = "SQLAlchemy-1.4.50-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4cb501d585aa74a0f86d0ea6263b9c5e1d1463f8f9071392477fd401bd3c7cc"},
-    {file = "SQLAlchemy-1.4.50-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a7a66297e46f85a04d68981917c75723e377d2e0599d15fbe7a56abed5e2d75"},
-    {file = "SQLAlchemy-1.4.50-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1db0221cb26d66294f4ca18c533e427211673ab86c1fbaca8d6d9ff78654293"},
-    {file = "SQLAlchemy-1.4.50-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7dbe6369677a2bea68fe9812c6e4bbca06ebfa4b5cde257b2b0bf208709131"},
-    {file = "SQLAlchemy-1.4.50-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a9bddb60566dc45c57fd0a5e14dd2d9e5f106d2241e0a2dc0c1da144f9444516"},
-    {file = "SQLAlchemy-1.4.50-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82dd4131d88395df7c318eeeef367ec768c2a6fe5bd69423f7720c4edb79473c"},
-    {file = "SQLAlchemy-1.4.50-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:273505fcad22e58cc67329cefab2e436006fc68e3c5423056ee0513e6523268a"},
-    {file = "SQLAlchemy-1.4.50-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3257a6e09626d32b28a0c5b4f1a97bced585e319cfa90b417f9ab0f6145c33c"},
-    {file = "SQLAlchemy-1.4.50-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d69738d582e3a24125f0c246ed8d712b03bd21e148268421e4a4d09c34f521a5"},
-    {file = "SQLAlchemy-1.4.50-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34e1c5d9cd3e6bf3d1ce56971c62a40c06bfc02861728f368dcfec8aeedb2814"},
-    {file = "SQLAlchemy-1.4.50-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1fcee5a2c859eecb4ed179edac5ffbc7c84ab09a5420219078ccc6edda45436"},
-    {file = "SQLAlchemy-1.4.50-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbaf6643a604aa17e7a7afd74f665f9db882df5c297bdd86c38368f2c471f37d"},
-    {file = "SQLAlchemy-1.4.50-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2e70e0673d7d12fa6cd363453a0d22dac0d9978500aa6b46aa96e22690a55eab"},
-    {file = "SQLAlchemy-1.4.50-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b881ac07d15fb3e4f68c5a67aa5cdaf9eb8f09eb5545aaf4b0a5f5f4659be18"},
-    {file = "SQLAlchemy-1.4.50-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f6997da81114daef9203d30aabfa6b218a577fc2bd797c795c9c88c9eb78d49"},
-    {file = "SQLAlchemy-1.4.50-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdb77e1789e7596b77fd48d99ec1d2108c3349abd20227eea0d48d3f8cf398d9"},
-    {file = "SQLAlchemy-1.4.50-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:128a948bd40780667114b0297e2cc6d657b71effa942e0a368d8cc24293febb3"},
-    {file = "SQLAlchemy-1.4.50-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d526aeea1bd6a442abc7c9b4b00386fd70253b80d54a0930c0a216230a35be"},
-    {file = "SQLAlchemy-1.4.50.tar.gz", hash = "sha256:3b97ddf509fc21e10b09403b5219b06c5b558b27fc2453150274fa4e70707dbf"},
+    {file = "SQLAlchemy-1.4.49-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2e126cf98b7fd38f1e33c64484406b78e937b1a280e078ef558b95bf5b6895f6"},
+    {file = "SQLAlchemy-1.4.49-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:03db81b89fe7ef3857b4a00b63dedd632d6183d4ea5a31c5d8a92e000a41fc71"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:95b9df9afd680b7a3b13b38adf6e3a38995da5e162cc7524ef08e3be4e5ed3e1"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a63e43bf3f668c11bb0444ce6e809c1227b8f067ca1068898f3008a273f52b09"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f835c050ebaa4e48b18403bed2c0fda986525896efd76c245bdd4db995e51a4c"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c21b172dfb22e0db303ff6419451f0cac891d2e911bb9fbf8003d717f1bcf91"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-win32.whl", hash = "sha256:5fb1ebdfc8373b5a291485757bd6431de8d7ed42c27439f543c81f6c8febd729"},
+    {file = "SQLAlchemy-1.4.49-cp310-cp310-win_amd64.whl", hash = "sha256:f8a65990c9c490f4651b5c02abccc9f113a7f56fa482031ac8cb88b70bc8ccaa"},
+    {file = "SQLAlchemy-1.4.49-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8923dfdf24d5aa8a3adb59723f54118dd4fe62cf59ed0d0d65d940579c1170a4"},
+    {file = "SQLAlchemy-1.4.49-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9ab2c507a7a439f13ca4499db6d3f50423d1d65dc9b5ed897e70941d9e135b0"},
+    {file = "SQLAlchemy-1.4.49-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5debe7d49b8acf1f3035317e63d9ec8d5e4d904c6e75a2a9246a119f5f2fdf3d"},
+    {file = "SQLAlchemy-1.4.49-cp311-cp311-win32.whl", hash = "sha256:82b08e82da3756765c2e75f327b9bf6b0f043c9c3925fb95fb51e1567fa4ee87"},
+    {file = "SQLAlchemy-1.4.49-cp311-cp311-win_amd64.whl", hash = "sha256:171e04eeb5d1c0d96a544caf982621a1711d078dbc5c96f11d6469169bd003f1"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:36e58f8c4fe43984384e3fbe6341ac99b6b4e083de2fe838f0fdb91cebe9e9cb"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b31e67ff419013f99ad6f8fc73ee19ea31585e1e9fe773744c0f3ce58c039c30"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c14b29d9e1529f99efd550cd04dbb6db6ba5d690abb96d52de2bff4ed518bc95"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c40f3470e084d31247aea228aa1c39bbc0904c2b9ccbf5d3cfa2ea2dac06f26d"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-win32.whl", hash = "sha256:706bfa02157b97c136547c406f263e4c6274a7b061b3eb9742915dd774bbc264"},
+    {file = "SQLAlchemy-1.4.49-cp36-cp36m-win_amd64.whl", hash = "sha256:a7f7b5c07ae5c0cfd24c2db86071fb2a3d947da7bd487e359cc91e67ac1c6d2e"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:4afbbf5ef41ac18e02c8dc1f86c04b22b7a2125f2a030e25bbb4aff31abb224b"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24e300c0c2147484a002b175f4e1361f102e82c345bf263242f0449672a4bccf"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:201de072b818f8ad55c80d18d1a788729cccf9be6d9dc3b9d8613b053cd4836d"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7653ed6817c710d0c95558232aba799307d14ae084cc9b1f4c389157ec50df5c"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-win32.whl", hash = "sha256:647e0b309cb4512b1f1b78471fdaf72921b6fa6e750b9f891e09c6e2f0e5326f"},
+    {file = "SQLAlchemy-1.4.49-cp37-cp37m-win_amd64.whl", hash = "sha256:ab73ed1a05ff539afc4a7f8cf371764cdf79768ecb7d2ec691e3ff89abbc541e"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:37ce517c011560d68f1ffb28af65d7e06f873f191eb3a73af5671e9c3fada08a"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1878ce508edea4a879015ab5215546c444233881301e97ca16fe251e89f1c55"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e8e608983e6f85d0852ca61f97e521b62e67969e6e640fe6c6b575d4db68557"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccf956da45290df6e809ea12c54c02ace7f8ff4d765d6d3dfb3655ee876ce58d"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-win32.whl", hash = "sha256:f167c8175ab908ce48bd6550679cc6ea20ae169379e73c7720a28f89e53aa532"},
+    {file = "SQLAlchemy-1.4.49-cp38-cp38-win_amd64.whl", hash = "sha256:45806315aae81a0c202752558f0df52b42d11dd7ba0097bf71e253b4215f34f4"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:b6d0c4b15d65087738a6e22e0ff461b407533ff65a73b818089efc8eb2b3e1de"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a843e34abfd4c797018fd8d00ffffa99fd5184c421f190b6ca99def4087689bd"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1c890421651b45a681181301b3497e4d57c0d01dc001e10438a40e9a9c25ee77"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d26f280b8f0a8f497bc10573849ad6dc62e671d2468826e5c748d04ed9e670d5"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-win32.whl", hash = "sha256:ec2268de67f73b43320383947e74700e95c6770d0c68c4e615e9897e46296294"},
+    {file = "SQLAlchemy-1.4.49-cp39-cp39-win_amd64.whl", hash = "sha256:bbdf16372859b8ed3f4d05f925a984771cd2abd18bd187042f24be4886c2a15f"},
+    {file = "SQLAlchemy-1.4.49.tar.gz", hash = "sha256:06ff25cbae30c396c4b7737464f2a7fc37a67b7da409993b182b024cec80aed9"},
 ]
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
 
 [package.extras]
-aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
+aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
 aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
@@ -3719,13 +3785,13 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.12.2"
+version = "0.12.1"
 description = "Style preserving TOML library"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "tomlkit-0.12.2-py3-none-any.whl", hash = "sha256:eeea7ac7563faeab0a1ed8fe12c2e5a51c61f933f2502f7e9db0241a65163ad0"},
-    {file = "tomlkit-0.12.2.tar.gz", hash = "sha256:df32fab589a81f0d7dc525a4267b6d7a64ee99619cbd1eeb0fae32c1dd426977"},
+    {file = "tomlkit-0.12.1-py3-none-any.whl", hash = "sha256:712cbd236609acc6a3e2e97253dfc52d4c2082982a88f61b640ecf0817eab899"},
+    {file = "tomlkit-0.12.1.tar.gz", hash = "sha256:38e1ff8edb991273ec9f6181244a6a391ac30e9f5098e7535640ea6be97a7c86"},
 ]
 
 [[package]]
@@ -3867,6 +3933,17 @@ rich = ">=12.0.0"
 urllib3 = ">=1.26.0"
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.12"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.12.tar.gz", hash = "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062"},
+    {file = "types_PyYAML-6.0.12.12-py3-none-any.whl", hash = "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -3890,46 +3967,66 @@ files = [
 
 [[package]]
 name = "tzlocal"
-version = "5.2"
+version = "5.0.1"
 description = "tzinfo object for the local timezone"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8"},
-    {file = "tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"},
+    {file = "tzlocal-5.0.1-py3-none-any.whl", hash = "sha256:f3596e180296aaf2dbd97d124fe76ae3a0e3d32b258447de7b939b3fd4be992f"},
+    {file = "tzlocal-5.0.1.tar.gz", hash = "sha256:46eb99ad4bdb71f3f72b7d24f4267753e240944ecfc16f25d2719ba89827a803"},
 ]
 
 [package.dependencies]
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
+devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "urllib3"
-version = "1.26.18"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]
-brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.24.6"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.24.6-py3-none-any.whl", hash = "sha256:520d056652454c5098a00c0f073611ccbea4c79089331f60bf9d7ba247bb7381"},
+    {file = "virtualenv-20.24.6.tar.gz", hash = "sha256:02ece4f56fbf939dbbc33c0715159951d6bf14aaf5457b092e4548e1382455af"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<4"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
+
+[[package]]
 name = "websocket-client"
-version = "1.6.4"
+version = "1.6.3"
 description = "WebSocket client for Python with low level API options"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "websocket-client-1.6.4.tar.gz", hash = "sha256:b3324019b3c28572086c4a319f91d1dcd44e6e11cd340232978c684a7650d0df"},
-    {file = "websocket_client-1.6.4-py3-none-any.whl", hash = "sha256:084072e0a7f5f347ef2ac3d8698a5e0b4ffbfcab607628cadabc650fc9a83a24"},
+    {file = "websocket-client-1.6.3.tar.gz", hash = "sha256:3aad25d31284266bcfcfd1fd8a743f63282305a364b8d0948a43bd606acc652f"},
+    {file = "websocket_client-1.6.3-py3-none-any.whl", hash = "sha256:6cfc30d051ebabb73a5fa246efdcc14c8fbebbd0330f8984ac3bb6d9edd2ad03"},
 ]
 
 [package.extras]
@@ -3939,13 +4036,13 @@ test = ["websockets"]
 
 [[package]]
 name = "werkzeug"
-version = "3.0.1"
+version = "2.3.7"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"},
-    {file = "werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc"},
+    {file = "werkzeug-2.3.7-py3-none-any.whl", hash = "sha256:effc12dba7f3bd72e605ce49807bbe692bd729c3bb122a3b91747a6ae77df528"},
+    {file = "werkzeug-2.3.7.tar.gz", hash = "sha256:2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8"},
 ]
 
 [package.dependencies]
@@ -4103,4 +4200,4 @@ drivers-vector-redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "d938659bcfafcdc4dddc4cba305b2ebae35e659307794f58ea935093eeb954a4"
+content-hash = "db25a6b5cd3c54df717c60af158ff463b7f1bf6eb1b59e591ea9010e5ec02786"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,11 +120,11 @@ black = "^23.7.0"
 pyright = "^1.1.324"
 
 [tool.black]
-line-length=80
+line-length=120
 skip_magic_trailing_comma = true
 
 [tool.ruff]
-line-length=80
+line-length=120
 
 [tool.pyright]
 include = ["griptape"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ cryptography = "^41.0.4"
 dateparser = "^1.1.8"
 mail-parser = "^3.15.0"
 requests = "^2"
-pre-commit = "^3.5.0"
 
 
 cohere = { version = ">=4", optional = true }
@@ -118,6 +117,7 @@ optional = true
 ruff = "^0.0.286"
 black = "^23.7.0"
 pyright = "^1.1.324"
+pre-commit = "^3.5.0"
 
 [tool.black]
 line-length=120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ cryptography = "^41.0.4"
 dateparser = "^1.1.8"
 mail-parser = "^3.15.0"
 requests = "^2"
+pre-commit = "^3.5.0"
 
 
 cohere = { version = ">=4", optional = true }

--- a/tests/integration/drivers/vector/test_pgvector_vector_store_driver.py
+++ b/tests/integration/drivers/vector/test_pgvector_vector_store_driver.py
@@ -6,9 +6,7 @@ from tests.utils.postgres import can_connect_to_postgres
 from sqlalchemy import create_engine
 
 
-@pytest.mark.skipif(
-    not can_connect_to_postgres(), reason="Postgres is not present"
-)
+@pytest.mark.skipif(not can_connect_to_postgres(), reason="Postgres is not present")
 class TestPgVectorVectorStoreDriver:
     connection_string = "postgresql://postgres:postgres@localhost:5432/postgres"
     table_name = "griptape_vectors"
@@ -22,39 +20,27 @@ class TestPgVectorVectorStoreDriver:
     @pytest.fixture
     def vector_store_driver(self, embedding_driver):
         driver = PgVectorVectorStoreDriver(
-            connection_string=self.connection_string,
-            embedding_driver=embedding_driver,
-            table_name=self.table_name,
+            connection_string=self.connection_string, embedding_driver=embedding_driver, table_name=self.table_name
         )
 
         driver.setup()
 
         return driver
 
-    def test_initialize_requires_engine_or_connection_string(
-        self, embedding_driver
-    ):
+    def test_initialize_requires_engine_or_connection_string(self, embedding_driver):
         with pytest.raises(ValueError):
-            driver = PgVectorVectorStoreDriver(
-                embedding_driver=embedding_driver, table_name=self.table_name
-            )
+            driver = PgVectorVectorStoreDriver(embedding_driver=embedding_driver, table_name=self.table_name)
             driver.setup()
 
     def test_initialize_accepts_engine(self, embedding_driver):
         engine = create_engine(self.connection_string)
-        driver = PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver,
-            engine=engine,
-            table_name=self.table_name,
-        )
+        driver = PgVectorVectorStoreDriver(embedding_driver=embedding_driver, engine=engine, table_name=self.table_name)
 
         driver.setup()
 
     def test_initialize_accepts_connection_string(self, embedding_driver):
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver,
-            connection_string=self.connection_string,
-            table_name=self.table_name,
+            embedding_driver=embedding_driver, connection_string=self.connection_string, table_name=self.table_name
         )
 
         driver.setup()
@@ -67,23 +53,17 @@ class TestPgVectorVectorStoreDriver:
     def test_can_insert_vector_with_id(self, vector_store_driver):
         vector_id = str(uuid.uuid4())
 
-        result = vector_store_driver.upsert_vector(
-            self.vec1, vector_id=vector_id
-        )
+        result = vector_store_driver.upsert_vector(self.vec1, vector_id=vector_id)
 
         assert result == vector_id
 
     def test_can_update_vector_by_id(self, vector_store_driver):
         vector_id = str(uuid.uuid4())
 
-        result = vector_store_driver.upsert_vector(
-            self.vec1, vector_id=vector_id
-        )
+        result = vector_store_driver.upsert_vector(self.vec1, vector_id=vector_id)
         assert result == vector_id
 
-        result = vector_store_driver.upsert_vector(
-            self.vec2, vector_id=vector_id
-        )
+        result = vector_store_driver.upsert_vector(self.vec2, vector_id=vector_id)
         assert result == vector_id
 
         result = vector_store_driver.load_entry(vector_id)
@@ -96,14 +76,10 @@ class TestPgVectorVectorStoreDriver:
         result = vector_store_driver.load_entry(result)
         assert result.vector == pytest.approx(self.vec1)
 
-    def test_can_insert_and_load_entry_with_namespace(
-        self, vector_store_driver
-    ):
+    def test_can_insert_and_load_entry_with_namespace(self, vector_store_driver):
         namespace = str(uuid.uuid4())
 
-        result = vector_store_driver.upsert_vector(
-            self.vec1, namespace=namespace
-        )
+        result = vector_store_driver.upsert_vector(self.vec1, namespace=namespace)
         assert result is not None
 
         result = vector_store_driver.load_entry(result, namespace=namespace)
@@ -131,12 +107,8 @@ class TestPgVectorVectorStoreDriver:
     def test_can_load_by_namespace(self, vector_store_driver):
         namespace = str(uuid.uuid4())
 
-        vec1_id = vector_store_driver.upsert_vector(
-            self.vec1, namespace=namespace
-        )
-        vec2_id = vector_store_driver.upsert_vector(
-            self.vec2, namespace=namespace
-        )
+        vec1_id = vector_store_driver.upsert_vector(self.vec1, namespace=namespace)
+        vec2_id = vector_store_driver.upsert_vector(self.vec2, namespace=namespace)
 
         results = vector_store_driver.load_entries(namespace=namespace)
 
@@ -153,9 +125,7 @@ class TestPgVectorVectorStoreDriver:
         namespace = str(uuid.uuid4())
         embedding = vector_store_driver.embedding_driver.embed_string(value)
 
-        vector_id = vector_store_driver.upsert_vector(
-            embedding, namespace=namespace
-        )
+        vector_id = vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace)
 
         assert len(results) == 1
@@ -167,9 +137,7 @@ class TestPgVectorVectorStoreDriver:
         embedding = vector_store_driver.embedding_driver.embed_string(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
-        results = vector_store_driver.query(
-            value, namespace=namespace, distance_metric="cosine_distance"
-        )
+        results = vector_store_driver.query(value, namespace=namespace, distance_metric="cosine_distance")
 
         assert len(results) == 1
 
@@ -179,9 +147,7 @@ class TestPgVectorVectorStoreDriver:
         embedding = vector_store_driver.embedding_driver.embed_string(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
-        results = vector_store_driver.query(
-            value, namespace=namespace, distance_metric="l2_distance"
-        )
+        results = vector_store_driver.query(value, namespace=namespace, distance_metric="l2_distance")
 
         assert len(results) == 1
 
@@ -191,9 +157,7 @@ class TestPgVectorVectorStoreDriver:
         embedding = vector_store_driver.embedding_driver.embed_string(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
-        results = vector_store_driver.query(
-            value, namespace=namespace, distance_metric="inner_product"
-        )
+        results = vector_store_driver.query(value, namespace=namespace, distance_metric="inner_product")
 
         assert len(results) == 1
 
@@ -203,16 +167,12 @@ class TestPgVectorVectorStoreDriver:
         embedding = vector_store_driver.embedding_driver.embed_string(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
-        results = vector_store_driver.query(
-            value, namespace=namespace, include_vectors=True
-        )
+        results = vector_store_driver.query(value, namespace=namespace, include_vectors=True)
 
         assert len(results) == 1
         assert results[0].vector == pytest.approx(embedding)
 
-    def test_can_use_custom_table_name(
-        self, embedding_driver, vector_store_driver
-    ):
+    def test_can_use_custom_table_name(self, embedding_driver, vector_store_driver):
         """This test ensures at least one row exists in the default table before specifying
         a custom table name. After inserting another row, we should be able to query only one
         vector from the table, and it should be the vector added to the table with the new name.
@@ -221,9 +181,7 @@ class TestPgVectorVectorStoreDriver:
 
         new_table_name = str(uuid.uuid4())
         new_vector_store_driver = PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver,
-            connection_string=self.connection_string,
-            table_name=new_table_name,
+            embedding_driver=embedding_driver, connection_string=self.connection_string, table_name=new_table_name
         )
 
         new_vector_store_driver.setup()

--- a/tests/integration/tasks/test_prompt_task.py
+++ b/tests/integration/tasks/test_prompt_task.py
@@ -9,22 +9,13 @@ import pytest
 
 
 class TestPromptTask:
-    @pytest.fixture(
-        autouse=True,
-        params=PROMPT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=PROMPT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
 
-        return Agent(
-            memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET]
-        )
+        return Agent(memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET])
 
     def test_prompt_task(self, agent):
-        result = run_structure(
-            agent,
-            "Write a haiku about pirates. It must contain the word 'ship'.",
-        )
+        result = run_structure(agent, "Write a haiku about pirates. It must contain the word 'ship'.")
 
         assert fuzz.partial_ratio(result["answer"], "ship") >= 95

--- a/tests/integration/tasks/test_summary_task.py
+++ b/tests/integration/tasks/test_summary_task.py
@@ -11,22 +11,12 @@ import pytest
 
 
 class TestSummaryTask:
-    @pytest.fixture(
-        autouse=True,
-        params=SUMMARY_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=SUMMARY_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
 
-        agent = Agent(
-            memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET]
-        )
-        agent.add_task(
-            TextSummaryTask(
-                summary_engine=PromptSummaryEngine(prompt_driver=request.param)
-            )
-        )
+        agent = Agent(memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET])
+        agent.add_task(TextSummaryTask(summary_engine=PromptSummaryEngine(prompt_driver=request.param)))
 
         return agent
 

--- a/tests/integration/tasks/test_toolkit_task.py
+++ b/tests/integration/tasks/test_toolkit_task.py
@@ -9,11 +9,7 @@ import pytest
 
 
 class TestToolkitTask:
-    @pytest.fixture(
-        autouse=True,
-        params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         import os
         from griptape.structures import Agent
@@ -23,8 +19,7 @@ class TestToolkitTask:
         return Agent(
             tools=[
                 WebSearch(
-                    google_api_key=os.environ["GOOGLE_API_KEY"],
-                    google_api_search_id=os.environ["GOOGLE_API_SEARCH_ID"],
+                    google_api_key=os.environ["GOOGLE_API_KEY"], google_api_search_id=os.environ["GOOGLE_API_SEARCH_ID"]
                 ),
                 WebScraper(),
             ],
@@ -34,9 +29,6 @@ class TestToolkitTask:
         )
 
     def test_multi_step_cot(self, agent):
-        result = run_structure(
-            agent,
-            "Give me a summary of the top 2 search results about parrot facts.",
-        )
+        result = run_structure(agent, "Give me a summary of the top 2 search results about parrot facts.")
 
         assert fuzz.partial_ratio(result["result"], "python framework")

--- a/tests/integration/tools/test_calculator.py
+++ b/tests/integration/tools/test_calculator.py
@@ -9,21 +9,12 @@ import pytest
 
 
 class TestCalculator:
-    @pytest.fixture(
-        autouse=True,
-        params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
         from griptape.tools import Calculator
 
-        return Agent(
-            tools=[Calculator()],
-            memory=None,
-            prompt_driver=request.param,
-            rulesets=[OUTPUT_RULESET],
-        )
+        return Agent(tools=[Calculator()], memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET])
 
     def test_calculate(self, agent):
         result = run_structure(agent, "What is 7 times 3 divided by 5 plus 10.")

--- a/tests/integration/tools/test_file_manager.py
+++ b/tests/integration/tools/test_file_manager.py
@@ -9,40 +9,24 @@ import pytest
 
 
 class TestFileManager:
-    @pytest.fixture(
-        autouse=True,
-        params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
         from griptape.tools import FileManager
 
-        return Agent(
-            tools=[FileManager()],
-            memory=None,
-            prompt_driver=request.param,
-            rulesets=[OUTPUT_RULESET],
-        )
+        return Agent(tools=[FileManager()], memory=None, prompt_driver=request.param, rulesets=[OUTPUT_RULESET])
 
     def test_save_content_to_disk(self, agent):
-        result = run_structure(
-            agent,
-            'Write the content "Hello World!" to a file called "poem.txt".',
-        )
+        result = run_structure(agent, 'Write the content "Hello World!" to a file called "poem.txt".')
 
         assert result["result"] == "success"
 
-        result = run_structure(
-            agent, 'Write the content "Hello World!" to a file called ".".'
-        )
+        result = run_structure(agent, 'Write the content "Hello World!" to a file called ".".')
 
         assert result["result"] == "failure"
 
     def test_load_files_from_disk(self, agent):
-        result = run_structure(
-            agent, "Read the content of the file called 'poem.txt'."
-        )
+        result = run_structure(agent, "Read the content of the file called 'poem.txt'.")
 
         assert fuzz.partial_ratio(result["answer"], "Hello World!") == 100
         assert result["result"] == "success"

--- a/tests/integration/tools/test_google_docs_client.py
+++ b/tests/integration/tools/test_google_docs_client.py
@@ -9,11 +9,7 @@ from tests.utils.structure_runner import (
 
 
 class TestGoogleDocsClient:
-    @pytest.fixture(
-        autouse=True,
-        params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
         from griptape.tools import GoogleDocsClient
@@ -42,41 +38,28 @@ class TestGoogleDocsClient:
         )
 
     def test_create_google_doc(self, agent):
-        result = run_structure(
-            agent, 'Create a Google Doc called "Test Document".'
-        )
+        result = run_structure(agent, 'Create a Google Doc called "Test Document".')
 
         assert result["task_result"] == "success"
         assert result["task_output"] is not None
 
     def test_append_text(self, agent):
-        result = run_structure(
-            agent,
-            'Append text "Appended Text." to the Google Doc "Test Document".',
-        )
+        result = run_structure(agent, 'Append text "Appended Text." to the Google Doc "Test Document".')
 
         assert result["task_result"] == "success"
 
     def test_prepend_text(self, agent):
-        result = run_structure(
-            agent,
-            'Prepend text "Prepended Text." to the Google Doc "Test Document".',
-        )
+        result = run_structure(agent, 'Prepend text "Prepended Text." to the Google Doc "Test Document".')
 
         assert result["task_result"] == "success"
 
     def test_download_google_doc(self, agent):
-        result = run_structure(
-            agent, 'Download the Google Doc "Test Document".'
-        )
+        result = run_structure(agent, 'Download the Google Doc "Test Document".')
 
         assert result["task_result"] == "success"
         assert result["task_output"] is not None
 
     def test_save_content_to_google_doc(self, agent):
-        result = run_structure(
-            agent,
-            'Save content "Hello, Google Doc!" to the Google Doc "Test Document".',
-        )
+        result = run_structure(agent, 'Save content "Hello, Google Doc!" to the Google Doc "Test Document".')
 
         assert result["task_result"] == "success"

--- a/tests/integration/tools/test_google_drive_client.py
+++ b/tests/integration/tools/test_google_drive_client.py
@@ -9,11 +9,7 @@ from tests.utils.structure_runner import (
 
 
 class TestGoogleDriveClient:
-    @pytest.fixture(
-        autouse=True,
-        params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS,
-        ids=prompt_driver_id_fn,
-    )
+    @pytest.fixture(autouse=True, params=TOOLKIT_TASK_CAPABLE_PROMPT_DRIVERS, ids=prompt_driver_id_fn)
     def agent(self, request):
         from griptape.structures import Agent
         from griptape.tools import GoogleDriveClient
@@ -48,34 +44,24 @@ class TestGoogleDriveClient:
         assert result["task_output"] is not None
 
     def test_download_file(self, agent):
-        result = run_structure(
-            agent, 'Download the file called "sample1.txt" from Google Drive.'
-        )
+        result = run_structure(agent, 'Download the file called "sample1.txt" from Google Drive.')
 
         assert result["task_result"] == "success"
         assert result["task_output"] is not None
 
     def test_save_content(self, agent):
-        result = run_structure(
-            agent,
-            'Save content "Hello, Google Drive!" on Google Drive as "hello.txt".',
-        )
+        result = run_structure(agent, 'Save content "Hello, Google Drive!" on Google Drive as "hello.txt".')
 
         assert result["task_result"] == "success"
 
     def test_search_files_by_name(self, agent):
-        result = run_structure(
-            agent, 'Search files with name "hello.txt" on Google Drive.'
-        )
+        result = run_structure(agent, 'Search files with name "hello.txt" on Google Drive.')
 
         assert result["task_result"] == "success"
         assert result["task_output"] is not None
 
     def test_search_files_by_content(self, agent):
-        result = run_structure(
-            agent,
-            'Search files with content "Hello, Google Drive!" on Google Drive.',
-        )
+        result = run_structure(agent, 'Search files with content "Hello, Google Drive!" on Google Drive.')
 
         assert result["task_result"] == "success"
         assert result["task_output"] is not None

--- a/tests/mocks/docker/fake_api.py
+++ b/tests/mocks/docker/fake_api.py
@@ -236,14 +236,7 @@ def get_fake_diff():
 
 def get_fake_events():
     status_code = 200
-    response = [
-        {
-            "status": "stop",
-            "id": FAKE_CONTAINER_ID,
-            "from": FAKE_IMAGE_ID,
-            "time": 1423247867,
-        }
-    ]
+    response = [{"status": "stop", "id": FAKE_CONTAINER_ID, "from": FAKE_IMAGE_ID, "time": 1423247867}]
     return status_code, response
 
 
@@ -390,18 +383,7 @@ def get_fake_stats():
 
 def get_fake_top():
     return 200, {
-        "Processes": [
-            [
-                "root",
-                "26501",
-                "6907",
-                "0",
-                "10:32",
-                "pts/55",
-                "00:00:00",
-                "sleep 60",
-            ]
-        ],
+        "Processes": [["root", "26501", "6907", "0", "10:32", "pts/55", "00:00:00", "sleep 60"]],
         "Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"],
     }
 
@@ -464,10 +446,7 @@ def get_fake_network_list():
             "Driver": "bridge",
             "EnableIPv6": False,
             "Internal": False,
-            "IPAM": {
-                "Driver": "default",
-                "Config": [{"Subnet": "172.17.0.0/16"}],
-            },
+            "IPAM": {"Driver": "default", "Config": [{"Subnet": "172.17.0.0/16"}]},
             "Containers": {
                 FAKE_CONTAINER_ID: {
                     "EndpointID": "ed2419a97c1d99",
@@ -565,41 +544,20 @@ fake_responses = {
     f"{prefix}/{CURRENT_VERSION}/events": get_fake_events,
     (f"{prefix}/{CURRENT_VERSION}/volumes", "GET"): get_fake_volume_list,
     (f"{prefix}/{CURRENT_VERSION}/volumes/create", "POST"): get_fake_volume,
-    (
-        "{1}/{0}/volumes/{2}".format(CURRENT_VERSION, prefix, FAKE_VOLUME_NAME),
-        "GET",
-    ): get_fake_volume,
-    (
-        "{1}/{0}/volumes/{2}".format(CURRENT_VERSION, prefix, FAKE_VOLUME_NAME),
-        "DELETE",
-    ): fake_remove_volume,
-    (
-        "{1}/{0}/nodes/{2}/update?version=1".format(
-            CURRENT_VERSION, prefix, FAKE_NODE_ID
-        ),
-        "POST",
-    ): post_fake_update_node,
+    ("{1}/{0}/volumes/{2}".format(CURRENT_VERSION, prefix, FAKE_VOLUME_NAME), "GET"): get_fake_volume,
+    ("{1}/{0}/volumes/{2}".format(CURRENT_VERSION, prefix, FAKE_VOLUME_NAME), "DELETE"): fake_remove_volume,
+    ("{1}/{0}/nodes/{2}/update?version=1".format(CURRENT_VERSION, prefix, FAKE_NODE_ID), "POST"): post_fake_update_node,
     (f"{prefix}/{CURRENT_VERSION}/swarm/join", "POST"): post_fake_join_swarm,
     (f"{prefix}/{CURRENT_VERSION}/networks", "GET"): get_fake_network_list,
     (f"{prefix}/{CURRENT_VERSION}/networks/create", "POST"): post_fake_network,
+    ("{1}/{0}/networks/{2}".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID), "GET"): get_fake_network,
+    ("{1}/{0}/networks/{2}".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID), "DELETE"): delete_fake_network,
     (
-        "{1}/{0}/networks/{2}".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID),
-        "GET",
-    ): get_fake_network,
-    (
-        "{1}/{0}/networks/{2}".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID),
-        "DELETE",
-    ): delete_fake_network,
-    (
-        "{1}/{0}/networks/{2}/connect".format(
-            CURRENT_VERSION, prefix, FAKE_NETWORK_ID
-        ),
+        "{1}/{0}/networks/{2}/connect".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID),
         "POST",
     ): post_fake_network_connect,
     (
-        "{1}/{0}/networks/{2}/disconnect".format(
-            CURRENT_VERSION, prefix, FAKE_NETWORK_ID
-        ),
+        "{1}/{0}/networks/{2}/disconnect".format(CURRENT_VERSION, prefix, FAKE_NETWORK_ID),
         "POST",
     ): post_fake_network_disconnect,
     f"{prefix}/{CURRENT_VERSION}/secrets/create": post_fake_secret,

--- a/tests/mocks/docker/fake_api_client.py
+++ b/tests/mocks/docker/fake_api_client.py
@@ -33,18 +33,14 @@ def make_fake_api_client(overrides=None):
         "build.return_value": fake_api.FAKE_IMAGE_ID,
         "commit.return_value": fake_api.post_fake_commit()[1],
         "containers.return_value": fake_api.get_fake_containers()[1],
-        "create_container.return_value": fake_api.post_fake_create_container()[
-            1
-        ],
+        "create_container.return_value": fake_api.post_fake_create_container()[1],
         "create_host_config.side_effect": api_client.create_host_config,
         "create_network.return_value": fake_api.post_fake_network()[1],
         "create_secret.return_value": fake_api.post_fake_secret()[1],
         "exec_create.return_value": fake_api.post_fake_exec_create()[1],
         "exec_start.return_value": fake_api.post_fake_exec_start()[1],
         "images.return_value": fake_api.get_fake_images()[1],
-        "inspect_container.return_value": fake_api.get_fake_inspect_container()[
-            1
-        ],
+        "inspect_container.return_value": fake_api.get_fake_inspect_container()[1],
         "inspect_image.return_value": fake_api.get_fake_inspect_image()[1],
         "inspect_network.return_value": fake_api.get_fake_network()[1],
         "logs.return_value": b"hello world\n",

--- a/tests/mocks/docker/fake_stat.py
+++ b/tests/mocks/docker/fake_stat.py
@@ -13,21 +13,12 @@ OBJ = {
     "cpu_stats": {
         "cpu_usage": {
             "total_usage": 157260874053,
-            "percpu_usage": [
-                52196306950,
-                24118413549,
-                53292684398,
-                27653469156,
-            ],
+            "percpu_usage": [52196306950, 24118413549, 53292684398, 27653469156],
             "usage_in_kernelmode": 37140000000,
             "usage_in_usermode": 62140000000,
         },
         "system_cpu_usage": 3.0881377e14,
-        "throttling_data": {
-            "periods": 0,
-            "throttled_periods": 0,
-            "throttled_time": 0,
-        },
+        "throttling_data": {"periods": 0, "throttled_periods": 0, "throttled_time": 0},
     },
     "memory_stats": {
         "usage": 179314688,

--- a/tests/mocks/invalid_mock_tool/tool.py
+++ b/tests/mocks/invalid_mock_tool/tool.py
@@ -15,9 +15,7 @@ class InvalidMockTool(BaseTool):
         }
     }
 
-    test_field: str = field(
-        default="test", kw_only=True, metadata={"env": "TEST_FIELD"}
-    )
+    test_field: str = field(default="test", kw_only=True, metadata={"env": "TEST_FIELD"})
 
     @activity(config=configs["test"])
     def test(self, value: any) -> str:

--- a/tests/mocks/mock_embedding_driver.py
+++ b/tests/mocks/mock_embedding_driver.py
@@ -7,9 +7,7 @@ from tests.mocks.mock_tokenizer import MockTokenizer
 class MockEmbeddingDriver(BaseEmbeddingDriver):
     dimensions: int = field(default=42, kw_only=True)
     max_attempts: int = field(default=1, kw_only=True)
-    tokenizer: MockTokenizer = field(
-        factory=lambda: MockTokenizer(model="foo bar"), kw_only=True
-    )
+    tokenizer: MockTokenizer = field(factory=lambda: MockTokenizer(model="foo bar"), kw_only=True)
 
     def try_embed_chunk(self, _: str) -> list[float]:
         return [0, 1]

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -12,9 +12,7 @@ class MockFailingPromptDriver(BasePromptDriver):
     max_failures: int
     current_attempt: int = 0
     model: str = "test-model"
-    tokenizer: BaseTokenizer = OpenAiTokenizer(
-        model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-    )
+    tokenizer: BaseTokenizer = OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         if self.current_attempt < self.max_failures:

--- a/tests/mocks/mock_prompt_driver.py
+++ b/tests/mocks/mock_prompt_driver.py
@@ -10,9 +10,7 @@ from griptape.artifacts import TextArtifact
 @define
 class MockPromptDriver(BasePromptDriver):
     model: str = "test-model"
-    tokenizer: BaseTokenizer = OpenAiTokenizer(
-        model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-    )
+    tokenizer: BaseTokenizer = OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
     mock_output: str = field(default="mock output", kw_only=True)
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:

--- a/tests/mocks/mock_tool/tool.py
+++ b/tests/mocks/mock_tool/tool.py
@@ -1,11 +1,6 @@
 from attr import define, field
 from schema import Schema, Literal
-from griptape.artifacts import (
-    TextArtifact,
-    ErrorArtifact,
-    BaseArtifact,
-    ListArtifact,
-)
+from griptape.artifacts import TextArtifact, ErrorArtifact, BaseArtifact, ListArtifact
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 
@@ -52,10 +47,7 @@ class MockTool(BaseTool):
         return ListArtifact([TextArtifact("foo"), TextArtifact("bar")])
 
     @activity(
-        config={
-            "description": "test description",
-            "schema": Schema({Literal("test"): str}, description="Test input"),
-        }
+        config={"description": "test description", "schema": Schema({Literal("test"): str}, description="Test input")}
     )
     def test_without_default_memory(self, value: dict) -> str:
         return f"ack {value['values']['test']}"

--- a/tests/mocks/mock_value_prompt_driver.py
+++ b/tests/mocks/mock_value_prompt_driver.py
@@ -9,9 +9,7 @@ from griptape.artifacts import TextArtifact
 class MockValuePromptDriver(BasePromptDriver):
     value: str
     model: str = "test-model"
-    tokenizer: BaseTokenizer = OpenAiTokenizer(
-        model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-    )
+    tokenizer: BaseTokenizer = OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
     def try_run(self, value: str) -> TextArtifact:
         return TextArtifact(value=self.value)

--- a/tests/unit/artifacts/test_base_artifact.py
+++ b/tests/unit/artifacts/test_base_artifact.py
@@ -1,12 +1,5 @@
 import pytest
-from griptape.artifacts import (
-    BaseArtifact,
-    TextArtifact,
-    ErrorArtifact,
-    InfoArtifact,
-    ListArtifact,
-    BlobArtifact,
-)
+from griptape.artifacts import BaseArtifact, TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact, BlobArtifact
 
 
 class TestBaseArtifact:
@@ -32,22 +25,14 @@ class TestBaseArtifact:
         assert artifact.to_text() == "foobar"
 
     def test_list_artifact_from_dict(self):
-        dict_value = {
-            "type": "ListArtifact",
-            "value": [{"type": "TextArtifact", "value": "foobar"}],
-        }
+        dict_value = {"type": "ListArtifact", "value": [{"type": "TextArtifact", "value": "foobar"}]}
         artifact = BaseArtifact.from_dict(dict_value)
 
         assert isinstance(artifact, ListArtifact)
         assert artifact.to_text() == "foobar"
 
     def test_blob_artifact_from_dict(self):
-        dict_value = {
-            "type": "BlobArtifact",
-            "value": b"Zm9vYmFy",
-            "dir_name": "foo",
-            "name": "bar",
-        }
+        dict_value = {"type": "BlobArtifact", "value": b"Zm9vYmFy", "dir_name": "foo", "name": "bar"}
         artifact = BaseArtifact.from_dict(dict_value)
 
         assert isinstance(artifact, BlobArtifact)

--- a/tests/unit/artifacts/test_blob_artifact.py
+++ b/tests/unit/artifacts/test_blob_artifact.py
@@ -13,20 +13,14 @@ class TestBlobArtifact:
 
     def test_to_text_encoding(self):
         assert (
-            BlobArtifact(
-                "ß".encode("ascii", errors="backslashreplace"),
-                name="foobar.txt",
-                encoding="ascii",
-            ).to_text()
+            BlobArtifact("ß".encode("ascii", errors="backslashreplace"), name="foobar.txt", encoding="ascii").to_text()
             == "\\xdf"
         )
 
     def test_to_text_encoding_error(self):
         with pytest.raises(ValueError):
             assert BlobArtifact(
-                "ß".encode("utf-8", errors="backslashreplace"),
-                name="foobar.txt",
-                encoding="ascii",
+                "ß".encode("utf-8", errors="backslashreplace"), name="foobar.txt", encoding="ascii"
             ).to_text()
 
     def test_to_text_encoding_error_handler(self):
@@ -41,23 +35,13 @@ class TestBlobArtifact:
         )
 
     def test_to_dict(self):
-        assert (
-            BlobArtifact(
-                b"foobar", name="foobar.txt", dir_name="foo"
-            ).to_dict()["name"]
-            == "foobar.txt"
-        )
+        assert BlobArtifact(b"foobar", name="foobar.txt", dir_name="foo").to_dict()["name"] == "foobar.txt"
 
     def test_full_path_with_path(self):
-        assert (
-            BlobArtifact(b"foobar", name="foobar.txt", dir_name="foo").full_path
-            == "foo/foobar.txt"
-        )
+        assert BlobArtifact(b"foobar", name="foobar.txt", dir_name="foo").full_path == "foo/foobar.txt"
 
     def test_full_path_without_path(self):
-        assert (
-            BlobArtifact(b"foobar", name="foobar.txt").full_path == "foobar.txt"
-        )
+        assert BlobArtifact(b"foobar", name="foobar.txt").full_path == "foobar.txt"
 
     def test_serialization(self):
         artifact = BlobArtifact(b"foobar", name="foobar.txt", dir_name="foo")
@@ -70,9 +54,7 @@ class TestBlobArtifact:
     def test_deserialization(self):
         artifact = BlobArtifact(b"foobar", name="foobar.txt", dir_name="foo")
         artifact_dict = BlobArtifactSchema().dump(artifact)
-        deserialized_artifact: BlobArtifact = BaseArtifact.from_dict(
-            artifact_dict
-        )
+        deserialized_artifact: BlobArtifact = BaseArtifact.from_dict(artifact_dict)
 
         assert deserialized_artifact.name == "foobar.txt"
         assert deserialized_artifact.dir_name == "foo"

--- a/tests/unit/artifacts/test_csv_row_artifact.py
+++ b/tests/unit/artifacts/test_csv_row_artifact.py
@@ -5,33 +5,23 @@ from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 class TestCsvRowArtifact:
     def test_value_type_conversion(self):
         assert CsvRowArtifact({"foo": "bar"}).value == {"foo": "bar"}
-        assert CsvRowArtifact({"foo": {"bar": "baz"}}).value == {
-            "foo": {"bar": "baz"}
-        }
+        assert CsvRowArtifact({"foo": {"bar": "baz"}}).value == {"foo": {"bar": "baz"}}
         assert CsvRowArtifact('{"foo": "bar"}').value == {"foo": "bar"}
 
     def test___add__(self):
-        assert (
-            CsvRowArtifact({"test1": "foo"}) + CsvRowArtifact({"test2": "bar"})
-        ).value == {"test1": "foo", "test2": "bar"}
+        assert (CsvRowArtifact({"test1": "foo"}) + CsvRowArtifact({"test2": "bar"})).value == {
+            "test1": "foo",
+            "test2": "bar",
+        }
 
     def test_generate_embedding(self):
-        assert CsvRowArtifact({"test1": "foo"}).generate_embedding(
-            MockEmbeddingDriver()
-        ) == [0, 1]
+        assert CsvRowArtifact({"test1": "foo"}).generate_embedding(MockEmbeddingDriver()) == [0, 1]
 
     def test_to_text(self):
-        assert (
-            CsvRowArtifact(
-                {"test1": "foo|bar", "test2": 1}, delimiter="|"
-            ).to_text()
-            == '"foo|bar"|1'
-        )
+        assert CsvRowArtifact({"test1": "foo|bar", "test2": 1}, delimiter="|").to_text() == '"foo|bar"|1'
 
     def test_to_dict(self):
-        assert CsvRowArtifact({"test1": "foo"}).to_dict()["value"] == {
-            "test1": "foo"
-        }
+        assert CsvRowArtifact({"test1": "foo"}).to_dict()["value"] == {"test1": "foo"}
 
     def test_name(self):
         artifact = CsvRowArtifact({})

--- a/tests/unit/artifacts/test_list_artifact.py
+++ b/tests/unit/artifacts/test_list_artifact.py
@@ -1,38 +1,17 @@
 import pytest
-from griptape.artifacts import (
-    ListArtifact,
-    TextArtifact,
-    BlobArtifact,
-    CsvRowArtifact,
-)
+from griptape.artifacts import ListArtifact, TextArtifact, BlobArtifact, CsvRowArtifact
 
 
 class TestListArtifact:
     def test_to_text(self):
-        assert (
-            ListArtifact([TextArtifact("foo"), TextArtifact("bar")]).to_text()
-            == "foo\n\nbar"
-        )
-        assert (
-            ListArtifact(
-                [TextArtifact("foo"), TextArtifact("bar")],
-                item_separator="test",
-            ).to_text()
-            == "footestbar"
-        )
+        assert ListArtifact([TextArtifact("foo"), TextArtifact("bar")]).to_text() == "foo\n\nbar"
+        assert ListArtifact([TextArtifact("foo"), TextArtifact("bar")], item_separator="test").to_text() == "footestbar"
 
     def test_to_dict(self):
-        assert (
-            ListArtifact([TextArtifact("foobar")]).to_dict()["value"][0][
-                "value"
-            ]
-            == "foobar"
-        )
+        assert ListArtifact([TextArtifact("foobar")]).to_dict()["value"][0]["value"] == "foobar"
 
     def test___add__(self):
-        artifact = ListArtifact([TextArtifact("foo")]) + ListArtifact(
-            [TextArtifact("bar")]
-        )
+        artifact = ListArtifact([TextArtifact("foo")]) + ListArtifact([TextArtifact("bar")])
 
         assert isinstance(artifact, ListArtifact)
         assert len(artifact) == 2
@@ -48,12 +27,8 @@ class TestListArtifact:
 
     def test_is_type(self):
         assert ListArtifact([TextArtifact("foo")]).is_type(TextArtifact)
-        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(
-            TextArtifact
-        )
-        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(
-            CsvRowArtifact
-        )
+        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(TextArtifact)
+        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(CsvRowArtifact)
 
     def test_has_items(self):
         assert not ListArtifact().has_items()

--- a/tests/unit/artifacts/test_text_artifact.py
+++ b/tests/unit/artifacts/test_text_artifact.py
@@ -13,9 +13,7 @@ class TestTextArtifact:
         assert (TextArtifact("foo") + TextArtifact("bar")).value == "foobar"
 
     def test_generate_embedding(self):
-        assert TextArtifact("foobar").generate_embedding(
-            MockEmbeddingDriver()
-        ) == [0, 1]
+        assert TextArtifact("foobar").generate_embedding(MockEmbeddingDriver()) == [0, 1]
 
     def test_embedding(self):
         artifact = TextArtifact("foobar")
@@ -30,9 +28,7 @@ class TestTextArtifact:
     def test_token_count(self):
         assert (
             TextArtifact("foobarbaz").token_count(
-                OpenAiTokenizer(
-                    model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-                )
+                OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
             )
             == 2
         )
@@ -41,19 +37,13 @@ class TestTextArtifact:
         assert TextArtifact("foobar").to_dict()["value"] == "foobar"
 
     def test_from_dict(self):
-        assert (
-            BaseArtifact.from_dict(TextArtifact("foobar").to_dict()).value
-            == "foobar"
-        )
+        assert BaseArtifact.from_dict(TextArtifact("foobar").to_dict()).value == "foobar"
 
     def test_to_json(self):
         assert json.loads(TextArtifact("foobar").to_json())["value"] == "foobar"
 
     def test_from_json(self):
-        assert (
-            BaseArtifact.from_json(TextArtifact("foobar").to_json()).value
-            == "foobar"
-        )
+        assert BaseArtifact.from_json(TextArtifact("foobar").to_json()).value == "foobar"
 
     def test_name(self):
         artifact = TextArtifact("foo")

--- a/tests/unit/chunkers/test_pdf_chunker.py
+++ b/tests/unit/chunkers/test_pdf_chunker.py
@@ -12,10 +12,7 @@ class TestPdfChunker:
         return PdfChunker(max_tokens=MAX_TOKENS)
 
     def test_chunk(self, chunker):
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/bitcoin.pdf",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/bitcoin.pdf")
 
         reader = PdfReader(path)
         text = "".join([p.extract_text() for p in reader.pages])

--- a/tests/unit/chunkers/test_text_chunker.py
+++ b/tests/unit/chunkers/test_text_chunker.py
@@ -12,16 +12,12 @@ class TestTextChunker:
         return TextChunker(max_tokens=MAX_TOKENS)
 
     def test_chunk_with_string(self, chunker):
-        chunks = chunker.chunk(
-            gen_paragraph(MAX_TOKENS * 2, chunker.tokenizer, " ")
-        )
+        chunks = chunker.chunk(gen_paragraph(MAX_TOKENS * 2, chunker.tokenizer, " "))
 
         assert len(chunks) == 3
 
     def test_chunk_with_text_artifact(self, chunker):
-        chunks = chunker.chunk(
-            TextArtifact(gen_paragraph(MAX_TOKENS * 2, chunker.tokenizer, " "))
-        )
+        chunks = chunker.chunk(TextArtifact(gen_paragraph(MAX_TOKENS * 2, chunker.tokenizer, " ")))
 
         assert len(chunks) == 3
 
@@ -68,10 +64,7 @@ class TestTextChunker:
         assert chunks[3].value.endswith(". foo-11.")
 
     def test_contiguous_chunks(self, chunker):
-        text = [
-            gen_paragraph(MAX_TOKENS, chunker.tokenizer, ""),
-            gen_paragraph(MAX_TOKENS, chunker.tokenizer, ""),
-        ]
+        text = [gen_paragraph(MAX_TOKENS, chunker.tokenizer, ""), gen_paragraph(MAX_TOKENS, chunker.tokenizer, "")]
         chunks = chunker.chunk("".join(text))
 
         assert len(chunks) == 2

--- a/tests/unit/chunkers/utils.py
+++ b/tests/unit/chunkers/utils.py
@@ -1,20 +1,14 @@
 from griptape.tokenizers import BaseTokenizer
 
 
-def gen_paragraph(
-    max_tokens: int, tokenizer: BaseTokenizer, sentence_separator: str
-) -> str:
+def gen_paragraph(max_tokens: int, tokenizer: BaseTokenizer, sentence_separator: str) -> str:
     all_text = ""
     word = "foo"
     index = 0
     add_word = lambda base, w, i: sentence_separator.join([base, f"{w}-{i}"])
 
     while max_tokens >= tokenizer.count_tokens(add_word(all_text, word, index)):
-        all_text = (
-            f"{word}-{index}"
-            if all_text == ""
-            else add_word(all_text, word, index)
-        )
+        all_text = f"{word}-{index}" if all_text == "" else add_word(all_text, word, index)
         index += 1
 
     return all_text + sentence_separator

--- a/tests/unit/drivers/embedding/test_azure_openai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_azure_openai_embedding_driver.py
@@ -11,9 +11,7 @@ class TestAzureOpenAiEmbeddingDriver:
 
     @pytest.fixture
     def driver(self):
-        return AzureOpenAiEmbeddingDriver(
-            api_base="foobar", model="gpt-4", deployment_id="foobar"
-        )
+        return AzureOpenAiEmbeddingDriver(api_base="foobar", model="gpt-4", deployment_id="foobar")
 
     def test_init(self, driver):
         assert driver

--- a/tests/unit/drivers/embedding/test_base_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_base_embedding_driver.py
@@ -25,9 +25,7 @@ class TestBaseEmbeddingDriver:
         assert embedding == [0, 1]
 
     @patch.object(MockEmbeddingDriver, "try_embed_chunk")
-    def test_embed_string_throws_when_retries_exhausted(
-        self, try_embed_chunk, driver
-    ):
+    def test_embed_string_throws_when_retries_exhausted(self, try_embed_chunk, driver):
         try_embed_chunk.side_effect = Exception("nope")
 
         with pytest.raises(Exception) as e:

--- a/tests/unit/drivers/embedding/test_bedrock_titan_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_bedrock_titan_embedding_driver.py
@@ -23,8 +23,4 @@ class TestBedrockTitanEmbeddingDriver:
         assert BedrockTitanEmbeddingDriver()
 
     def test_try_embed_chunk(self):
-        assert BedrockTitanEmbeddingDriver().try_embed_chunk("foobar") == [
-            0,
-            1,
-            0,
-        ]
+        assert BedrockTitanEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]

--- a/tests/unit/drivers/embedding/test_openai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_openai_embedding_driver.py
@@ -8,9 +8,7 @@ class TestOpenAiEmbeddingDriver:
     def mock_openai(self, mocker):
         fake_response = {"data": [{"embedding": [0, 1, 0]}]}
 
-        return mocker.patch(
-            "openai.Embedding.create", return_value=fake_response
-        )
+        return mocker.patch("openai.Embedding.create", return_value=fake_response)
 
     def test_init(self):
         assert OpenAiEmbeddingDriver()
@@ -19,12 +17,6 @@ class TestOpenAiEmbeddingDriver:
         assert OpenAiEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]
 
     @pytest.mark.parametrize("model", OpenAiTokenizer.EMBEDDING_MODELS)
-    def test_try_embed_chunk_replaces_newlines_in_older_ada_models(
-        self, model, mock_openai
-    ):
+    def test_try_embed_chunk_replaces_newlines_in_older_ada_models(self, model, mock_openai):
         OpenAiEmbeddingDriver(model=model).try_embed_chunk("foo\nbar")
-        assert (
-            mock_openai.call_args.kwargs["input"] == "foo bar"
-            if model.endswith("001")
-            else "foo\nbar"
-        )
+        assert mock_openai.call_args.kwargs["input"] == "foo bar" if model.endswith("001") else "foo\nbar"

--- a/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
@@ -25,18 +25,8 @@ class TestDynamoDbConversationMemoryDriver:
         dynamodb = boto3.Session(region_name=self.AWS_REGION).client("dynamodb")
         dynamodb.create_table(
             TableName=self.DYNAMODB_TABLE_NAME,
-            KeySchema=[
-                {
-                    "AttributeName": self.DYNAMODB_PARTITION_KEY,
-                    "KeyType": "HASH",
-                }
-            ],
-            AttributeDefinitions=[
-                {
-                    "AttributeName": self.DYNAMODB_PARTITION_KEY,
-                    "AttributeType": "S",
-                }
-            ],
+            KeySchema=[{"AttributeName": self.DYNAMODB_PARTITION_KEY, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": self.DYNAMODB_PARTITION_KEY, "AttributeType": "S"}],
             BillingMode="PAY_PER_REQUEST",
         )
 
@@ -62,16 +52,12 @@ class TestDynamoDbConversationMemoryDriver:
 
         pipeline.add_task(PromptTask("test"))
 
-        response = table.get_item(
-            TableName=self.DYNAMODB_TABLE_NAME, Key={"entryId": "bar"}
-        )
+        response = table.get_item(TableName=self.DYNAMODB_TABLE_NAME, Key={"entryId": "bar"})
         assert "Item" not in response
 
         pipeline.run()
 
-        response = table.get_item(
-            TableName=self.DYNAMODB_TABLE_NAME, Key={"entryId": "bar"}
-        )
+        response = table.get_item(TableName=self.DYNAMODB_TABLE_NAME, Key={"entryId": "bar"})
         assert "Item" in response
 
     def test_load(self):

--- a/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
@@ -20,9 +20,7 @@ class TestLocalConversationMemoryDriver:
 
     def test_store(self):
         prompt_driver = MockPromptDriver()
-        memory_driver = LocalConversationMemoryDriver(
-            file_path=self.MEMORY_FILE_PATH
-        )
+        memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
         memory = ConversationMemory(driver=memory_driver, autoload=False)
         pipeline = Pipeline(prompt_driver=prompt_driver, memory=memory)
 
@@ -41,12 +39,8 @@ class TestLocalConversationMemoryDriver:
 
     def test_load(self):
         prompt_driver = MockPromptDriver()
-        memory_driver = LocalConversationMemoryDriver(
-            file_path=self.MEMORY_FILE_PATH
-        )
-        memory = ConversationMemory(
-            driver=memory_driver, autoload=False, max_runs=5
-        )
+        memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
+        memory = ConversationMemory(driver=memory_driver, autoload=False, max_runs=5)
         pipeline = Pipeline(prompt_driver=prompt_driver, memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -64,9 +58,7 @@ class TestLocalConversationMemoryDriver:
 
     def test_autoload(self):
         prompt_driver = MockPromptDriver()
-        memory_driver = LocalConversationMemoryDriver(
-            file_path=self.MEMORY_FILE_PATH
-        )
+        memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
         memory = ConversationMemory(driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, memory=memory)
 

--- a/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
@@ -1,10 +1,7 @@
 from botocore.response import StreamingBody
 from griptape.artifacts import TextArtifact
 from griptape.drivers import AmazonBedrockPromptDriver
-from griptape.drivers import (
-    BedrockClaudePromptModelDriver,
-    BedrockTitanPromptModelDriver,
-)
+from griptape.drivers import BedrockClaudePromptModelDriver, BedrockTitanPromptModelDriver
 from griptape.tokenizers import AnthropicTokenizer, BedrockTitanTokenizer
 from io import StringIO
 from unittest.mock import Mock
@@ -18,12 +15,8 @@ class TestAmazonBedrockPromptDriver:
     @pytest.fixture
     def mock_prompt_model_driver(self):
         mock_prompt_model_driver = Mock()
-        mock_prompt_model_driver.prompt_stack_to_model_params.return_value = {
-            "model-param-key": "model-param-value"
-        }
-        mock_prompt_model_driver.process_output.return_value = TextArtifact(
-            "model-output"
-        )
+        mock_prompt_model_driver.prompt_stack_to_model_params.return_value = {"model-param-key": "model-param-value"}
+        mock_prompt_model_driver.process_output.return_value = TextArtifact("model-output")
         return mock_prompt_model_driver
 
     @pytest.fixture(autouse=True)
@@ -32,15 +25,13 @@ class TestAmazonBedrockPromptDriver:
 
     def test_init(self):
         assert AmazonBedrockPromptDriver(
-            model=BedrockClaudeTokenizer.DEFAULT_MODEL,
-            prompt_model_driver=BedrockClaudePromptModelDriver(),
+            model=BedrockClaudeTokenizer.DEFAULT_MODEL, prompt_model_driver=BedrockClaudePromptModelDriver()
         )
 
     def test_custom_tokenizer(self):
         assert isinstance(
             AmazonBedrockPromptDriver(
-                model=BedrockClaudeTokenizer.DEFAULT_MODEL,
-                prompt_model_driver=BedrockClaudePromptModelDriver(),
+                model=BedrockClaudeTokenizer.DEFAULT_MODEL, prompt_model_driver=BedrockClaudePromptModelDriver()
             ).tokenizer,
             AnthropicTokenizer,
         )
@@ -48,41 +39,27 @@ class TestAmazonBedrockPromptDriver:
         assert isinstance(
             AmazonBedrockPromptDriver(
                 model=BedrockTitanTokenizer.DEFAULT_MODEL,
-                tokenizer=BedrockTitanTokenizer(
-                    model=BedrockTitanTokenizer.DEFAULT_MODEL
-                ),
+                tokenizer=BedrockTitanTokenizer(model=BedrockTitanTokenizer.DEFAULT_MODEL),
                 prompt_model_driver=BedrockTitanPromptModelDriver(),
             ).tokenizer,
             BedrockTitanTokenizer,
         )
 
-    @pytest.mark.parametrize(
-        "model_inputs", [{"model-input-key": "model-input-value"}, "not-a-dict"]
-    )
+    @pytest.mark.parametrize("model_inputs", [{"model-input-key": "model-input-value"}, "not-a-dict"])
     def test_try_run(self, model_inputs, mock_prompt_model_driver, mock_client):
         # Given
-        driver = AmazonBedrockPromptDriver(
-            model="model", prompt_model_driver=mock_prompt_model_driver
-        )
+        driver = AmazonBedrockPromptDriver(model="model", prompt_model_driver=mock_prompt_model_driver)
         prompt_stack = "prompt-stack"
         response_body = "invoke-model-response-body"
-        mock_prompt_model_driver.prompt_stack_to_model_input.return_value = (
-            model_inputs
-        )
-        mock_client.invoke_model.return_value = {
-            "body": to_streaming_body(response_body)
-        }
+        mock_prompt_model_driver.prompt_stack_to_model_input.return_value = model_inputs
+        mock_client.invoke_model.return_value = {"body": to_streaming_body(response_body)}
 
         # When
         text_artifact = driver.try_run(prompt_stack)
 
         # Then
-        mock_prompt_model_driver.prompt_stack_to_model_input.assert_called_once_with(
-            prompt_stack
-        )
-        mock_prompt_model_driver.prompt_stack_to_model_params.assert_called_once_with(
-            prompt_stack
-        )
+        mock_prompt_model_driver.prompt_stack_to_model_input.assert_called_once_with(prompt_stack)
+        mock_prompt_model_driver.prompt_stack_to_model_params.assert_called_once_with(prompt_stack)
         mock_client.invoke_model.assert_called_once_with(
             modelId=driver.model,
             contentType="application/json",
@@ -94,46 +71,25 @@ class TestAmazonBedrockPromptDriver:
                 }
             ),
         )
-        mock_prompt_model_driver.process_output.assert_called_once_with(
-            response_body
-        )
-        assert (
-            text_artifact
-            == mock_prompt_model_driver.process_output.return_value
-        )
+        mock_prompt_model_driver.process_output.assert_called_once_with(response_body)
+        assert text_artifact == mock_prompt_model_driver.process_output.return_value
 
-    @pytest.mark.parametrize(
-        "model_inputs", [{"model-input-key": "model-input-value"}, "not-a-dict"]
-    )
-    def test_try_stream_run(
-        self, model_inputs, mock_prompt_model_driver, mock_client
-    ):
+    @pytest.mark.parametrize("model_inputs", [{"model-input-key": "model-input-value"}, "not-a-dict"])
+    def test_try_stream_run(self, model_inputs, mock_prompt_model_driver, mock_client):
         # Given
-        driver = AmazonBedrockPromptDriver(
-            model="model",
-            prompt_model_driver=mock_prompt_model_driver,
-            stream=True,
-        )
+        driver = AmazonBedrockPromptDriver(model="model", prompt_model_driver=mock_prompt_model_driver, stream=True)
         prompt_stack = "prompt-stack"
         model_response = "invoke-model-response-body"
         response_body = [{"chunk": {"bytes": model_response}}]
-        mock_prompt_model_driver.prompt_stack_to_model_input.return_value = (
-            model_inputs
-        )
-        mock_client.invoke_model_with_response_stream.return_value = {
-            "body": response_body
-        }
+        mock_prompt_model_driver.prompt_stack_to_model_input.return_value = model_inputs
+        mock_client.invoke_model_with_response_stream.return_value = {"body": response_body}
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
 
         # Then
-        mock_prompt_model_driver.prompt_stack_to_model_input.assert_called_once_with(
-            prompt_stack
-        )
-        mock_prompt_model_driver.prompt_stack_to_model_params.assert_called_once_with(
-            prompt_stack
-        )
+        mock_prompt_model_driver.prompt_stack_to_model_input.assert_called_once_with(prompt_stack)
+        mock_prompt_model_driver.prompt_stack_to_model_params.assert_called_once_with(prompt_stack)
         mock_client.invoke_model_with_response_stream.assert_called_once_with(
             modelId=driver.model,
             contentType="application/json",
@@ -145,21 +101,12 @@ class TestAmazonBedrockPromptDriver:
                 }
             ),
         )
-        mock_prompt_model_driver.process_output.assert_called_once_with(
-            model_response
-        )
-        assert (
-            text_artifact.value
-            == mock_prompt_model_driver.process_output.return_value.value
-        )
+        mock_prompt_model_driver.process_output.assert_called_once_with(model_response)
+        assert text_artifact.value == mock_prompt_model_driver.process_output.return_value.value
 
-    def test_try_run_throws_on_empty_response(
-        self, mock_prompt_model_driver, mock_client
-    ):
+    def test_try_run_throws_on_empty_response(self, mock_prompt_model_driver, mock_client):
         # Given
-        driver = AmazonBedrockPromptDriver(
-            model="model", prompt_model_driver=mock_prompt_model_driver
-        )
+        driver = AmazonBedrockPromptDriver(model="model", prompt_model_driver=mock_prompt_model_driver)
         mock_client.invoke_model.return_value = {"body": to_streaming_body("")}
 
         # When

--- a/tests/unit/drivers/prompt/test_amazon_sagemaker_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_sagemaker_prompt_driver.py
@@ -1,9 +1,6 @@
 from botocore.response import StreamingBody
 from griptape.artifacts import TextArtifact
-from griptape.drivers import (
-    AmazonSageMakerPromptDriver,
-    SageMakerLlamaPromptModelDriver,
-)
+from griptape.drivers import AmazonSageMakerPromptDriver, SageMakerLlamaPromptModelDriver
 from griptape.tokenizers import HuggingFaceTokenizer, OpenAiTokenizer
 from io import BytesIO
 from unittest.mock import Mock
@@ -15,15 +12,9 @@ class TestAmazonSageMakerPromptDriver:
     @pytest.fixture
     def mock_model_driver(self):
         mock_model_driver = Mock()
-        mock_model_driver.prompt_stack_to_model_input.return_value = (
-            "model-inputs"
-        )
-        mock_model_driver.prompt_stack_to_model_params.return_value = (
-            "model-params"
-        )
-        mock_model_driver.process_output.return_value = TextArtifact(
-            "model-output"
-        )
+        mock_model_driver.prompt_stack_to_model_input.return_value = "model-inputs"
+        mock_model_driver.prompt_stack_to_model_params.return_value = "model-params"
+        mock_model_driver.process_output.return_value = TextArtifact("model-output")
         return mock_model_driver
 
     @pytest.fixture(autouse=True)
@@ -31,25 +22,18 @@ class TestAmazonSageMakerPromptDriver:
         return mocker.patch("boto3.Session").return_value.client.return_value
 
     def test_init(self):
-        assert AmazonSageMakerPromptDriver(
-            model="foo", prompt_model_driver=SageMakerLlamaPromptModelDriver()
-        )
+        assert AmazonSageMakerPromptDriver(model="foo", prompt_model_driver=SageMakerLlamaPromptModelDriver())
 
     def test_custom_tokenizer(self):
         assert isinstance(
-            AmazonSageMakerPromptDriver(
-                model="foo",
-                prompt_model_driver=SageMakerLlamaPromptModelDriver(),
-            ).tokenizer,
+            AmazonSageMakerPromptDriver(model="foo", prompt_model_driver=SageMakerLlamaPromptModelDriver()).tokenizer,
             HuggingFaceTokenizer,
         )
 
         assert isinstance(
             AmazonSageMakerPromptDriver(
                 model="foo",
-                tokenizer=OpenAiTokenizer(
-                    model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-                ),
+                tokenizer=OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL),
                 prompt_model_driver=SageMakerLlamaPromptModelDriver(),
             ).tokenizer,
             OpenAiTokenizer,
@@ -57,25 +41,17 @@ class TestAmazonSageMakerPromptDriver:
 
     def test_try_run(self, mock_model_driver, mock_client):
         # Given
-        driver = AmazonSageMakerPromptDriver(
-            model="model", prompt_model_driver=mock_model_driver
-        )
+        driver = AmazonSageMakerPromptDriver(model="model", prompt_model_driver=mock_model_driver)
         prompt_stack = "prompt-stack"
         response_body = "invoke-endpoint-response-body"
-        mock_client.invoke_endpoint.return_value = {
-            "Body": to_streaming_body(response_body)
-        }
+        mock_client.invoke_endpoint.return_value = {"Body": to_streaming_body(response_body)}
 
         # When
         text_artifact = driver.try_run(prompt_stack)
 
         # Then
-        mock_model_driver.prompt_stack_to_model_input.assert_called_once_with(
-            prompt_stack
-        )
-        mock_model_driver.prompt_stack_to_model_params.assert_called_once_with(
-            prompt_stack
-        )
+        mock_model_driver.prompt_stack_to_model_input.assert_called_once_with(prompt_stack)
+        mock_model_driver.prompt_stack_to_model_params.assert_called_once_with(prompt_stack)
         mock_client.invoke_endpoint.assert_called_once_with(
             EndpointName=driver.model,
             ContentType="application/json",
@@ -90,16 +66,10 @@ class TestAmazonSageMakerPromptDriver:
         mock_model_driver.process_output.assert_called_once_with(response_body)
         assert text_artifact == mock_model_driver.process_output.return_value
 
-    def test_try_run_throws_on_empty_response(
-        self, mock_model_driver, mock_client
-    ):
+    def test_try_run_throws_on_empty_response(self, mock_model_driver, mock_client):
         # Given
-        driver = AmazonSageMakerPromptDriver(
-            model="model", prompt_model_driver=mock_model_driver
-        )
-        mock_client.invoke_endpoint.return_value = {
-            "Body": to_streaming_body("")
-        }
+        driver = AmazonSageMakerPromptDriver(model="model", prompt_model_driver=mock_model_driver)
+        mock_client.invoke_endpoint.return_value = {"Body": to_streaming_body("")}
 
         # When
         with pytest.raises(Exception) as e:

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -8,26 +8,20 @@ import pytest
 class TestAnthropicPromptDriver:
     @pytest.fixture
     def mock_completion_create(self, mocker):
-        mock_completion_create = mocker.patch(
-            "anthropic.Anthropic"
-        ).return_value.completions.create
+        mock_completion_create = mocker.patch("anthropic.Anthropic").return_value.completions.create
         mock_completion_create.return_value.completion = "model-output"
         return mock_completion_create
 
     @pytest.fixture
     def mock_completion_stream_create(self, mocker):
-        mock_completion_create = mocker.patch(
-            "anthropic.Anthropic"
-        ).return_value.completions.create
+        mock_completion_create = mocker.patch("anthropic.Anthropic").return_value.completions.create
         mock_chunk = Mock()
         mock_chunk.completion = "model-output"
         mock_completion_create.return_value = iter([mock_chunk])
         return mock_completion_create
 
     def test_init(self):
-        assert AnthropicPromptDriver(
-            model=AnthropicTokenizer.DEFAULT_MODEL, api_key="1234"
-        )
+        assert AnthropicPromptDriver(model=AnthropicTokenizer.DEFAULT_MODEL, api_key="1234")
 
     def test_try_run(self, mock_completion_create):
         # Given
@@ -36,9 +30,7 @@ class TestAnthropicPromptDriver:
         prompt_stack.add_system_input("system-input")
         prompt_stack.add_user_input("user-input")
         prompt_stack.add_assistant_input("assistant-input")
-        driver = AnthropicPromptDriver(
-            model=AnthropicTokenizer.DEFAULT_MODEL, api_key="api-key"
-        )
+        driver = AnthropicPromptDriver(model=AnthropicTokenizer.DEFAULT_MODEL, api_key="api-key")
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -69,11 +61,7 @@ class TestAnthropicPromptDriver:
         prompt_stack.add_system_input("system-input")
         prompt_stack.add_user_input("user-input")
         prompt_stack.add_assistant_input("assistant-input")
-        driver = AnthropicPromptDriver(
-            model=AnthropicTokenizer.DEFAULT_MODEL,
-            api_key="api-key",
-            stream=True,
-        )
+        driver = AnthropicPromptDriver(model=AnthropicTokenizer.DEFAULT_MODEL, api_key="api-key", stream=True)
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
@@ -101,9 +89,7 @@ class TestAnthropicPromptDriver:
     def test_try_run_throws_when_prompt_stack_is_string(self):
         # Given
         prompt_stack = "prompt-stack"
-        driver = AnthropicPromptDriver(
-            model=AnthropicTokenizer.DEFAULT_MODEL, api_key="api-key"
-        )
+        driver = AnthropicPromptDriver(model=AnthropicTokenizer.DEFAULT_MODEL, api_key="api-key")
 
         # When
         with pytest.raises(Exception) as e:

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -1,20 +1,14 @@
 from griptape.drivers import AzureOpenAiChatPromptDriver
-from tests.unit.drivers.prompt.test_openai_chat_prompt_driver import (
-    TestOpenAiChatPromptDriverFixtureMixin,
-)
+from tests.unit.drivers.prompt.test_openai_chat_prompt_driver import TestOpenAiChatPromptDriverFixtureMixin
 
 
 class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_init(self):
-        assert AzureOpenAiChatPromptDriver(
-            api_base="foobar", deployment_id="foobar", model="gpt-4"
-        )
+        assert AzureOpenAiChatPromptDriver(api_base="foobar", deployment_id="foobar", model="gpt-4")
 
     def test_try_run(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
-        driver = AzureOpenAiChatPromptDriver(
-            api_base="api-base", deployment_id="deployment-id", model="gpt-4"
-        )
+        driver = AzureOpenAiChatPromptDriver(api_base="api-base", deployment_id="deployment-id", model="gpt-4")
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -35,15 +29,10 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_stream_run(
-        self, mock_chat_completion_stream_create, prompt_stack, messages
-    ):
+    def test_try_stream_run(self, mock_chat_completion_stream_create, prompt_stack, messages):
         # Given
         driver = AzureOpenAiChatPromptDriver(
-            api_base="api-base",
-            deployment_id="deployment-id",
-            model="gpt-4",
-            stream=True,
+            api_base="api-base", deployment_id="deployment-id", model="gpt-4", stream=True
         )
 
         # When

--- a/tests/unit/drivers/prompt/test_azure_openai_completion_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_completion_prompt_driver.py
@@ -1,24 +1,16 @@
 from griptape.drivers import AzureOpenAiCompletionPromptDriver
-from tests.unit.drivers.prompt.test_openai_completion_prompt_driver import (
-    TestOpenAiCompletionPromptDriverFixtureMixin,
-)
+from tests.unit.drivers.prompt.test_openai_completion_prompt_driver import TestOpenAiCompletionPromptDriverFixtureMixin
 from unittest.mock import ANY
 
 
-class TestAzureOpenAiCompletionPromptDriver(
-    TestOpenAiCompletionPromptDriverFixtureMixin
-):
+class TestAzureOpenAiCompletionPromptDriver(TestOpenAiCompletionPromptDriverFixtureMixin):
     def test_init(self):
-        assert AzureOpenAiCompletionPromptDriver(
-            api_base="foobar", deployment_id="foobar", model="text-davinci-003"
-        )
+        assert AzureOpenAiCompletionPromptDriver(api_base="foobar", deployment_id="foobar", model="text-davinci-003")
 
     def test_try_run(self, mock_completion_create, prompt_stack, prompt):
         # Given
         driver = AzureOpenAiCompletionPromptDriver(
-            api_base="api-base",
-            deployment_id="deployment-id",
-            model="text-davinci-003",
+            api_base="api-base", deployment_id="deployment-id", model="text-davinci-003"
         )
 
         # When
@@ -41,15 +33,10 @@ class TestAzureOpenAiCompletionPromptDriver(
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_stream_run(
-        self, mock_completion_stream_create, prompt_stack, prompt
-    ):
+    def test_try_stream_run(self, mock_completion_stream_create, prompt_stack, prompt):
         # Given
         driver = AzureOpenAiCompletionPromptDriver(
-            api_base="api-base",
-            deployment_id="deployment-id",
-            model="text-davinci-003",
-            stream=True,
+            api_base="api-base", deployment_id="deployment-id", model="text-davinci-003", stream=True
         )
 
         # When

--- a/tests/unit/drivers/prompt/test_base_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_base_prompt_driver.py
@@ -32,47 +32,30 @@ class TestBasePromptDriver:
 
         pipeline.run()
 
-        events = [
-            call_args[0][0] for call_args in mock_publish_event.call_args_list
-        ]
+        events = [call_args[0][0] for call_args in mock_publish_event.call_args_list]
         assert instance_count(events, StartPromptEvent) == 1
         assert instance_count(events, FinishPromptEvent) == 1
 
     def test_run(self):
-        assert isinstance(
-            MockPromptDriver().run(PromptStack(inputs=[])), TextArtifact
-        )
+        assert isinstance(MockPromptDriver().run(PromptStack(inputs=[])), TextArtifact)
 
     def test_token_count(self):
         assert (
             MockPromptDriver().token_count(
-                PromptStack(
-                    inputs=[
-                        PromptStack.Input("foobar", role=PromptStack.USER_ROLE)
-                    ]
-                )
+                PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)])
             )
             == 7
         )
 
     def test_max_output_tokens(self):
         assert MockPromptDriver().max_output_tokens("foobar") == 4087
-        assert (
-            MockPromptDriver(max_tokens=4088).max_output_tokens("foobar")
-            == 4087
-        )
-        assert (
-            MockPromptDriver(max_tokens=100).max_output_tokens("foobar") == 100
-        )
+        assert MockPromptDriver(max_tokens=4088).max_output_tokens("foobar") == 4087
+        assert MockPromptDriver(max_tokens=100).max_output_tokens("foobar") == 100
 
     def test_prompt_stack_to_string(self):
         assert (
             MockPromptDriver().prompt_stack_to_string(
-                PromptStack(
-                    inputs=[
-                        PromptStack.Input("foobar", role=PromptStack.USER_ROLE)
-                    ]
-                )
+                PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)])
             )
             == "User: foobar\n\nAssistant:"
         )
@@ -81,18 +64,10 @@ class TestBasePromptDriver:
         assert (
             MockPromptDriver(
                 prompt_stack_to_string=lambda stack: f"Foo: {stack.inputs[0].content}"
-            ).prompt_stack_to_string(
-                PromptStack(
-                    inputs=[
-                        PromptStack.Input("foobar", role=PromptStack.USER_ROLE)
-                    ]
-                )
-            )
+            ).prompt_stack_to_string(PromptStack(inputs=[PromptStack.Input("foobar", role=PromptStack.USER_ROLE)]))
             == "Foo: foobar"
         )
 
 
 def instance_count(instances, clazz):
-    return len(
-        [instance for instance in instances if isinstance(instance, clazz)]
-    )
+    return len([instance for instance in instances if isinstance(instance, clazz)])

--- a/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
@@ -35,15 +35,11 @@ class TestCoherePromptDriver:
         return prompt_stack
 
     def test_init(self):
-        assert CoherePromptDriver(
-            model=CohereTokenizer.DEFAULT_MODEL, api_key="foobar"
-        )
+        assert CoherePromptDriver(model=CohereTokenizer.DEFAULT_MODEL, api_key="foobar")
 
     def test_try_run(self, mock_client, prompt_stack):  # pyright: ignore
         # Given
-        driver = CoherePromptDriver(
-            model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key"
-        )
+        driver = CoherePromptDriver(model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key")
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -51,13 +47,9 @@ class TestCoherePromptDriver:
         # Then
         assert text_artifact.value == "model-output"
 
-    def test_try_stream_run(
-        self, mock_stream_client, prompt_stack
-    ):  # pyright: ignore
+    def test_try_stream_run(self, mock_stream_client, prompt_stack):  # pyright: ignore
         # Given
-        driver = CoherePromptDriver(
-            model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key", stream=True
-        )
+        driver = CoherePromptDriver(model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key", stream=True)
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
@@ -66,13 +58,9 @@ class TestCoherePromptDriver:
         assert text_artifact.value == "model-output"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(
-        self, choices, mock_client, prompt_stack
-    ):
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_client, prompt_stack):
         # Given
-        driver = CoherePromptDriver(
-            model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key"
-        )
+        driver = CoherePromptDriver(model=CohereTokenizer.DEFAULT_MODEL, api_key="api-key")
         mock_client.generate.return_value.generations = choices
 
         # When
@@ -80,6 +68,4 @@ class TestCoherePromptDriver:
             driver.try_run(prompt_stack)
 
         # Then
-        e.value.args[
-            0
-        ] == "Completion with more than one choice is not supported yet."
+        e.value.args[0] == "Completion with more than one choice is not supported yet."

--- a/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
@@ -22,9 +22,7 @@ class TestHuggingFaceHubPromptDriver:
 
     @pytest.fixture(autouse=True)
     def mock_autotokenizer(self, mocker):
-        mock_autotokenizer = mocker.patch(
-            "transformers.AutoTokenizer.from_pretrained"
-        ).return_value
+        mock_autotokenizer = mocker.patch("transformers.AutoTokenizer.from_pretrained").return_value
         mock_autotokenizer.model_max_length = 42
         return mock_autotokenizer
 
@@ -33,9 +31,7 @@ class TestHuggingFaceHubPromptDriver:
 
     def test_try_run(self, prompt_stack):
         # Given
-        driver = HuggingFaceHubPromptDriver(
-            api_token="api-token", model="repo-id"
-        )
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -44,13 +40,9 @@ class TestHuggingFaceHubPromptDriver:
         assert text_artifact.value == "model-output"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(
-        self, choices, mock_client, prompt_stack
-    ):
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_client, prompt_stack):
         # Given
-        driver = HuggingFaceHubPromptDriver(
-            api_token="api-token", model="repo-id"
-        )
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
         mock_client.return_value = choices
 
         # When
@@ -58,17 +50,11 @@ class TestHuggingFaceHubPromptDriver:
             driver.try_run(prompt_stack)
 
         # Then
-        e.value.args[
-            0
-        ] == "completion with more than one choice is not supported yet"
+        e.value.args[0] == "completion with more than one choice is not supported yet"
 
-    def test_try_run_throws_when_unsupported_task_returned(
-        self, prompt_stack, mock_client
-    ):
+    def test_try_run_throws_when_unsupported_task_returned(self, prompt_stack, mock_client):
         # Given
-        driver = HuggingFaceHubPromptDriver(
-            api_token="api-token", model="repo-id"
-        )
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
         mock_client.task = "obviously-an-unsupported-task"
 
         # When
@@ -76,6 +62,4 @@ class TestHuggingFaceHubPromptDriver:
             driver.try_run(prompt_stack)
 
         # Then
-        assert e.value.args[0].startswith(
-            "only models with the following tasks are supported: "
-        )
+        assert e.value.args[0].startswith("only models with the following tasks are supported: ")

--- a/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
@@ -18,9 +18,7 @@ class TestHuggingFacePipelinePromptDriver:
 
     @pytest.fixture(autouse=True)
     def mock_autotokenizer(self, mocker):
-        mock_autotokenizer = mocker.patch(
-            "transformers.AutoTokenizer.from_pretrained"
-        ).return_value
+        mock_autotokenizer = mocker.patch("transformers.AutoTokenizer.from_pretrained").return_value
         mock_autotokenizer.model_max_length = 42
         return mock_autotokenizer
 
@@ -47,9 +45,7 @@ class TestHuggingFacePipelinePromptDriver:
         assert text_artifact.value == "model-output"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(
-        self, choices, mock_generator, prompt_stack
-    ):
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_generator, prompt_stack):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo")
         mock_generator.return_value = choices
@@ -59,13 +55,9 @@ class TestHuggingFacePipelinePromptDriver:
             driver.try_run(prompt_stack)
 
         # Then
-        e.value.args[
-            0
-        ] == "completion with more than one choice is not supported yet"
+        e.value.args[0] == "completion with more than one choice is not supported yet"
 
-    def test_try_run_throws_when_unsupported_task_returned(
-        self, prompt_stack, mock_generator
-    ):
+    def test_try_run_throws_when_unsupported_task_returned(self, prompt_stack, mock_generator):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo")
         mock_generator.task = "obviously-an-unsupported-task"
@@ -75,6 +67,4 @@ class TestHuggingFacePipelinePromptDriver:
             driver.try_run(prompt_stack)
 
         # Then
-        assert e.value.args[0].startswith(
-            "only models with the following tasks are supported: "
-        )
+        assert e.value.args[0].startswith("only models with the following tasks are supported: ")

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -11,9 +11,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
     @pytest.fixture
     def mock_chat_completion_create(self, mocker):
         mock_chat_create = mocker.patch("openai.ChatCompletion").create
-        mock_chat_create.return_value.choices = [
-            {"message": {"content": "model-output"}}
-        ]
+        mock_chat_create.return_value.choices = [{"message": {"content": "model-output"}}]
         return mock_chat_create
 
     @pytest.fixture
@@ -78,15 +76,11 @@ class OpenAiApiResponseWithHeaders:
 
 class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_init(self):
-        assert OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL
-        )
+        assert OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL)
 
     def test_try_run(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -106,13 +100,9 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_stream_run(
-        self, mock_chat_completion_stream_create, prompt_stack, messages
-    ):
+    def test_try_stream_run(self, mock_chat_completion_stream_create, prompt_stack, messages):
         # Given
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True)
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
@@ -133,13 +123,9 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_run_with_max_tokens(
-        self, mock_chat_completion_create, prompt_stack, messages
-    ):
+    def test_try_run_with_max_tokens(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, max_tokens=1
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, max_tokens=1)
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -160,18 +146,13 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_run_max_tokens_limited_by_tokenizer(
-        self, mock_chat_completion_create, prompt_stack, messages
-    ):
+    def test_try_run_max_tokens_limited_by_tokenizer(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
         max_tokens_request = 9999999
         driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
-            max_tokens=max_tokens_request,
+            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, max_tokens=max_tokens_request
         )
-        tokens_left = driver.tokenizer.count_tokens_left(
-            driver._prompt_stack_to_messages(prompt_stack)
-        )
+        tokens_left = driver.tokenizer.count_tokens_left(driver._prompt_stack_to_messages(prompt_stack))
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -195,9 +176,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
     def test_try_run_throws_when_prompt_stack_is_string(self):
         # Given
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
         # When
         with pytest.raises(Exception) as e:
@@ -207,13 +186,9 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert e.value.args[0] == "'str' object has no attribute 'inputs'"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(
-        self, choices, mock_chat_completion_create, prompt_stack
-    ):
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_chat_completion_create, prompt_stack):
         # Given
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         mock_chat_completion_create.return_value.choices = choices
 
         # When
@@ -221,18 +196,13 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             driver.try_run(prompt_stack)
 
         # Then
-        e.value.args[
-            0
-        ] == "Completion with more than one choice is not supported yet."
+        e.value.args[0] == "Completion with more than one choice is not supported yet."
 
     def test_token_count(self, prompt_stack, messages):
         # Given
         mock_tokenizer = Mock()
         mock_tokenizer.count_tokens.return_value = 42
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
-            tokenizer=mock_tokenizer,
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, tokenizer=mock_tokenizer)
 
         # When
         token_count = driver.token_count(prompt_stack)
@@ -245,10 +215,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         # Given
         mock_tokenizer = Mock()
         mock_tokenizer.count_tokens_left.return_value = 42
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
-            tokenizer=mock_tokenizer,
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, tokenizer=mock_tokenizer)
 
         # When
         max_output_tokens = driver.max_output_tokens(messages)
@@ -266,73 +233,39 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
     def test_extract_ratelimit_metadata(self):
         response_with_headers = OpenAiApiResponseWithHeaders()
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         driver._extract_ratelimit_metadata(response_with_headers)
 
-        assert (
-            driver._ratelimit_requests_remaining
-            == response_with_headers.remaining_requests
-        )
-        assert (
-            driver._ratelimit_tokens_remaining
-            == response_with_headers.remaining_tokens
-        )
-        assert (
-            driver._ratelimit_request_limit
-            == response_with_headers.limit_requests
-        )
-        assert (
-            driver._ratelimit_token_limit == response_with_headers.limit_tokens
-        )
+        assert driver._ratelimit_requests_remaining == response_with_headers.remaining_requests
+        assert driver._ratelimit_tokens_remaining == response_with_headers.remaining_tokens
+        assert driver._ratelimit_request_limit == response_with_headers.limit_requests
+        assert driver._ratelimit_token_limit == response_with_headers.limit_tokens
 
         # Assert that the reset times are within one second of the expected value.
-        expected_request_reset_time = (
-            datetime.datetime.now()
-            + datetime.timedelta(
-                seconds=response_with_headers.reset_requests_in
-            )
+        expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(
+            seconds=response_with_headers.reset_requests_in
         )
-        expected_token_reset_time = (
-            datetime.datetime.now()
-            + datetime.timedelta(seconds=response_with_headers.reset_tokens_in)
+        expected_token_reset_time = datetime.datetime.now() + datetime.timedelta(
+            seconds=response_with_headers.reset_tokens_in
         )
 
-        assert abs(
-            driver._ratelimit_requests_reset_at - expected_request_reset_time
-        ) < datetime.timedelta(seconds=1)
-        assert abs(
-            driver._ratelimit_tokens_reset_at - expected_token_reset_time
-        ) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
 
     def test_extract_ratelimit_metadata_with_subsecond_reset_times(self):
         response_with_headers = OpenAiApiResponseWithHeaders(
-            reset_requests_in=1,
-            reset_requests_in_unit="ms",
-            reset_tokens_in=10,
-            reset_tokens_in_unit="ms",
+            reset_requests_in=1, reset_requests_in_unit="ms", reset_tokens_in=10, reset_tokens_in_unit="ms"
         )
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         driver._extract_ratelimit_metadata(response_with_headers)
 
         # Assert that the reset times are within one second of the expected value. With a sub-second reset time,
         # this is rounded up to one second in the future.
-        expected_request_reset_time = (
-            datetime.datetime.now() + datetime.timedelta(seconds=1)
-        )
-        expected_token_reset_time = (
-            datetime.datetime.now() + datetime.timedelta(seconds=1)
-        )
+        expected_request_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
+        expected_token_reset_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
 
-        assert abs(
-            driver._ratelimit_requests_reset_at - expected_request_reset_time
-        ) < datetime.timedelta(seconds=1)
-        assert abs(
-            driver._ratelimit_tokens_reset_at - expected_token_reset_time
-        ) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_requests_reset_at - expected_request_reset_time) < datetime.timedelta(seconds=1)
+        assert abs(driver._ratelimit_tokens_reset_at - expected_token_reset_time) < datetime.timedelta(seconds=1)
 
     def test_extract_ratelimit_metadata_missing_headers(self):
         class OpenAiApiResponseNoHeaders:
@@ -342,9 +275,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
         response_without_headers = OpenAiApiResponseNoHeaders()
 
-        driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         driver._extract_ratelimit_metadata(response_without_headers)
 
         assert driver._ratelimit_request_limit is None

--- a/tests/unit/drivers/prompt/test_openai_completion_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_completion_prompt_driver.py
@@ -43,19 +43,13 @@ class TestOpenAiCompletionPromptDriverFixtureMixin:
         )
 
 
-class TestOpenAiCompletionPromptDriver(
-    TestOpenAiCompletionPromptDriverFixtureMixin
-):
+class TestOpenAiCompletionPromptDriver(TestOpenAiCompletionPromptDriverFixtureMixin):
     def test_init(self):
-        assert OpenAiCompletionPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        assert OpenAiCompletionPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
     def test_try_run(self, mock_completion_create, prompt_stack, prompt):
         # Given
-        driver = OpenAiCompletionPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiCompletionPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
         # When
         text_artifact = driver.try_run(prompt_stack)
@@ -76,13 +70,9 @@ class TestOpenAiCompletionPromptDriver(
         )
         assert text_artifact.value == "model-output"
 
-    def test_try_stream_run(
-        self, mock_completion_stream_create, prompt_stack, prompt
-    ):
+    def test_try_stream_run(self, mock_completion_stream_create, prompt_stack, prompt):
         # Given
-        driver = OpenAiCompletionPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True
-        )
+        driver = OpenAiCompletionPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True)
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
@@ -106,9 +96,7 @@ class TestOpenAiCompletionPromptDriver(
 
     def test_try_run_throws_when_prompt_stack_is_string(self):
         # Given
-        driver = OpenAiCompletionPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiCompletionPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
         # When
         with pytest.raises(Exception) as e:
@@ -118,13 +106,9 @@ class TestOpenAiCompletionPromptDriver(
         assert e.value.args[0] == "'str' object has no attribute 'inputs'"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(
-        self, choices, mock_completion_create, prompt_stack
-    ):
+    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_completion_create, prompt_stack):
         # Given
-        driver = OpenAiCompletionPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        driver = OpenAiCompletionPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
         mock_completion_create.return_value.choices = choices
 
         # When
@@ -132,6 +116,4 @@ class TestOpenAiCompletionPromptDriver(
             driver.try_run(prompt_stack)
 
         # Then
-        e.value.args[
-            0
-        ] == "Completion with more than one choice is not supported yet."
+        e.value.args[0] == "Completion with more than one choice is not supported yet."

--- a/tests/unit/drivers/prompt_models/test_bedrock_claude_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_claude_prompt_model_driver.py
@@ -4,10 +4,7 @@ import boto3
 import pytest
 from griptape.tokenizers import BedrockClaudeTokenizer
 from griptape.utils import PromptStack
-from griptape.drivers import (
-    AmazonBedrockPromptDriver,
-    BedrockClaudePromptModelDriver,
-)
+from griptape.drivers import AmazonBedrockPromptDriver, BedrockClaudePromptModelDriver
 
 
 class TestBedrockClaudePromptModelDriver:
@@ -46,23 +43,11 @@ class TestBedrockClaudePromptModelDriver:
         model_input = driver.prompt_stack_to_model_input(stack)
 
         assert isinstance(model_input, dict)
-        assert model_input["prompt"].startswith(
-            "\n\nHuman: foo\n\nHuman: bar\n\nAssistant:"
-        )
+        assert model_input["prompt"].startswith("\n\nHuman: foo\n\nHuman: bar\n\nAssistant:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert (
-            driver.prompt_stack_to_model_params(stack)["max_tokens_to_sample"]
-            == 8178
-        )
-        assert (
-            driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
-        )
+        assert driver.prompt_stack_to_model_params(stack)["max_tokens_to_sample"] == 8178
+        assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):
-        assert (
-            driver.process_output(
-                json.dumps({"completion": "foobar"}).encode()
-            ).value
-            == "foobar"
-        )
+        assert driver.process_output(json.dumps({"completion": "foobar"}).encode()).value == "foobar"

--- a/tests/unit/drivers/prompt_models/test_bedrock_jurassic_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_jurassic_prompt_model_driver.py
@@ -2,14 +2,9 @@ from unittest import mock
 import json
 import boto3
 import pytest
-from griptape.tokenizers.bedrock_jurassic_tokenizer import (
-    BedrockJurassicTokenizer,
-)
+from griptape.tokenizers.bedrock_jurassic_tokenizer import BedrockJurassicTokenizer
 from griptape.utils import PromptStack
-from griptape.drivers import (
-    AmazonBedrockPromptDriver,
-    BedrockJurassicPromptModelDriver,
-)
+from griptape.drivers import AmazonBedrockPromptDriver, BedrockJurassicPromptModelDriver
 
 
 class TestBedrockJurassicPromptModelDriver:
@@ -64,23 +59,15 @@ class TestBedrockJurassicPromptModelDriver:
         model_input = driver.prompt_stack_to_model_input(stack)
 
         assert isinstance(model_input, dict)
-        assert model_input["prompt"].startswith(
-            "Instructions: foo\nUser: bar\nBot:"
-        )
+        assert model_input["prompt"].startswith("Instructions: foo\nUser: bar\nBot:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
         assert driver.prompt_stack_to_model_params(stack)["maxTokens"] == 8189
-        assert (
-            driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
-        )
+        assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver):
         assert (
-            driver.process_output(
-                json.dumps(
-                    {"completions": [{"data": {"text": "foobar"}}]}
-                ).encode()
-            ).value
+            driver.process_output(json.dumps({"completions": [{"data": {"text": "foobar"}}]}).encode()).value
             == "foobar"
         )
 

--- a/tests/unit/drivers/prompt_models/test_bedrock_titan_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_titan_prompt_model_driver.py
@@ -4,10 +4,7 @@ import boto3
 import pytest
 from griptape.tokenizers.bedrock_titan_tokenizer import BedrockTitanTokenizer
 from griptape.utils import PromptStack
-from griptape.drivers import (
-    AmazonBedrockPromptDriver,
-    BedrockTitanPromptModelDriver,
-)
+from griptape.drivers import AmazonBedrockPromptDriver, BedrockTitanPromptModelDriver
 
 
 class TestBedrockTitanPromptModelDriver:
@@ -52,31 +49,14 @@ class TestBedrockTitanPromptModelDriver:
         model_input = driver.prompt_stack_to_model_input(stack)
 
         assert isinstance(model_input, dict)
-        assert model_input["inputText"].startswith(
-            "Instructions: foo\n\nUser: bar\n\nBot:"
-        )
+        assert model_input["inputText"].startswith("Instructions: foo\n\nUser: bar\n\nBot:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert (
-            driver.prompt_stack_to_model_params(stack)["textGenerationConfig"][
-                "maxTokenCount"
-            ]
-            == 4083
-        )
-        assert (
-            driver.prompt_stack_to_model_params(stack)["textGenerationConfig"][
-                "temperature"
-            ]
-            == 0.12345
-        )
+        assert driver.prompt_stack_to_model_params(stack)["textGenerationConfig"]["maxTokenCount"] == 4083
+        assert driver.prompt_stack_to_model_params(stack)["textGenerationConfig"]["temperature"] == 0.12345
 
     def test_process_output(self, driver):
-        assert (
-            driver.process_output(
-                json.dumps({"results": [{"outputText": "foobar"}]})
-            ).value
-            == "foobar"
-        )
+        assert driver.process_output(json.dumps({"results": [{"outputText": "foobar"}]})).value == "foobar"
 
     def test_session_initialization(self, driver, mock_session):
         assert driver.tokenizer.session == mock_session

--- a/tests/unit/drivers/prompt_models/test_sagemaker_falcon_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_sagemaker_falcon_prompt_model_driver.py
@@ -1,10 +1,7 @@
 import boto3
 import pytest
 from griptape.utils import PromptStack
-from griptape.drivers import (
-    AmazonSageMakerPromptDriver,
-    SageMakerFalconPromptModelDriver,
-)
+from griptape.drivers import AmazonSageMakerPromptDriver, SageMakerFalconPromptModelDriver
 
 
 class TestSageMakerFalconPromptModelDriver:
@@ -36,18 +33,11 @@ class TestSageMakerFalconPromptModelDriver:
         assert model_input.startswith("foo\n\nUser: bar")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert (
-            driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 590
-        )
-        assert (
-            driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
-        )
+        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 590
+        assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):
-        assert (
-            driver.process_output([{"generated_text": "foobar"}]).value
-            == "foobar"
-        )
+        assert driver.process_output([{"generated_text": "foobar"}]).value == "foobar"
 
     def test_tokenizer_max_model_length(self, driver):
         assert driver.tokenizer.tokenizer.model_max_length == 600
@@ -56,9 +46,7 @@ class TestSageMakerFalconPromptModelDriver:
             AmazonSageMakerPromptDriver(
                 model="foo",
                 session=boto3.Session(region_name="us-east-1"),
-                prompt_model_driver=SageMakerFalconPromptModelDriver(
-                    max_tokens=10
-                ),
+                prompt_model_driver=SageMakerFalconPromptModelDriver(max_tokens=10),
                 temperature=0.12345,
             ).prompt_model_driver.tokenizer.tokenizer.model_max_length
             == 10

--- a/tests/unit/drivers/prompt_models/test_sagemaker_llama_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_sagemaker_llama_prompt_model_driver.py
@@ -1,10 +1,7 @@
 import boto3
 import pytest
 from griptape.utils import PromptStack
-from griptape.drivers import (
-    AmazonSageMakerPromptDriver,
-    SageMakerLlamaPromptModelDriver,
-)
+from griptape.drivers import AmazonSageMakerPromptDriver, SageMakerLlamaPromptModelDriver
 
 
 class TestSageMakerLlamaPromptModelDriver:
@@ -40,18 +37,11 @@ class TestSageMakerLlamaPromptModelDriver:
         assert model_input[0][1]["content"] == "bar"
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert (
-            driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 588
-        )
-        assert (
-            driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
-        )
+        assert driver.prompt_stack_to_model_params(stack)["max_new_tokens"] == 588
+        assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver, stack):
-        assert (
-            driver.process_output([{"generation": {"content": "foobar"}}]).value
-            == "foobar"
-        )
+        assert driver.process_output([{"generation": {"content": "foobar"}}]).value == "foobar"
 
     def test_tokenizer_max_model_length(self, driver):
         assert driver.tokenizer.tokenizer.model_max_length == 600
@@ -60,9 +50,7 @@ class TestSageMakerLlamaPromptModelDriver:
             AmazonSageMakerPromptDriver(
                 model="foo",
                 session=boto3.Session(region_name="us-east-1"),
-                prompt_model_driver=SageMakerLlamaPromptModelDriver(
-                    max_tokens=10
-                ),
+                prompt_model_driver=SageMakerLlamaPromptModelDriver(max_tokens=10),
                 temperature=0.12345,
             ).prompt_model_driver.tokenizer.tokenizer.model_max_length
             == 10

--- a/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
+++ b/tests/unit/drivers/sql/test_amazon_redshift_sql_driver.py
@@ -46,11 +46,7 @@ class TestAmazonRedshiftSqlDriver:
         session = boto3.Session(region_name="us-east-1")
         client = session.client("redshift-data")
         stubber = Stubber(client)
-        expected_params = {
-            "Sql": "query",
-            "Database": "dev",
-            "WorkgroupName": "dev",
-        }
+        expected_params = {"Sql": "query", "Database": "dev", "WorkgroupName": "dev"}
         response = {"Id": "responseId"}
         stubber.add_response("execute_statement", response, expected_params)
 
@@ -110,53 +106,29 @@ class TestAmazonRedshiftSqlDriver:
         stubber.add_response("get_statement_result", response, expected_params)
         stubber.activate()
 
-        return AmazonRedshiftSqlDriver(
-            database="dev", session=session, workgroup_name="dev", client=client
-        )
+        return AmazonRedshiftSqlDriver(database="dev", session=session, workgroup_name="dev", client=client)
 
     @pytest.fixture
     def describe_table_driver(self):
         session = boto3.Session(region_name="us-east-1")
         client = session.client("redshift-data")
         stubber = Stubber(client)
-        describe_table_response = {
-            "ColumnList": TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA
-        }
-        expected_params = {
-            "Database": "dev",
-            "WorkgroupName": "dev",
-            "Table": "dev",
-        }
-        stubber.add_response(
-            "describe_table", describe_table_response, expected_params
-        )
+        describe_table_response = {"ColumnList": TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA}
+        expected_params = {"Database": "dev", "WorkgroupName": "dev", "Table": "dev"}
+        stubber.add_response("describe_table", describe_table_response, expected_params)
 
         stubber.activate()
 
-        return AmazonRedshiftSqlDriver(
-            database="dev", session=session, workgroup_name="dev", client=client
-        )
+        return AmazonRedshiftSqlDriver(database="dev", session=session, workgroup_name="dev", client=client)
 
-    def test_amazon_redshift_sql_driver_parameter_validation_correct_params(
-        self,
-    ):
-        AmazonRedshiftSqlDriver(
-            database="dev",
-            session=boto3.Session(region_name="us-east-1"),
-            workgroup_name="dev",
-        )
+    def test_amazon_redshift_sql_driver_parameter_validation_correct_params(self):
+        AmazonRedshiftSqlDriver(database="dev", session=boto3.Session(region_name="us-east-1"), workgroup_name="dev")
 
-    def test_amazon_redshift_sql_driver_parameter_validation_missing_params(
-        self,
-    ):
+    def test_amazon_redshift_sql_driver_parameter_validation_missing_params(self):
         with pytest.raises(ValueError):
-            AmazonRedshiftSqlDriver(
-                database="dev", session=boto3.Session(region_name="us-east-1")
-            )
+            AmazonRedshiftSqlDriver(database="dev", session=boto3.Session(region_name="us-east-1"))
 
-    def test_amazon_redshift_sql_driver_parameter_validation_conflicting_params(
-        self,
-    ):
+    def test_amazon_redshift_sql_driver_parameter_validation_conflicting_params(self):
         with pytest.raises(ValueError):
             AmazonRedshiftSqlDriver(
                 database="dev",
@@ -166,9 +138,10 @@ class TestAmazonRedshiftSqlDriver:
             )
 
     def test_process_rows_from_records(self):
-        assert AmazonRedshiftSqlDriver._process_rows_from_records(
-            TestAmazonRedshiftSqlDriver.TEST_RECORDS
-        ) == [["Bob", "Ross"], ["Tony", "Hawk"]]
+        assert AmazonRedshiftSqlDriver._process_rows_from_records(TestAmazonRedshiftSqlDriver.TEST_RECORDS) == [
+            ["Bob", "Ross"],
+            ["Tony", "Hawk"],
+        ]
 
     def test_process_columns_from_column_metadata(self):
         assert AmazonRedshiftSqlDriver._process_columns_from_column_metadata(
@@ -177,31 +150,16 @@ class TestAmazonRedshiftSqlDriver:
 
     def test_post_process(self):
         assert AmazonRedshiftSqlDriver._post_process(
-            TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA,
-            TestAmazonRedshiftSqlDriver.TEST_RECORDS,
-        ) == [
-            {"first_name": "Bob", "last_name": "Ross"},
-            {"first_name": "Tony", "last_name": "Hawk"},
-        ]
+            TestAmazonRedshiftSqlDriver.TEST_COLUMN_METADATA, TestAmazonRedshiftSqlDriver.TEST_RECORDS
+        ) == [{"first_name": "Bob", "last_name": "Ross"}, {"first_name": "Tony", "last_name": "Hawk"}]
 
     def test_execute_query_raw(self, statement_driver):
-        rows = [
-            {"first_name": "Bob", "last_name": "Ross"},
-            {"first_name": "Tony", "last_name": "Hawk"},
-        ]
+        rows = [{"first_name": "Bob", "last_name": "Ross"}, {"first_name": "Tony", "last_name": "Hawk"}]
         assert statement_driver.execute_query_raw("query") == rows
 
     def test_execute_query(self, statement_driver):
-        rows = [
-            {"first_name": "Bob", "last_name": "Ross"},
-            {"first_name": "Tony", "last_name": "Hawk"},
-        ]
-        assert statement_driver.execute_query("query") == [
-            BaseSqlDriver.RowResult(row) for row in rows
-        ]
+        rows = [{"first_name": "Bob", "last_name": "Ross"}, {"first_name": "Tony", "last_name": "Hawk"}]
+        assert statement_driver.execute_query("query") == [BaseSqlDriver.RowResult(row) for row in rows]
 
     def test_get_table_schema(self, describe_table_driver):
-        assert describe_table_driver.get_table_schema("dev") == [
-            "first_name",
-            "last_name",
-        ]
+        assert describe_table_driver.get_table_schema("dev") == ["first_name", "last_name"]

--- a/tests/unit/drivers/sql/test_snowflake_sql_driver.py
+++ b/tests/unit/drivers/sql/test_snowflake_sql_driver.py
@@ -7,10 +7,7 @@ from griptape.drivers import BaseSqlDriver, SnowflakeSqlDriver
 
 
 class TestSnowflakeSqlDriver:
-    TEST_ROWS = [
-        {"first_name": "Tony", "last_name": "Hawk"},
-        {"first_name": "Bob", "last_name": "Ross"},
-    ]
+    TEST_ROWS = [{"first_name": "Tony", "last_name": "Hawk"}, {"first_name": "Bob", "last_name": "Ross"}]
 
     TEST_COLUMNS = [("first_name", "VARCHAR"), ("last_name", "VARCHAR")]
 
@@ -21,9 +18,7 @@ class TestSnowflakeSqlDriver:
             name: str
             type: str = "VARCHAR"
 
-        mock_table = mocker.MagicMock(
-            name="table", columns=[Column("first_name"), Column("last_name")]
-        )
+        mock_table = mocker.MagicMock(name="table", columns=[Column("first_name"), Column("last_name")])
         return mock_table
 
     @pytest.fixture
@@ -39,45 +34,29 @@ class TestSnowflakeSqlDriver:
         items_mock = mocker.MagicMock(name="items")
         items_mock_2 = mocker.MagicMock(name="items2")
 
-        items_mock.items.return_value = [
-            ("first_name", "Tony"),
-            ("last_name", "Hawk"),
-        ]
-        items_mock_2.items.return_value = [
-            ("first_name", "Bob"),
-            ("last_name", "Ross"),
-        ]
+        items_mock.items.return_value = [("first_name", "Tony"), ("last_name", "Hawk")]
+        items_mock_2.items.return_value = [("first_name", "Bob"), ("last_name", "Ross")]
 
         result_mock.return_value.returns_rows = True
         result_mock.__iter__.return_value = iter([items_mock, items_mock_2])
 
-        mock_engine.connect.return_value.__enter__.return_value.execute.return_value = (
-            result_mock
-        )
+        mock_engine.connect.return_value.__enter__.return_value.execute.return_value = result_mock
 
         return mock_engine
 
     @pytest.fixture
     def mock_snowflake_connection(self, mocker):
-        mock_connection = mocker.MagicMock(
-            spec=SnowflakeConnection, name="connection"
-        )
+        mock_connection = mocker.MagicMock(spec=SnowflakeConnection, name="connection")
         return mock_connection
 
     @pytest.fixture
     def mock_snowflake_connection_no_schema(self, mocker):
-        mock_connection = mocker.MagicMock(
-            spec=SnowflakeConnection, name="connection_no_schema", schema=None
-        )
+        mock_connection = mocker.MagicMock(spec=SnowflakeConnection, name="connection_no_schema", schema=None)
         return mock_connection
 
     @pytest.fixture
     def mock_snowflake_connection_no_database(self, mocker):
-        mock_connection = mocker.MagicMock(
-            spec=SnowflakeConnection,
-            name="connection_no_database",
-            database=None,
-        )
+        mock_connection = mocker.MagicMock(spec=SnowflakeConnection, name="connection_no_database", database=None)
         return mock_connection
 
     @pytest.fixture
@@ -85,9 +64,7 @@ class TestSnowflakeSqlDriver:
         def get_connection():
             return mock_snowflake_connection
 
-        new_driver = SnowflakeSqlDriver(
-            connection_func=get_connection, engine=mock_snowflake_engine
-        )
+        new_driver = SnowflakeSqlDriver(connection_func=get_connection, engine=mock_snowflake_engine)
 
         return new_driver
 
@@ -98,49 +75,34 @@ class TestSnowflakeSqlDriver:
         with pytest.raises(ValueError):
             SnowflakeSqlDriver(connection_func=get_connection)
 
-    def test_connection_validation_no_schema(
-        self, mock_snowflake_connection_no_schema
-    ):
+    def test_connection_validation_no_schema(self, mock_snowflake_connection_no_schema):
         def get_connection():
             return mock_snowflake_connection_no_schema
 
         with pytest.raises(ValueError):
             SnowflakeSqlDriver(connection_func=get_connection)
 
-    def test_connection_validation_no_database(
-        self, mock_snowflake_connection_no_database
-    ):
+    def test_connection_validation_no_database(self, mock_snowflake_connection_no_database):
         def get_connection():
             return mock_snowflake_connection_no_database
 
         with pytest.raises(ValueError):
             SnowflakeSqlDriver(connection_func=get_connection)
 
-    def test_engine_url_validation_wrong_engine(
-        self, mock_snowflake_connection
-    ):
+    def test_engine_url_validation_wrong_engine(self, mock_snowflake_connection):
         with pytest.raises(ValueError):
-            SnowflakeSqlDriver(
-                connection_func=mock_snowflake_connection,
-                engine=create_engine("sqlite:///:memory:"),
-            )
+            SnowflakeSqlDriver(connection_func=mock_snowflake_connection, engine=create_engine("sqlite:///:memory:"))
 
     def test_execute_query(self, driver):
         assert driver.execute_query("query") == [
-            BaseSqlDriver.RowResult(row)
-            for row in TestSnowflakeSqlDriver.TEST_ROWS
+            BaseSqlDriver.RowResult(row) for row in TestSnowflakeSqlDriver.TEST_ROWS
         ]
 
     def test_execute_query_raw(self, driver):
-        assert (
-            driver.execute_query_raw("query")
-            == TestSnowflakeSqlDriver.TEST_ROWS
-        )
+        assert driver.execute_query_raw("query") == TestSnowflakeSqlDriver.TEST_ROWS
 
     def test_table(self, driver, mock_table, mock_metadata):
-        with mock.patch(
-            "sqlalchemy.Table", return_value=mock_table
-        ), mock.patch("sqlalchemy.MetaData", return_value=mock_metadata):
-            assert driver.get_table_schema("table") == str(
-                TestSnowflakeSqlDriver.TEST_COLUMNS
-            )
+        with mock.patch("sqlalchemy.Table", return_value=mock_table), mock.patch(
+            "sqlalchemy.MetaData", return_value=mock_metadata
+        ):
+            assert driver.get_table_schema("table") == str(TestSnowflakeSqlDriver.TEST_COLUMNS)

--- a/tests/unit/drivers/sql/test_sql_driver.py
+++ b/tests/unit/drivers/sql/test_sql_driver.py
@@ -11,16 +11,12 @@ class TestSqlDriver:
             "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER, city TEXT);"
         )
 
-        new_driver.execute_query(
-            "INSERT INTO test_table (name, age, city) VALUES ('Alice', 25, 'New York');"
-        )
+        new_driver.execute_query("INSERT INTO test_table (name, age, city) VALUES ('Alice', 25, 'New York');")
 
         return new_driver
 
     def test_execute_query(self, driver):
-        assert driver.execute_query("SELECT count(*) FROM test_table")[
-            0
-        ].cells == {"count(*)": 1}
+        assert driver.execute_query("SELECT count(*) FROM test_table")[0].cells == {"count(*)": 1}
 
     def test_execute_query_raw(self, driver):
         assert driver.execute_query_raw("SELECT * FROM test_table") == [

--- a/tests/unit/drivers/vector/test_amazon_opensearch_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_amazon_opensearch_vector_store_driver.py
@@ -9,21 +9,12 @@ class TestAmazonOpenSearchVectorStoreDriver:
     @pytest.fixture
     def driver(self):
         mock_session = create_autospec(boto3.Session, instance=True)
-        mock_driver = create_autospec(
-            AmazonOpenSearchVectorStoreDriver,
-            instance=True,
-            session=mock_session,
-        )
+        mock_driver = create_autospec(AmazonOpenSearchVectorStoreDriver, instance=True, session=mock_session)
         mock_driver.upsert_vector.return_value = "foo"
         return mock_driver
 
     def test_upsert_vector(self, driver):
-        assert (
-            driver.upsert_vector(
-                [0.1, 0.2, 0.3], vector_id="foo", namespace="company"
-            )
-            == "foo"
-        )
+        assert driver.upsert_vector([0.1, 0.2, 0.3], vector_id="foo", namespace="company") == "foo"
 
     def test_load_entry(self, driver):
         mock_entry = Mock()

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -20,61 +20,35 @@ class TestLocalVectorStoreDriver:
         assert len(driver.entries) == 2
 
     def test_upsert_multiple(self, driver):
-        driver.upsert_text_artifacts(
-            {"foo": [TextArtifact("foo")], "bar": [TextArtifact("bar")]}
-        )
+        driver.upsert_text_artifacts({"foo": [TextArtifact("foo")], "bar": [TextArtifact("bar")]})
 
         foo_entries = driver.load_entries("foo")
         bar_entries = driver.load_entries("bar")
 
         assert len(driver.entries) == 2
-        assert (
-            BaseArtifact.from_json(foo_entries[0].meta["artifact"]).value
-            == "foo"
-        )
-        assert (
-            BaseArtifact.from_json(bar_entries[0].meta["artifact"]).value
-            == "bar"
-        )
+        assert BaseArtifact.from_json(foo_entries[0].meta["artifact"]).value == "foo"
+        assert BaseArtifact.from_json(bar_entries[0].meta["artifact"]).value == "bar"
 
     def test_query(self, driver):
-        vector_id = driver.upsert_text_artifact(
-            TextArtifact("foobar"), namespace="test-namespace"
-        )
+        vector_id = driver.upsert_text_artifact(TextArtifact("foobar"), namespace="test-namespace")
 
         assert len(driver.query("foobar")) == 1
         assert len(driver.query("foobar", namespace="bad-namespace")) == 0
         assert len(driver.query("foobar", namespace="test-namespace")) == 1
         assert driver.query("foobar")[0].vector == []
         assert driver.query("foobar", include_vectors=True)[0].vector == [0, 1]
-        assert (
-            BaseArtifact.from_json(
-                driver.query("foobar")[0].meta["artifact"]
-            ).value
-            == "foobar"
-        )
+        assert BaseArtifact.from_json(driver.query("foobar")[0].meta["artifact"]).value == "foobar"
         assert driver.query("foobar")[0].id == vector_id
 
     def test_load_entry(self, driver):
-        vector_id = driver.upsert_text_artifact(
-            TextArtifact("foobar"), namespace="test-namespace"
-        )
+        vector_id = driver.upsert_text_artifact(TextArtifact("foobar"), namespace="test-namespace")
 
-        assert (
-            driver.load_entry(vector_id, namespace="test-namespace").id
-            == vector_id
-        )
+        assert driver.load_entry(vector_id, namespace="test-namespace").id == vector_id
 
     def test_load_entries(self, driver):
-        driver.upsert_text_artifact(
-            TextArtifact("foobar 1"), namespace="test-namespace-1"
-        )
-        driver.upsert_text_artifact(
-            TextArtifact("foobar 2"), namespace="test-namespace-1"
-        )
-        driver.upsert_text_artifact(
-            TextArtifact("foobar 3"), namespace="test-namespace-2"
-        )
+        driver.upsert_text_artifact(TextArtifact("foobar 1"), namespace="test-namespace-1")
+        driver.upsert_text_artifact(TextArtifact("foobar 2"), namespace="test-namespace-1")
+        driver.upsert_text_artifact(TextArtifact("foobar 3"), namespace="test-namespace-2")
 
         assert len(driver.load_entries()) == 3
         assert len(driver.load_entries("test-namespace-1")) == 2

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -11,13 +11,7 @@ class TestMarqoVectorStorageDriver:
         # Create a fake responses
         fake_add_document_response = {
             "errors": False,
-            "items": [
-                {
-                    "_id": "5aed93eb-3878-4f12-bc92-0fda01c7d23d",
-                    "result": "created",
-                    "status": 201,
-                }
-            ],
+            "items": [{"_id": "5aed93eb-3878-4f12-bc92-0fda01c7d23d", "result": "created", "status": 201}],
             "processingTimeMs": 6,
             "index_name": "my-first-index",
         }
@@ -31,10 +25,7 @@ class TestMarqoVectorStorageDriver:
                     "_id": "5aed93eb-3878-4f12-bc92-0fda01c7d23d",
                     "_source": {
                         "values": [0.1, 0.2, 0.3],
-                        "metadata": {
-                            "Title": "Test title",
-                            "Description": "Test description",
-                        },
+                        "metadata": {"Title": "Test title", "Description": "Test description"},
                     },
                     "_score": 0.6047464,
                 }
@@ -51,39 +42,21 @@ class TestMarqoVectorStorageDriver:
             # '_id': 'article_152',
             "_id": "5aed93eb-3878-4f12-bc92-0fda01c7d23d",
             "_tensor_facets": [
-                {
-                    "Title": "Test Title",
-                    "_embedding": [
-                        -0.10393160581588745,
-                        0.0465407557785511,
-                        -0.01760256476700306,
-                    ],
-                },
+                {"Title": "Test Title", "_embedding": [-0.10393160581588745, 0.0465407557785511, -0.01760256476700306]},
                 {
                     "Blurb": "Test description",
-                    "_embedding": [
-                        -0.045681700110435486,
-                        0.056278493255376816,
-                        0.022254955023527145,
-                    ],
+                    "_embedding": [-0.045681700110435486, 0.056278493255376816, 0.022254955023527145],
                 },
             ],
         }
 
-        fake_create_index_response = {
-            "acknowledged": True,
-            "shards_acknowledged": True,
-            "index": "my-first-index",
-        }
+        fake_create_index_response = {"acknowledged": True, "shards_acknowledged": True, "index": "my-first-index"}
 
         # Define a namedtuple type for the mock indexes
         MockIndex = namedtuple("MockIndex", ["index_name"])
 
         # Create a list of mock indexes
-        mock_indexes = [
-            MockIndex(index_name="my-first-index"),
-            MockIndex(index_name="test-index"),
-        ]
+        mock_indexes = [MockIndex(index_name="my-first-index"), MockIndex(index_name="test-index")]
         mock_get_indexes_response = {"results": mock_indexes}
 
         # Mock the marqo.Client
@@ -124,17 +97,13 @@ class TestMarqoVectorStorageDriver:
         assert result["index"] == "my-first-index"
 
     def test_upsert_text(self, driver, mock_marqo):
-        result = driver.upsert_text(
-            "test text", vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d"
-        )
+        result = driver.upsert_text("test text", vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d")
         mock_marqo.index().add_documents.assert_called()
         assert result == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
 
     def test_upsert_text_artifact(self, driver, mock_marqo):
         # Arrange
-        text = TextArtifact(
-            id="a44b04ff052e4109b3c6fda0f3f3e997", value="racoons"
-        )
+        text = TextArtifact(id="a44b04ff052e4109b3c6fda0f3f3e997", value="racoons")
         mock_marqo.index().add_documents.return_value = {
             "errors": False,
             "items": [{"_id": text.id, "result": "created", "status": 201}],
@@ -173,10 +142,7 @@ class TestMarqoVectorStorageDriver:
 
         # Assert
         mock_marqo.index().search.assert_called_once_with(
-            "Test query",
-            limit=5,
-            attributes_to_retrieve=["*"],
-            filter_string=None,
+            "Test query", limit=5, attributes_to_retrieve=["*"], filter_string=None
         )
         mock_marqo.index().get_document.assert_called_once_with(
             "5aed93eb-3878-4f12-bc92-0fda01c7d23d", expose_facets=True
@@ -185,19 +151,14 @@ class TestMarqoVectorStorageDriver:
         assert results[0].score == 0.6047464
         assert results[0].meta["Title"] == "Test Title"
         assert results[0].meta["Description"] == "Test description"
-        assert results[0].vector == [
-            -0.10393160581588745,
-            0.0465407557785511,
-            -0.01760256476700306,
-        ]  # The vector
+        assert results[0].vector == [-0.10393160581588745, 0.0465407557785511, -0.01760256476700306]  # The vector
         # values should match the "_embedding" values of title in mock response
 
     def test_laod_entry(self, driver, mock_marqo):
         # Mock 'get_document' method to return a dictionary
         entry = driver.load_entry("5aed93eb-3878-4f12-bc92-0fda01c7d23d")
         mock_marqo.index().get_document.assert_called_once_with(
-            document_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d",
-            expose_facets=True,
+            document_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d", expose_facets=True
         )
         assert entry.id == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
         assert entry.meta["Title"] == "Test Title"
@@ -232,21 +193,16 @@ class TestMarqoVectorStorageDriver:
         }
 
         mock_marqo.index().search.return_value = fake_search_response
-        mock_marqo.index().get_documents.return_value = (
-            fake_get_documents_response
-        )
+        mock_marqo.index().get_documents.return_value = fake_get_documents_response
 
         # Act
         entries = driver.load_entries()
 
         # Assert
         assert len(entries) == 1
-        mock_marqo.index().search.assert_called_once_with(
-            "", limit=10000, filter_string=None
-        )
+        mock_marqo.index().search.assert_called_once_with("", limit=10000, filter_string=None)
         mock_marqo.index().get_documents.assert_called_once_with(
-            document_ids=["5aed93eb-3878-4f12-bc92-0fda01c7d23d"],
-            expose_facets=True,
+            document_ids=["5aed93eb-3878-4f12-bc92-0fda01c7d23d"], expose_facets=True
         )
         assert entries[0].id == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
         assert entries[0].vector == [0.1, 0.2, 0.3]

--- a/tests/unit/drivers/vector/test_mongodb_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_mongodb_vector_store_driver.py
@@ -2,10 +2,7 @@ import pytest
 import mongomock
 from pymongo import MongoClient
 from griptape.artifacts import TextArtifact
-from griptape.drivers import (
-    MongoDbAtlasVectorStoreDriver,
-    BaseVectorStoreDriver,
-)
+from griptape.drivers import MongoDbAtlasVectorStoreDriver, BaseVectorStoreDriver
 from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
 
@@ -40,23 +37,11 @@ class TestMongoDbAtlasVectorStoreDriver:
 
     def test_query(self, driver, monkeypatch):
         mock_query_result = [
-            BaseVectorStoreDriver.QueryResult(
-                "foo", [0.5, 0.5, 0.5], score=None, meta={}, namespace=None
-            ),
-            BaseVectorStoreDriver.QueryResult(
-                "foo",
-                vector=[0.5, 0.5, 0.5],
-                score=None,
-                meta={},
-                namespace=None,
-            ),
+            BaseVectorStoreDriver.QueryResult("foo", [0.5, 0.5, 0.5], score=None, meta={}, namespace=None),
+            BaseVectorStoreDriver.QueryResult("foo", vector=[0.5, 0.5, 0.5], score=None, meta={}, namespace=None),
         ]
 
-        monkeypatch.setattr(
-            MongoDbAtlasVectorStoreDriver,
-            "query",
-            lambda *args, **kwargs: mock_query_result,
-        )
+        monkeypatch.setattr(MongoDbAtlasVectorStoreDriver, "query", lambda *args, **kwargs: mock_query_result)
 
         query_str = "some query string"
         results = driver.query(query_str, include_vectors=True)
@@ -69,17 +54,13 @@ class TestMongoDbAtlasVectorStoreDriver:
     def test_load_entry(self, driver):
         vector_id_str = "123"
         vector = [0.5, 0.5, 0.5]
-        driver.upsert_vector(
-            vector, vector_id=vector_id_str
-        )  # ensure the entry exists
+        driver.upsert_vector(vector, vector_id=vector_id_str)  # ensure the entry exists
         result = driver.load_entry(vector_id_str)
         assert result is not None
 
     def test_load_entries(self, driver):
         vector_id_str = "123"
         vector = [0.5, 0.5, 0.5]
-        driver.upsert_vector(
-            vector, vector_id=vector_id_str
-        )  # ensure at least one entry exists
+        driver.upsert_vector(vector, vector_id=vector_id_str)  # ensure at least one entry exists
         results = list(driver.load_entries())
         assert results is not None and len(results) > 0

--- a/tests/unit/drivers/vector/test_opensearch_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_opensearch_vector_store_driver.py
@@ -7,19 +7,12 @@ import numpy as np
 class TestOpenSearchVectorStoreDriver:
     @pytest.fixture
     def driver(self):
-        mock_driver = create_autospec(
-            OpenSearchVectorStoreDriver, instance=True
-        )
+        mock_driver = create_autospec(OpenSearchVectorStoreDriver, instance=True)
         mock_driver.upsert_vector.return_value = "foo"
         return mock_driver
 
     def test_upsert_vector(self, driver):
-        assert (
-            driver.upsert_vector(
-                [0.1, 0.2, 0.3], vector_id="foo", namespace="company"
-            )
-            == "foo"
-        )
+        assert driver.upsert_vector([0.1, 0.2, 0.3], vector_id="foo", namespace="company") == "foo"
 
     def test_load_entry(self, driver):
         mock_entry = Mock()

--- a/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
@@ -23,34 +23,21 @@ class TestPgVectorVectorStoreDriver:
         session = MagicMock()
         mock_session_manager = MagicMock()
         mock_session_manager.__enter__.return_value = session
-        mocker.patch(
-            "griptape.drivers.vector.pgvector_vector_store_driver.Session",
-            return_value=mock_session_manager,
-        )
+        mocker.patch("griptape.drivers.vector.pgvector_vector_store_driver.Session", return_value=mock_session_manager)
 
         return session
 
-    def test_initialize_requires_engine_or_connection_string(
-        self, embedding_driver
-    ):
+    def test_initialize_requires_engine_or_connection_string(self, embedding_driver):
         with pytest.raises(ValueError):
-            driver = PgVectorVectorStoreDriver(
-                embedding_driver=embedding_driver, table_name=self.table_name
-            )
+            driver = PgVectorVectorStoreDriver(embedding_driver=embedding_driver, table_name=self.table_name)
 
     def test_initialize_accepts_engine(self, embedding_driver):
         engine = create_engine(self.connection_string)
-        driver = PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver,
-            engine=engine,
-            table_name=self.table_name,
-        )
+        driver = PgVectorVectorStoreDriver(embedding_driver=embedding_driver, engine=engine, table_name=self.table_name)
 
     def test_initialize_accepts_connection_string(self, embedding_driver):
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver,
-            connection_string=self.connection_string,
-            table_name=self.table_name,
+            embedding_driver=embedding_driver, connection_string=self.connection_string, table_name=self.table_name
         )
 
     def test_upsert_vector(self, mock_session, mock_engine):
@@ -58,9 +45,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.merge.return_value = Mock(id=test_id)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(),
-            engine=mock_engine,
-            table_name=self.table_name,
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         returned_id = driver.upsert_vector([1.0, 2.0, 3.0])
@@ -74,17 +59,10 @@ class TestPgVectorVectorStoreDriver:
         test_vec = [0.1, 0.2, 0.3]
         test_namespace = str(uuid.uuid4())
         test_meta = {"key": "value"}
-        mock_session.get.return_value = Mock(
-            id=test_id,
-            vector=test_vec,
-            namespace=test_namespace,
-            meta=test_meta,
-        )
+        mock_session.get.return_value = Mock(id=test_id, vector=test_vec, namespace=test_namespace, meta=test_meta)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(),
-            engine=mock_engine,
-            table_name=self.table_name,
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         entry = driver.load_entry(vector_id=test_id)
@@ -101,25 +79,13 @@ class TestPgVectorVectorStoreDriver:
         test_metas = [{"key": "value1"}, {"key": "value2"}]
         mock_query = MagicMock()
         mock_query.all.return_value = [
-            Mock(
-                id=test_ids[0],
-                vector=test_vecs[0],
-                namespace=test_namespaces[0],
-                meta=test_metas[0],
-            ),
-            Mock(
-                id=test_ids[1],
-                vector=test_vecs[1],
-                namespace=test_namespaces[1],
-                meta=test_metas[1],
-            ),
+            Mock(id=test_ids[0], vector=test_vecs[0], namespace=test_namespaces[0], meta=test_metas[0]),
+            Mock(id=test_ids[1], vector=test_vecs[1], namespace=test_namespaces[1], meta=test_metas[1]),
         ]
         mock_session.query.return_value = mock_query
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(),
-            engine=mock_engine,
-            table_name=self.table_name,
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         entries = driver.load_entries()
@@ -135,9 +101,7 @@ class TestPgVectorVectorStoreDriver:
 
     def test_query_invalid_distance_metric(self, mock_engine):
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(),
-            engine=mock_engine,
-            table_name=self.table_name,
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         with pytest.raises(ValueError):
@@ -149,31 +113,13 @@ class TestPgVectorVectorStoreDriver:
         test_namespaces = [str(uuid.uuid4()), str(uuid.uuid4())]
         test_metas = [{"key": "value1"}, {"key": "value2"}]
         test_result = [
-            [
-                Mock(
-                    id=test_ids[0],
-                    vector=test_vecs[0],
-                    namespace=test_namespaces[0],
-                    meta=test_metas[0],
-                ),
-                0.1,
-            ],
-            [
-                Mock(
-                    id=test_ids[1],
-                    vector=test_vecs[1],
-                    namespace=test_namespaces[1],
-                    meta=test_metas[1],
-                ),
-                0.9,
-            ],
+            [Mock(id=test_ids[0], vector=test_vecs[0], namespace=test_namespaces[0], meta=test_metas[0]), 0.1],
+            [Mock(id=test_ids[1], vector=test_vecs[1], namespace=test_namespaces[1], meta=test_metas[1]), 0.9],
         ]
         mock_session.query().order_by().limit().all.return_value = test_result
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(),
-            engine=mock_engine,
-            table_name=self.table_name,
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         result = driver.query("some query", include_vectors=True)

--- a/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
+++ b/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
@@ -14,14 +14,7 @@ class TestPineconeVectorStorageDriver:
     def mock_pinecone(self, mocker):
         # Create a fake response
         fake_query_response = {
-            "matches": [
-                {
-                    "id": "foo",
-                    "values": [0, 1, 0],
-                    "score": 42,
-                    "metadata": {"foo": "bar"},
-                }
-            ],
+            "matches": [{"id": "foo", "values": [0, 1, 0], "score": 42, "metadata": {"foo": "bar"}}],
             "namespace": "foobar",
         }
 
@@ -33,10 +26,7 @@ class TestPineconeVectorStorageDriver:
     @pytest.fixture
     def driver(self):
         return PineconeVectorStoreDriver(
-            api_key="foobar",
-            index_name="test",
-            environment="test",
-            embedding_driver=MockEmbeddingDriver(),
+            api_key="foobar", index_name="test", environment="test", embedding_driver=MockEmbeddingDriver()
         )
 
     def test_upsert_text_artifact(self, driver):

--- a/tests/unit/drivers/vector/test_redis_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_redis_vector_store_driver.py
@@ -7,51 +7,28 @@ from griptape.drivers import RedisVectorStoreDriver
 class TestRedisVectorStorageDriver:
     @pytest.fixture(autouse=True)
     def mock_redis(self, mocker):
-        fake_hgetall_response = {
-            b"vector": b"\x00\x00\x80?\x00\x00\x00@\x00\x00@@",
-            b"metadata": b'{"foo": "bar"}',
-        }
+        fake_hgetall_response = {b"vector": b"\x00\x00\x80?\x00\x00\x00@\x00\x00@@", b"metadata": b'{"foo": "bar"}'}
 
         mocker.patch.object(redis.StrictRedis, "hset", return_value=None)
-        mocker.patch.object(
-            redis.StrictRedis, "hgetall", return_value=fake_hgetall_response
-        )
-        mocker.patch.object(
-            redis.StrictRedis,
-            "keys",
-            return_value=[b"some_namespace:some_vector_id"],
-        )
+        mocker.patch.object(redis.StrictRedis, "hgetall", return_value=fake_hgetall_response)
+        mocker.patch.object(redis.StrictRedis, "keys", return_value=[b"some_namespace:some_vector_id"])
 
         fake_redisearch = mocker.MagicMock()
-        fake_redisearch.search = mocker.MagicMock(
-            return_value=mocker.MagicMock(docs=[])
-        )
-        fake_redisearch.info = mocker.MagicMock(
-            side_effect=Exception("Index not found")
-        )
+        fake_redisearch.search = mocker.MagicMock(return_value=mocker.MagicMock(docs=[]))
+        fake_redisearch.info = mocker.MagicMock(side_effect=Exception("Index not found"))
         fake_redisearch.create_index = mocker.MagicMock(return_value=None)
 
-        mocker.patch.object(
-            redis.StrictRedis, "ft", return_value=fake_redisearch
-        )
+        mocker.patch.object(redis.StrictRedis, "ft", return_value=fake_redisearch)
 
     @pytest.fixture
     def driver(self):
         return RedisVectorStoreDriver(
-            host="localhost",
-            port=6379,
-            index="test_index",
-            db=0,
-            embedding_driver=MockEmbeddingDriver(),
+            host="localhost", port=6379, index="test_index", db=0, embedding_driver=MockEmbeddingDriver()
         )
 
     def test_upsert_vector(self, driver):
         assert (
-            driver.upsert_vector(
-                [1.0, 2.0, 3.0],
-                vector_id="some_vector_id",
-                namespace="some_namespace",
-            )
+            driver.upsert_vector([1.0, 2.0, 3.0], vector_id="some_vector_id", namespace="some_namespace")
             == "some_vector_id"
         )
 

--- a/tests/unit/engines/extraction/test_json_extraction_engine.py
+++ b/tests/unit/engines/extraction/test_json_extraction_engine.py
@@ -23,11 +23,7 @@ class TestJsonExtractionEngine:
         assert result.value[1].value == "{'test_key_2': 'test_value_2'}"
 
     def test_extract_error(self, engine):
-        assert isinstance(
-            engine.extract("foo", lambda: "non serializable"), ErrorArtifact
-        )
+        assert isinstance(engine.extract("foo", lambda: "non serializable"), ErrorArtifact)
 
     def test_json_to_text_artifacts(self, engine):
-        assert [
-            a.value for a in engine.json_to_text_artifacts('["foo", "bar"]')
-        ] == ["foo", "bar"]
+        assert [a.value for a in engine.json_to_text_artifacts('["foo", "bar"]')] == ["foo", "bar"]

--- a/tests/unit/engines/query/test_vector_query_engine.py
+++ b/tests/unit/engines/query/test_vector_query_engine.py
@@ -14,9 +14,7 @@ class TestVectorQueryEngine:
     @pytest.fixture
     def engine(self):
         return VectorQueryEngine(
-            vector_store_driver=LocalVectorStoreDriver(
-                embedding_driver=MockEmbeddingDriver()
-            ),
+            vector_store_driver=LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver()),
             prompt_driver=MockPromptDriver(),
         )
 
@@ -32,18 +30,11 @@ class TestVectorQueryEngine:
     def test_upsert_text_artifact(self, engine):
         engine.upsert_text_artifact(TextArtifact("foobar"), namespace="test")
 
-        assert (
-            BaseArtifact.from_json(
-                engine.vector_store_driver.load_entries()[0].meta["artifact"]
-            ).value
-            == "foobar"
-        )
+        assert BaseArtifact.from_json(engine.vector_store_driver.load_entries()[0].meta["artifact"]).value == "foobar"
 
     def test_prompt_creation(self, engine):
         message = engine.template_generator.render(
-            metadata="*META*",
-            query="*QUESTION*",
-            text_segments=["*TEXT SEGMENT 1*", "*TEXT SEGMENT 2*"],
+            metadata="*META*", query="*QUESTION*", text_segments=["*TEXT SEGMENT 1*", "*TEXT SEGMENT 2*"]
         )
 
         assert "*META*" in message
@@ -52,29 +43,13 @@ class TestVectorQueryEngine:
         assert "*TEXT SEGMENT 2*" in message
 
     def test_upsert_text_artifacts(self, engine):
-        engine.upsert_text_artifacts(
-            artifacts=[TextArtifact("foobar1"), TextArtifact("foobar2")],
-            namespace="test",
-        )
+        engine.upsert_text_artifacts(artifacts=[TextArtifact("foobar1"), TextArtifact("foobar2")], namespace="test")
 
-        assert (
-            BaseArtifact.from_json(
-                engine.vector_store_driver.load_entries()[0].meta["artifact"]
-            ).value
-            == "foobar1"
-        )
-        assert (
-            BaseArtifact.from_json(
-                engine.vector_store_driver.load_entries()[1].meta["artifact"]
-            ).value
-            == "foobar2"
-        )
+        assert BaseArtifact.from_json(engine.vector_store_driver.load_entries()[0].meta["artifact"]).value == "foobar1"
+        assert BaseArtifact.from_json(engine.vector_store_driver.load_entries()[1].meta["artifact"]).value == "foobar2"
 
     def test_load_artifacts(self, engine):
-        engine.upsert_text_artifacts(
-            artifacts=[TextArtifact("foobar1"), TextArtifact("foobar2")],
-            namespace="test",
-        )
+        engine.upsert_text_artifacts(artifacts=[TextArtifact("foobar1"), TextArtifact("foobar2")], namespace="test")
 
         assert len(engine.load_artifacts("doesntexist")) == 0
         assert len(engine.load_artifacts("test")) == 2

--- a/tests/unit/engines/summary/test_prompt_summary_engine.py
+++ b/tests/unit/engines/summary/test_prompt_summary_engine.py
@@ -14,8 +14,5 @@ class TestPromptSummaryEngine:
 
     def test_summarize_artifacts(self, engine):
         assert (
-            engine.summarize_artifacts(
-                ListArtifact([TextArtifact("foo"), TextArtifact("bar")])
-            ).value
-            == "mock output"
+            engine.summarize_artifacts(ListArtifact([TextArtifact("foo"), TextArtifact("bar")])).value == "mock output"
         )

--- a/tests/unit/events/test_base_event.py
+++ b/tests/unit/events/test_base_event.py
@@ -26,11 +26,7 @@ class TestBaseEvent:
         assert "timestamp" in MockEvent().to_dict()
 
     def test_start_prompt_event_from_dict(self):
-        dict_value = {
-            "type": "StartPromptEvent",
-            "timestamp": 123.0,
-            "token_count": 10,
-        }
+        dict_value = {"type": "StartPromptEvent", "timestamp": 123.0, "token_count": 10}
 
         event = BaseEvent.from_dict(dict_value)
 
@@ -39,11 +35,7 @@ class TestBaseEvent:
         assert event.token_count == 10
 
     def test_finish_prompt_event_from_dict(self):
-        dict_value = {
-            "type": "FinishPromptEvent",
-            "timestamp": 123.0,
-            "token_count": 10,
-        }
+        dict_value = {"type": "FinishPromptEvent", "timestamp": 123.0, "token_count": 10}
 
         event = BaseEvent.from_dict(dict_value)
 
@@ -172,11 +164,7 @@ class TestBaseEvent:
         assert event.timestamp == 123
 
     def test_completion_chunk_event_from_dict(self):
-        dict_value = {
-            "type": "CompletionChunkEvent",
-            "timestamp": 123.0,
-            "token": "foo",
-        }
+        dict_value = {"type": "CompletionChunkEvent", "timestamp": 123.0, "token": "foo"}
 
         event = BaseEvent.from_dict(dict_value)
 

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -33,10 +33,7 @@ class TestEventListener:
         event_handler_1 = Mock()
         event_handler_2 = Mock()
 
-        pipeline.event_listeners = [
-            EventListener(handler=event_handler_1),
-            EventListener(handler=event_handler_2),
-        ]
+        pipeline.event_listeners = [EventListener(handler=event_handler_1), EventListener(handler=event_handler_2)]
         # can't mock subtask events, so must manually call
         pipeline.tasks[0].subtasks[0].before_run()
         pipeline.tasks[0].subtasks[0].after_run()
@@ -57,37 +54,15 @@ class TestEventListener:
         completion_chunk_handler = Mock()
 
         pipeline.event_listeners = [
-            EventListener(
-                start_prompt_event_handler, event_types=[StartPromptEvent]
-            ),
-            EventListener(
-                finish_prompt_event_handler, event_types=[FinishPromptEvent]
-            ),
-            EventListener(
-                start_task_event_handler, event_types=[StartTaskEvent]
-            ),
-            EventListener(
-                finish_task_event_handler, event_types=[FinishTaskEvent]
-            ),
-            EventListener(
-                start_subtask_event_handler,
-                event_types=[StartActionSubtaskEvent],
-            ),
-            EventListener(
-                finish_subtask_event_handler,
-                event_types=[FinishActionSubtaskEvent],
-            ),
-            EventListener(
-                start_structure_run_event_handler,
-                event_types=[StartStructureRunEvent],
-            ),
-            EventListener(
-                finish_structure_run_event_handler,
-                event_types=[FinishStructureRunEvent],
-            ),
-            EventListener(
-                completion_chunk_handler, event_types=[CompletionChunkEvent]
-            ),
+            EventListener(start_prompt_event_handler, event_types=[StartPromptEvent]),
+            EventListener(finish_prompt_event_handler, event_types=[FinishPromptEvent]),
+            EventListener(start_task_event_handler, event_types=[StartTaskEvent]),
+            EventListener(finish_task_event_handler, event_types=[FinishTaskEvent]),
+            EventListener(start_subtask_event_handler, event_types=[StartActionSubtaskEvent]),
+            EventListener(finish_subtask_event_handler, event_types=[FinishActionSubtaskEvent]),
+            EventListener(start_structure_run_event_handler, event_types=[StartStructureRunEvent]),
+            EventListener(finish_structure_run_event_handler, event_types=[FinishStructureRunEvent]),
+            EventListener(completion_chunk_handler, event_types=[CompletionChunkEvent]),
         ]
 
         # can't mock subtask events, so must manually call
@@ -108,19 +83,11 @@ class TestEventListener:
         mock1 = Mock()
         mock2 = Mock()
         # duplicate event listeners will only get added once
-        event_listener_1 = pipeline.add_event_listener(
-            EventListener(mock1, event_types=[StartPromptEvent])
-        )
-        pipeline.add_event_listener(
-            EventListener(mock1, event_types=[StartPromptEvent])
-        )
+        event_listener_1 = pipeline.add_event_listener(EventListener(mock1, event_types=[StartPromptEvent]))
+        pipeline.add_event_listener(EventListener(mock1, event_types=[StartPromptEvent]))
 
-        event_listener_3 = pipeline.add_event_listener(
-            EventListener(mock1, event_types=[FinishPromptEvent])
-        )
-        event_listener_4 = pipeline.add_event_listener(
-            EventListener(mock2, event_types=[StartPromptEvent])
-        )
+        event_listener_3 = pipeline.add_event_listener(EventListener(mock1, event_types=[FinishPromptEvent]))
+        event_listener_4 = pipeline.add_event_listener(EventListener(mock2, event_types=[StartPromptEvent]))
 
         event_listener_5 = pipeline.add_event_listener(EventListener(mock2))
 

--- a/tests/unit/events/test_finish_action_subtask_event.py
+++ b/tests/unit/events/test_finish_action_subtask_event.py
@@ -28,36 +28,13 @@ class TestFinishActionSubtaskEvent:
 
         assert "timestamp" in event_dict
         assert event_dict["task_id"] == finish_subtask_event.task_id
-        assert (
-            event_dict["task_parent_ids"]
-            == finish_subtask_event.task_parent_ids
-        )
-        assert (
-            event_dict["task_child_ids"] == finish_subtask_event.task_child_ids
-        )
-        assert (
-            event_dict["task_input"]
-            == finish_subtask_event.task_input.to_dict()
-        )
+        assert event_dict["task_parent_ids"] == finish_subtask_event.task_parent_ids
+        assert event_dict["task_child_ids"] == finish_subtask_event.task_child_ids
+        assert event_dict["task_input"] == finish_subtask_event.task_input.to_dict()
         assert event_dict["task_output"] is None
 
-        assert (
-            event_dict["subtask_parent_task_id"]
-            == finish_subtask_event.subtask_parent_task_id
-        )
-        assert (
-            event_dict["subtask_thought"]
-            == finish_subtask_event.subtask_thought
-        )
-        assert (
-            event_dict["subtask_action_name"]
-            == finish_subtask_event.subtask_action_name
-        )
-        assert (
-            event_dict["subtask_action_path"]
-            == finish_subtask_event.subtask_action_path
-        )
-        assert (
-            event_dict["subtask_action_input"]
-            == finish_subtask_event.subtask_action_input
-        )
+        assert event_dict["subtask_parent_task_id"] == finish_subtask_event.subtask_parent_task_id
+        assert event_dict["subtask_thought"] == finish_subtask_event.subtask_thought
+        assert event_dict["subtask_action_name"] == finish_subtask_event.subtask_action_name
+        assert event_dict["subtask_action_path"] == finish_subtask_event.subtask_action_path
+        assert event_dict["subtask_action_input"] == finish_subtask_event.subtask_action_input

--- a/tests/unit/events/test_finish_task_event.py
+++ b/tests/unit/events/test_finish_task_event.py
@@ -20,13 +20,7 @@ class TestFinishTaskEvent:
 
         assert "timestamp" in event_dict
         assert event_dict["task_id"] == finish_task_event.task_id
-        assert (
-            event_dict["task_parent_ids"] == finish_task_event.task_parent_ids
-        )
+        assert event_dict["task_parent_ids"] == finish_task_event.task_parent_ids
         assert event_dict["task_child_ids"] == finish_task_event.task_child_ids
-        assert (
-            event_dict["task_input"] == finish_task_event.task_input.to_dict()
-        )
-        assert (
-            event_dict["task_output"] == finish_task_event.task_output.to_dict()
-        )
+        assert event_dict["task_input"] == finish_task_event.task_input.to_dict()
+        assert event_dict["task_output"] == finish_task_event.task_output.to_dict()

--- a/tests/unit/events/test_start_action_subtask_event.py
+++ b/tests/unit/events/test_start_action_subtask_event.py
@@ -28,33 +28,13 @@ class TestStartActionSubtaskEvent:
 
         assert "timestamp" in event_dict
         assert event_dict["task_id"] == start_subtask_event.task_id
-        assert (
-            event_dict["task_parent_ids"] == start_subtask_event.task_parent_ids
-        )
-        assert (
-            event_dict["task_child_ids"] == start_subtask_event.task_child_ids
-        )
-        assert (
-            event_dict["task_input"] == start_subtask_event.task_input.to_dict()
-        )
+        assert event_dict["task_parent_ids"] == start_subtask_event.task_parent_ids
+        assert event_dict["task_child_ids"] == start_subtask_event.task_child_ids
+        assert event_dict["task_input"] == start_subtask_event.task_input.to_dict()
         assert event_dict["task_output"] is None
 
-        assert (
-            event_dict["subtask_parent_task_id"]
-            == start_subtask_event.subtask_parent_task_id
-        )
-        assert (
-            event_dict["subtask_thought"] == start_subtask_event.subtask_thought
-        )
-        assert (
-            event_dict["subtask_action_name"]
-            == start_subtask_event.subtask_action_name
-        )
-        assert (
-            event_dict["subtask_action_path"]
-            == start_subtask_event.subtask_action_path
-        )
-        assert (
-            event_dict["subtask_action_input"]
-            == start_subtask_event.subtask_action_input
-        )
+        assert event_dict["subtask_parent_task_id"] == start_subtask_event.subtask_parent_task_id
+        assert event_dict["subtask_thought"] == start_subtask_event.subtask_thought
+        assert event_dict["subtask_action_name"] == start_subtask_event.subtask_action_name
+        assert event_dict["subtask_action_path"] == start_subtask_event.subtask_action_path
+        assert event_dict["subtask_action_input"] == start_subtask_event.subtask_action_input

--- a/tests/unit/events/test_start_task_event.py
+++ b/tests/unit/events/test_start_task_event.py
@@ -23,6 +23,4 @@ class TestStartTaskEvent:
         assert event_dict["task_parent_ids"] == start_task_event.task_parent_ids
         assert event_dict["task_child_ids"] == start_task_event.task_child_ids
         assert event_dict["task_input"] == start_task_event.task_input.to_dict()
-        assert (
-            event_dict["task_output"] == start_task_event.task_output.to_dict()
-        )
+        assert event_dict["task_output"] == start_task_event.task_output.to_dict()

--- a/tests/unit/loaders/test_csv_loader.py
+++ b/tests/unit/loaders/test_csv_loader.py
@@ -16,10 +16,7 @@ class TestCsvLoader:
     def test_load_with_path(self, loaders):
         (loader, loader_pipe) = loaders
         # test loading a file delimited by comma
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-1.csv",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-1.csv")
 
         artifacts = loader.load(path)
 
@@ -29,10 +26,7 @@ class TestCsvLoader:
         assert first_artifact["Bar"] == "bar1"
 
         # test loading a file delimited by pipe
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-pipe.csv",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-pipe.csv")
 
         artifacts = loader_pipe.load(path)
 
@@ -46,14 +40,8 @@ class TestCsvLoader:
     def test_load_collection_with_path(self, loaders):
         loader = loaders[0]
 
-        path1 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-1.csv",
-        )
-        path2 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-2.csv",
-        )
+        path1 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-1.csv")
+        path2 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-2.csv")
         collection = loader.load_collection([path1, path2])
 
         key1 = utils.str_to_hash(str(path1))

--- a/tests/unit/loaders/test_dataframe_loader.py
+++ b/tests/unit/loaders/test_dataframe_loader.py
@@ -13,10 +13,7 @@ class TestDataFrameLoader:
 
     def test_load_with_path(self, loader):
         # test loading a file delimited by comma
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-1.csv",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-1.csv")
 
         artifacts = loader.load(pd.read_csv(path))
 
@@ -28,14 +25,8 @@ class TestDataFrameLoader:
         assert artifacts[0].embedding == [0, 1]
 
     def test_load_collection_with_path(self, loader):
-        path1 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-1.csv",
-        )
-        path2 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test-2.csv",
-        )
+        path1 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-1.csv")
+        path2 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test-2.csv")
         df1 = pd.read_csv(path1)
         df2 = pd.read_csv(path2)
         collection = loader.load_collection([df1, df2])

--- a/tests/unit/loaders/test_email_loader.py
+++ b/tests/unit/loaders/test_email_loader.py
@@ -37,11 +37,7 @@ class TestEmailLoader:
 
     @pytest.fixture
     def loader(self):
-        return EmailLoader(
-            imap_url="an.email.server.hostname",
-            username="username",
-            password="password",
-        )
+        return EmailLoader(imap_url="an.email.server.hostname", username="username", password="password")
 
     def test_load_accepts_explicit_plain_text(self, loader):
         # When
@@ -62,34 +58,21 @@ class TestEmailLoader:
         assert to_value_set(list_artifact) == set()
 
     @pytest.mark.parametrize("match_count", range(3))
-    def test_load_with_search(
-        self, loader, mock_search, mock_fetch, match_count
-    ):
+    def test_load_with_search(self, loader, mock_search, mock_fetch, match_count):
         # Given
         mock_search.return_value = to_search_response(match_count)
-        mock_fetch.side_effect = [
-            to_fetch_message(f"message-{i}", "text/plain")
-            for i in range(match_count)
-        ]
+        mock_fetch.side_effect = [to_fetch_message(f"message-{i}", "text/plain") for i in range(match_count)]
 
         # When
-        list_artifact = loader.load(
-            EmailLoader.EmailQuery(
-                label="INBOX", key="key", search_criteria="search-criteria"
-            )
-        )
+        list_artifact = loader.load(EmailLoader.EmailQuery(label="INBOX", key="key", search_criteria="search-criteria"))
 
         # Then
         mock_search.called_once_with(None, "key", '"search-criteria"')
         assert mock_fetch.call_count == match_count
         assert isinstance(list_artifact, ListArtifact)
-        assert to_value_set(list_artifact) == {
-            f"message-{i}" for i in range(match_count)
-        }
+        assert to_value_set(list_artifact) == {f"message-{i}" for i in range(match_count)}
 
-    def test_load_returns_error_artifact_when_select_returns_non_ok(
-        self, loader, mock_select
-    ):
+    def test_load_returns_error_artifact_when_select_returns_non_ok(self, loader, mock_select):
         # Given
         mock_select.return_value = (None, ["NOT-OK".encode()])
 
@@ -99,9 +82,7 @@ class TestEmailLoader:
         # Then
         assert isinstance(artifact, ErrorArtifact)
 
-    def test_load_returns_error_artifact_when_login_throws(
-        self, loader, mock_login
-    ):
+    def test_load_returns_error_artifact_when_login_throws(self, loader, mock_login):
         # Given
         mock_login.side_effect = Exception("login-failed")
 
@@ -113,29 +94,21 @@ class TestEmailLoader:
 
     def test_load_collection(self, loader, mock_fetch):
         # Given
-        mock_fetch.side_effect = [
-            to_fetch_message(f"message-{i}", "text/plain") for i in range(3)
-        ]
+        mock_fetch.side_effect = [to_fetch_message(f"message-{i}", "text/plain") for i in range(3)]
 
         # When
-        list_artifact_by_hash = loader.load_collection(
-            [EmailLoader.EmailQuery(label=f"INBOX-{i}") for i in range(3)]
-        )
+        list_artifact_by_hash = loader.load_collection([EmailLoader.EmailQuery(label=f"INBOX-{i}") for i in range(3)])
 
         # Then
         assert mock_fetch.call_count == 3
-        assert to_value_set(list_artifact_by_hash) == {
-            f"message-{i}" for i in range(3)
-        }
+        assert to_value_set(list_artifact_by_hash) == {f"message-{i}" for i in range(3)}
 
     def test_load_collection_skips_duplicate_queries(self, loader, mock_fetch):
         # Given
         mock_fetch.return_value = to_fetch_message("message", "text/plain")
 
         # When
-        list_artifact_by_hash = loader.load_collection(
-            [EmailLoader.EmailQuery(label="INBOX")] * 3
-        )
+        list_artifact_by_hash = loader.load_collection([EmailLoader.EmailQuery(label="INBOX")] * 3)
 
         # Then
         mock_fetch.assert_called_once()
@@ -167,9 +140,7 @@ def to_message(body: str, content_type: Optional[str]) -> message:
     return message
 
 
-def to_value_set(
-    artifact_or_dict: ListArtifact | dict[str, ListArtifact]
-) -> set[str]:
+def to_value_set(artifact_or_dict: ListArtifact | dict[str, ListArtifact]) -> set[str]:
     if isinstance(artifact_or_dict, ListArtifact):
         return set([value.value for value in artifact_or_dict.value])
     elif isinstance(artifact_or_dict, dict):

--- a/tests/unit/loaders/test_file_loader.py
+++ b/tests/unit/loaders/test_file_loader.py
@@ -12,10 +12,7 @@ class TestFileLoader:
         return FileLoader()
 
     def test_load_with_path(self, loader):
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test.txt",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test.txt")
 
         artifact = loader.load(path)
 
@@ -27,10 +24,7 @@ class TestFileLoader:
 
     def test_load_with_encoding(self):
         loader = FileLoader(encoding="utf-8")
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test.txt",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test.txt")
 
         artifact = loader.load(path)
 
@@ -39,14 +33,8 @@ class TestFileLoader:
         assert artifact.value.startswith("foobar foobar foobar")
 
     def test_load_collection_with_path(self, loader):
-        text_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/test.txt",
-        )
-        pdf_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/bitcoin.pdf",
-        )
+        text_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test.txt")
+        pdf_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/bitcoin.pdf")
         artifacts = loader.load_collection([text_path, pdf_path])
 
         text_key = utils.str_to_hash(str(text_path))

--- a/tests/unit/loaders/test_pdf_loader.py
+++ b/tests/unit/loaders/test_pdf_loader.py
@@ -10,15 +10,10 @@ MAX_TOKENS = 50
 class TestPdfLoader:
     @pytest.fixture
     def loader(self):
-        return PdfLoader(
-            max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver()
-        )
+        return PdfLoader(max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver())
 
     def test_load(self, loader):
-        path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/bitcoin.pdf",
-        )
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/bitcoin.pdf")
 
         artifacts = loader.load(path)
 
@@ -29,14 +24,8 @@ class TestPdfLoader:
         assert artifacts[0].embedding == [0, 1]
 
     def test_load_collection(self, loader):
-        path1 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/bitcoin.pdf",
-        )
-        path2 = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "../../resources/bitcoin-2.pdf",
-        )
+        path1 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/bitcoin.pdf")
+        path2 = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/bitcoin-2.pdf")
         key1 = utils.str_to_hash(path1)
         key2 = utils.str_to_hash(path2)
 

--- a/tests/unit/loaders/test_sql_loader.py
+++ b/tests/unit/loaders/test_sql_loader.py
@@ -14,10 +14,7 @@ class TestSqlLoader:
         sql_loader = SqlLoader(
             sql_driver=SqlDriver(
                 engine_url="sqlite:///:memory:",
-                create_engine_params={
-                    "connect_args": {"check_same_thread": False},
-                    "poolclass": StaticPool,
-                },
+                create_engine_params={"connect_args": {"check_same_thread": False}, "poolclass": StaticPool},
             ),
             embedding_driver=MockEmbeddingDriver(),
         )
@@ -41,45 +38,21 @@ class TestSqlLoader:
         artifacts = loader.load("SELECT * FROM test_table;")
 
         assert len(artifacts) == 3
-        assert artifacts[0].value == {
-            "id": 1,
-            "name": "Alice",
-            "age": 25,
-            "city": "New York",
-        }
-        assert artifacts[1].value == {
-            "id": 2,
-            "name": "Bob",
-            "age": 30,
-            "city": "Los Angeles",
-        }
-        assert artifacts[2].value == {
-            "id": 3,
-            "name": "Charlie",
-            "age": 22,
-            "city": "Chicago",
-        }
+        assert artifacts[0].value == {"id": 1, "name": "Alice", "age": 25, "city": "New York"}
+        assert artifacts[1].value == {"id": 2, "name": "Bob", "age": 30, "city": "Los Angeles"}
+        assert artifacts[2].value == {"id": 3, "name": "Charlie", "age": 22, "city": "Chicago"}
 
         assert artifacts[0].embedding == [0, 1]
 
     def test_load_collection(self, loader):
-        artifacts = loader.load_collection(
-            [
-                "SELECT * FROM test_table LIMIT 1;",
-                "SELECT * FROM test_table LIMIT 2;",
-            ]
-        )
+        artifacts = loader.load_collection(["SELECT * FROM test_table LIMIT 1;", "SELECT * FROM test_table LIMIT 2;"])
 
         assert list(artifacts.keys()) == [
             utils.str_to_hash("SELECT * FROM test_table LIMIT 1;"),
             utils.str_to_hash("SELECT * FROM test_table LIMIT 2;"),
         ]
 
-        assert [
-            a.value
-            for artifact_list in artifacts.values()
-            for a in artifact_list
-        ] == [
+        assert [a.value for artifact_list in artifacts.values() for a in artifact_list] == [
             {"age": 25, "city": "New York", "id": 1, "name": "Alice"},
             {"age": 25, "city": "New York", "id": 1, "name": "Alice"},
             {"age": 30, "city": "Los Angeles", "id": 2, "name": "Bob"},

--- a/tests/unit/loaders/test_text_loader.py
+++ b/tests/unit/loaders/test_text_loader.py
@@ -12,9 +12,7 @@ MAX_TOKENS = 50
 class TestTextLoader:
     @pytest.fixture
     def loader(self):
-        return TextLoader(
-            max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver()
-        )
+        return TextLoader(max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver())
 
     def test_load_with_str(self, loader):
         text = gen_paragraph(MAX_TOKENS * 2, loader.tokenizer, " ")
@@ -26,12 +24,7 @@ class TestTextLoader:
         assert artifacts[0].embedding == [0, 1]
 
     def test_load_with_path(self, loader):
-        path = Path(
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "../../resources/test.txt",
-            )
-        )
+        path = Path(os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test.txt"))
 
         artifacts = loader.load(path)
 
@@ -43,25 +36,13 @@ class TestTextLoader:
     def test_load_collection_with_strings(self, loader):
         artifacts = loader.load_collection(["bar", "bat"])
 
-        assert list(artifacts.keys()) == [
-            utils.str_to_hash("bar"),
-            utils.str_to_hash("bat"),
-        ]
-        assert [
-            a.value
-            for artifact_list in artifacts.values()
-            for a in artifact_list
-        ] == ["bar", "bat"]
+        assert list(artifacts.keys()) == [utils.str_to_hash("bar"), utils.str_to_hash("bat")]
+        assert [a.value for artifact_list in artifacts.values() for a in artifact_list] == ["bar", "bat"]
 
         assert list(artifacts.values())[0][0].embedding == [0, 1]
 
     def test_load_collection_with_path(self, loader):
-        path = Path(
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "../../resources/test.txt",
-            )
-        )
+        path = Path(os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/test.txt"))
         artifacts = loader.load_collection([path])
 
         key = utils.str_to_hash(str(path))

--- a/tests/unit/loaders/test_web_loader.py
+++ b/tests/unit/loaders/test_web_loader.py
@@ -15,15 +15,11 @@ class TestWebLoader:
         fake_extract = {"text": "foobar"}
 
         mocker.patch("trafilatura.fetch_url", return_value=fake_response)
-        mocker.patch(
-            "trafilatura.extract", return_value=json.dumps(fake_extract)
-        )
+        mocker.patch("trafilatura.extract", return_value=json.dumps(fake_extract))
 
     @pytest.fixture
     def loader(self):
-        return WebLoader(
-            max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver()
-        )
+        return WebLoader(max_tokens=MAX_TOKENS, embedding_driver=MockEmbeddingDriver())
 
     def test_load(self, loader):
         artifacts = loader.load("https://github.com/griptape-ai/griptape")
@@ -35,23 +31,13 @@ class TestWebLoader:
 
     def test_load_collection(self, loader):
         artifacts = loader.load_collection(
-            [
-                "https://github.com/griptape-ai/griptape",
-                "https://github.com/griptape-ai/griptape-docs",
-            ]
+            ["https://github.com/griptape-ai/griptape", "https://github.com/griptape-ai/griptape-docs"]
         )
 
         assert list(artifacts.keys()) == [
             utils.str_to_hash("https://github.com/griptape-ai/griptape"),
             utils.str_to_hash("https://github.com/griptape-ai/griptape-docs"),
         ]
-        assert (
-            "foobar"
-            in [
-                a.value
-                for artifact_list in artifacts.values()
-                for a in artifact_list
-            ][0].lower()
-        )
+        assert "foobar" in [a.value for artifact_list in artifacts.values() for a in artifact_list][0].lower()
 
         assert list(artifacts.values())[0][0].embedding == [0, 1]

--- a/tests/unit/memory/structure/test_summary_conversation_memory.py
+++ b/tests/unit/memory/structure/test_summary_conversation_memory.py
@@ -9,9 +9,7 @@ from griptape.structures import Pipeline
 
 class TestSummaryConversationMemory:
     def test_unsummarized_subtasks(self):
-        memory = SummaryConversationMemory(
-            offset=1, prompt_driver=MockPromptDriver()
-        )
+        memory = SummaryConversationMemory(offset=1, prompt_driver=MockPromptDriver())
 
         pipeline = Pipeline(memory=memory, prompt_driver=MockPromptDriver())
 
@@ -25,9 +23,7 @@ class TestSummaryConversationMemory:
         assert len(memory.unsummarized_runs()) == 1
 
     def test_after_run(self):
-        memory = SummaryConversationMemory(
-            offset=1, prompt_driver=MockPromptDriver()
-        )
+        memory = SummaryConversationMemory(offset=1, prompt_driver=MockPromptDriver())
 
         pipeline = Pipeline(memory=memory, prompt_driver=MockPromptDriver())
 
@@ -45,9 +41,7 @@ class TestSummaryConversationMemory:
         memory = SummaryConversationMemory()
         memory.add_run(Run(input="foo", output="bar"))
 
-        assert (
-            json.loads(memory.to_json())["type"] == "SummaryConversationMemory"
-        )
+        assert json.loads(memory.to_json())["type"] == "SummaryConversationMemory"
         assert json.loads(memory.to_json())["runs"][0]["input"] == "foo"
 
     def test_to_dict(self):
@@ -63,10 +57,7 @@ class TestSummaryConversationMemory:
 
         prompt_stack = memory.to_prompt_stack()
 
-        assert (
-            prompt_stack.inputs[0].content
-            == "Summary of the conversation so far: foobar"
-        )
+        assert prompt_stack.inputs[0].content == "Summary of the conversation so far: foobar"
         assert prompt_stack.inputs[1].content == "foo"
         assert prompt_stack.inputs[2].content == "bar"
 
@@ -75,9 +66,7 @@ class TestSummaryConversationMemory:
         memory.add_run(Run(input="foo", output="bar"))
         memory_dict = memory.to_dict()
 
-        assert isinstance(
-            memory.from_dict(memory_dict), SummaryConversationMemory
-        )
+        assert isinstance(memory.from_dict(memory_dict), SummaryConversationMemory)
         assert memory.from_dict(memory_dict).runs[0].input == "foo"
 
     def test_from_json(self):
@@ -85,7 +74,5 @@ class TestSummaryConversationMemory:
         memory.add_run(Run(input="foo", output="bar"))
         memory_dict = memory.to_dict()
 
-        assert isinstance(
-            memory.from_dict(memory_dict), SummaryConversationMemory
-        )
+        assert isinstance(memory.from_dict(memory_dict), SummaryConversationMemory)
         assert memory.from_dict(memory_dict).runs[0].input == "foo"

--- a/tests/unit/memory/tool/test_tool_memory.py
+++ b/tests/unit/memory/tool/test_tool_memory.py
@@ -1,16 +1,8 @@
 import pytest
-from griptape.artifacts import (
-    CsvRowArtifact,
-    BlobArtifact,
-    ErrorArtifact,
-    InfoArtifact,
-)
+from griptape.artifacts import CsvRowArtifact, BlobArtifact, ErrorArtifact, InfoArtifact
 from griptape.artifacts import TextArtifact, ListArtifact
 from griptape.memory import ToolMemory
-from griptape.memory.tool.storage import (
-    BlobArtifactStorage,
-    TextArtifactStorage,
-)
+from griptape.memory.tool.storage import BlobArtifactStorage, TextArtifactStorage
 from griptape.tasks import ActionSubtask
 from tests.mocks.mock_tool.tool import MockTool
 from tests.utils import defaults
@@ -19,10 +11,7 @@ from tests.utils import defaults
 class TestToolMemory:
     @pytest.fixture(autouse=True)
     def mock_griptape(self, mocker):
-        mocker.patch(
-            "griptape.engines.CsvExtractionEngine.extract",
-            return_value=[CsvRowArtifact({"foo": "bar"})],
-        )
+        mocker.patch("griptape.engines.CsvExtractionEngine.extract", return_value=[CsvRowArtifact({"foo": "bar"})])
 
     @pytest.fixture
     def memory(self):
@@ -33,38 +22,20 @@ class TestToolMemory:
 
     def test_validate_artifact_storages(self):
         with pytest.raises(ValueError):
-            ToolMemory(
-                artifact_storages={
-                    TextArtifact: BlobArtifactStorage(),
-                    BlobArtifact: BlobArtifactStorage(),
-                }
-            )
+            ToolMemory(artifact_storages={TextArtifact: BlobArtifactStorage(), BlobArtifact: BlobArtifactStorage()})
 
     def test_get_memory_driver_for(self, memory):
-        assert isinstance(
-            memory.get_storage_for(TextArtifact("foo")), TextArtifactStorage
-        )
-        assert isinstance(
-            memory.get_storage_for(BlobArtifact(b"foo")), BlobArtifactStorage
-        )
+        assert isinstance(memory.get_storage_for(TextArtifact("foo")), TextArtifactStorage)
+        assert isinstance(memory.get_storage_for(BlobArtifact(b"foo")), BlobArtifactStorage)
 
     def test_store_artifact(self, memory):
         assert memory.store_artifact("test", TextArtifact("foo1")) is None
         assert memory.store_artifact("test", TextArtifact("foo2")) is None
-        assert isinstance(
-            memory.store_artifact("test", BlobArtifact(b"foo3")), ErrorArtifact
-        )
+        assert isinstance(memory.store_artifact("test", BlobArtifact(b"foo3")), ErrorArtifact)
         assert memory.store_artifact("btest", BlobArtifact(b"foo4")) is None
-        assert isinstance(
-            memory.store_artifact("btest", TextArtifact("foo5")), ErrorArtifact
-        )
-        assert isinstance(
-            memory.store_artifact("test", InfoArtifact("foo1")), InfoArtifact
-        )
-        assert (
-            memory.store_artifact("test", ListArtifact([TextArtifact("foo1")]))
-            is None
-        )
+        assert isinstance(memory.store_artifact("btest", TextArtifact("foo5")), ErrorArtifact)
+        assert isinstance(memory.store_artifact("test", InfoArtifact("foo1")), InfoArtifact)
+        assert memory.store_artifact("test", ListArtifact([TextArtifact("foo1")])) is None
 
     def test_find_input_memory(self, memory):
         assert memory.find_input_memory(memory.name) == memory
@@ -78,32 +49,22 @@ class TestToolMemory:
             .to_text()
             .startswith('Output of "MockTool.test" was stored in memory')
         )
-        assert (
-            memory.namespace_metadata[artifact.id] == subtask.action_to_json()
-        )
+        assert memory.namespace_metadata[artifact.id] == subtask.action_to_json()
 
     def test_process_output_with_many_artifacts(self, memory):
         assert (
-            memory.process_output(
-                MockTool().test,
-                ActionSubtask(),
-                ListArtifact([TextArtifact("foo")]),
-            )
+            memory.process_output(MockTool().test, ActionSubtask(), ListArtifact([TextArtifact("foo")]))
             .to_text()
             .startswith('Output of "MockTool.test" was stored in memory')
         )
 
     def test_load_artifacts_for_text_artifact(self, memory):
-        memory.process_output(
-            MockTool().test, ActionSubtask(), TextArtifact("foo", name="test")
-        )
+        memory.process_output(MockTool().test, ActionSubtask(), TextArtifact("foo", name="test"))
 
         assert len(memory.load_artifacts("test")) == 1
 
     def test_load_artifacts_for_blob_artifact(self, memory):
-        memory.process_output(
-            MockTool().test, ActionSubtask(), BlobArtifact(b"foo", name="test")
-        )
+        memory.process_output(MockTool().test, ActionSubtask(), BlobArtifact(b"foo", name="test"))
 
         assert len(memory.load_artifacts("test")) == 1
 
@@ -111,13 +72,7 @@ class TestToolMemory:
         memory.process_output(
             MockTool().test,
             ActionSubtask(),
-            ListArtifact(
-                [
-                    TextArtifact("foo", name="test1"),
-                    TextArtifact("foo", name="test2"),
-                ],
-                name="test",
-            ),
+            ListArtifact([TextArtifact("foo", name="test1"), TextArtifact("foo", name="test2")], name="test"),
         )
 
         assert len(memory.load_artifacts("test")) == 2
@@ -126,13 +81,7 @@ class TestToolMemory:
         memory.process_output(
             MockTool().test,
             ActionSubtask(),
-            ListArtifact(
-                [
-                    BlobArtifact(b"foo", name="test1"),
-                    BlobArtifact(b"foo", name="test2"),
-                ],
-                name="test",
-            ),
+            ListArtifact([BlobArtifact(b"foo", name="test1"), BlobArtifact(b"foo", name="test2")], name="test"),
         )
 
         assert len(memory.load_artifacts("test")) == 2

--- a/tests/unit/mixins/test_activity_mixin.py
+++ b/tests/unit/mixins/test_activity_mixin.py
@@ -19,9 +19,7 @@ class TestActivityMixin:
     def test_activity_schema(self, tool):
         schema = tool.activity_schema(tool.test)
 
-        assert schema == Schema(
-            {"values": tool.test.config["schema"].schema}
-        ).json_schema("InputSchema")
+        assert schema == Schema({"values": tool.test.config["schema"].schema}).json_schema("InputSchema")
         assert schema["properties"].get("artifact") is None
 
     def test_activity_with_no_schema(self, tool):

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -15,10 +15,7 @@ from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 class TestAgent:
     def test_init(self):
         driver = MockPromptDriver()
-        agent = Agent(
-            prompt_driver=driver,
-            rulesets=[Ruleset("TestRuleset", [Rule("test")])],
-        )
+        agent = Agent(prompt_driver=driver, rulesets=[Ruleset("TestRuleset", [Rule("test")])])
 
         assert agent.prompt_driver is driver
         assert isinstance(agent.task, PromptTask)
@@ -31,9 +28,7 @@ class TestAgent:
     def test_rulesets(self):
         agent = Agent(rulesets=[Ruleset("Foo", [Rule("foo test")])])
 
-        agent.add_task(
-            PromptTask(rulesets=[Ruleset("Bar", [Rule("bar test")])])
-        )
+        agent.add_task(PromptTask(rulesets=[Ruleset("Bar", [Rule("bar test")])]))
 
         assert isinstance(agent.task, PromptTask)
         assert len(agent.task.all_rulesets) == 2
@@ -52,19 +47,11 @@ class TestAgent:
 
     def test_rules_and_rulesets(self):
         with pytest.raises(ValueError):
-            Agent(
-                rules=[Rule("foo test")],
-                rulesets=[Ruleset("Bar", [Rule("bar test")])],
-            )
+            Agent(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
 
         with pytest.raises(ValueError):
             agent = Agent()
-            agent.add_task(
-                PromptTask(
-                    rules=[Rule("foo test")],
-                    rulesets=[Ruleset("Bar", [Rule("bar test")])],
-                )
-            )
+            agent.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
 
     def test_with_default_tool_memory(self):
         agent = Agent(tools=[MockTool()])
@@ -88,9 +75,7 @@ class TestAgent:
 
         artifact_storage = list(agent.tool_memory.artifact_storages.values())[0]
         assert isinstance(artifact_storage, TextArtifactStorage)
-        memory_embedding_driver = (
-            artifact_storage.query_engine.vector_store_driver.embedding_driver
-        )
+        memory_embedding_driver = artifact_storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
 
@@ -101,9 +86,7 @@ class TestAgent:
         assert agent.tools[0].output_memory is None
 
     def test_with_memory(self):
-        agent = Agent(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         assert agent.memory is not None
         assert len(agent.memory.runs) == 0
@@ -185,9 +168,7 @@ class TestAgent:
         assert len(task1.prompt_stack.inputs) == 3
 
     def test_prompt_stack_with_memory(self):
-        agent = Agent(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         task1 = PromptTask("test")
 
@@ -243,18 +224,13 @@ class TestAgent:
     def test_tool_memory_defaults(self):
         prompt_driver = MockPromptDriver()
         embedding_driver = MockEmbeddingDriver()
-        agent = Agent(
-            prompt_driver=prompt_driver, embedding_driver=embedding_driver
-        )
+        agent = Agent(prompt_driver=prompt_driver, embedding_driver=embedding_driver)
 
         storage = list(agent.tool_memory.artifact_storages.values())[0]
         assert isinstance(storage, TextArtifactStorage)
 
         assert storage.query_engine.prompt_driver == prompt_driver
-        assert (
-            storage.query_engine.vector_store_driver.embedding_driver
-            == embedding_driver
-        )
+        assert storage.query_engine.vector_store_driver.embedding_driver == embedding_driver
         assert isinstance(storage.summary_engine, PromptSummaryEngine)
         assert storage.summary_engine.prompt_driver == prompt_driver
         assert storage.csv_extraction_engine.prompt_driver == prompt_driver

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -15,10 +15,7 @@ from tests.unit.structures.test_agent import MockEmbeddingDriver
 class TestPipeline:
     def test_init(self):
         driver = MockPromptDriver()
-        pipeline = Pipeline(
-            prompt_driver=driver,
-            rulesets=[Ruleset("TestRuleset", [Rule("test")])],
-        )
+        pipeline = Pipeline(prompt_driver=driver, rulesets=[Ruleset("TestRuleset", [Rule("test")])])
 
         assert pipeline.prompt_driver is driver
         assert pipeline.input_task is None
@@ -48,10 +45,7 @@ class TestPipeline:
     def test_rules(self):
         pipeline = Pipeline(rules=[Rule("foo test")])
 
-        pipeline.add_tasks(
-            PromptTask(rules=[Rule("bar test")]),
-            PromptTask(rules=[Rule("baz test")]),
-        )
+        pipeline.add_tasks(PromptTask(rules=[Rule("bar test")]), PromptTask(rules=[Rule("baz test")]))
 
         assert isinstance(pipeline.tasks[0], PromptTask)
         assert len(pipeline.tasks[0].all_rulesets) == 2
@@ -64,19 +58,11 @@ class TestPipeline:
 
     def test_rules_and_rulesets(self):
         with pytest.raises(ValueError):
-            Pipeline(
-                rules=[Rule("foo test")],
-                rulesets=[Ruleset("Bar", [Rule("bar test")])],
-            )
+            Pipeline(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
 
         with pytest.raises(ValueError):
             pipeline = Pipeline()
-            pipeline.add_task(
-                PromptTask(
-                    rules=[Rule("foo test")],
-                    rulesets=[Ruleset("Bar", [Rule("bar test")])],
-                )
-            )
+            pipeline.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
 
     def test_with_default_tool_memory(self):
         pipeline = Pipeline()
@@ -86,14 +72,9 @@ class TestPipeline:
         assert isinstance(pipeline.tasks[0], ToolkitTask)
         assert pipeline.tasks[0].tool_memory == pipeline.tool_memory
         assert pipeline.tasks[0].tools[0].input_memory is not None
-        assert (
-            pipeline.tasks[0].tools[0].input_memory[0] == pipeline.tool_memory
-        )
+        assert pipeline.tasks[0].tools[0].input_memory[0] == pipeline.tool_memory
         assert pipeline.tasks[0].tools[0].output_memory is not None
-        assert (
-            pipeline.tasks[0].tools[0].output_memory["test"][0]
-            == pipeline.tool_memory
-        )
+        assert pipeline.tasks[0].tools[0].output_memory["test"][0] == pipeline.tool_memory
 
     def test_embedding_driver(self):
         embedding_driver = MockEmbeddingDriver()
@@ -103,9 +84,7 @@ class TestPipeline:
 
         storage = list(pipeline.tool_memory.artifact_storages.values())[0]
         assert isinstance(storage, TextArtifactStorage)
-        memory_embedding_driver = (
-            storage.query_engine.vector_store_driver.embedding_driver
-        )
+        memory_embedding_driver = storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
 
@@ -131,9 +110,7 @@ class TestPipeline:
         second_task = PromptTask("test2")
         third_task = PromptTask("test3")
 
-        pipeline = Pipeline(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        pipeline = Pipeline(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         pipeline + [first_task, second_task, third_task]
 
@@ -286,9 +263,7 @@ class TestPipeline:
         assert len(task2.prompt_stack.inputs) == 3
 
     def test_prompt_stack_with_memory(self):
-        pipeline = Pipeline(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        pipeline = Pipeline(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         task1 = PromptTask("test")
         task2 = PromptTask("test")
@@ -312,14 +287,8 @@ class TestPipeline:
         text = "foobar"
 
         assert TextArtifact(text).token_count(
-            OpenAiTokenizer(
-                model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-            )
-        ) == OpenAiTokenizer(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        ).count_tokens(
-            text
-        )
+            OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+        ) == OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL).count_tokens(text)
 
     def test_run(self):
         task = PromptTask("test")

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -12,10 +12,7 @@ from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 class TestWorkflow:
     def test_init(self):
         driver = MockPromptDriver()
-        workflow = Workflow(
-            prompt_driver=driver,
-            rulesets=[Ruleset("TestRuleset", [Rule("test")])],
-        )
+        workflow = Workflow(prompt_driver=driver, rulesets=[Ruleset("TestRuleset", [Rule("test")])])
 
         assert workflow.prompt_driver is driver
         assert len(workflow.tasks) == 0
@@ -43,10 +40,7 @@ class TestWorkflow:
     def test_rules(self):
         workflow = Workflow(rules=[Rule("foo test")])
 
-        workflow.add_tasks(
-            PromptTask(rules=[Rule("bar test")]),
-            PromptTask(rules=[Rule("baz test")]),
-        )
+        workflow.add_tasks(PromptTask(rules=[Rule("bar test")]), PromptTask(rules=[Rule("baz test")]))
 
         assert isinstance(workflow.tasks[0], PromptTask)
         assert len(workflow.tasks[0].all_rulesets) == 2
@@ -60,19 +54,11 @@ class TestWorkflow:
 
     def test_rules_and_rulesets(self):
         with pytest.raises(ValueError):
-            Workflow(
-                rules=[Rule("foo test")],
-                rulesets=[Ruleset("Bar", [Rule("bar test")])],
-            )
+            Workflow(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
 
         with pytest.raises(ValueError):
             workflow = Workflow()
-            workflow.add_task(
-                PromptTask(
-                    rules=[Rule("foo test")],
-                    rulesets=[Ruleset("Bar", [Rule("bar test")])],
-                )
-            )
+            workflow.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
 
     def test_with_default_tool_memory(self):
         workflow = Workflow()
@@ -81,14 +67,9 @@ class TestWorkflow:
 
         assert isinstance(workflow.tasks[0], ToolkitTask)
         assert workflow.tasks[0].tools[0].input_memory is not None
-        assert (
-            workflow.tasks[0].tools[0].input_memory[0] == workflow.tool_memory
-        )
+        assert workflow.tasks[0].tools[0].input_memory[0] == workflow.tool_memory
         assert workflow.tasks[0].tools[0].output_memory is not None
-        assert (
-            workflow.tasks[0].tools[0].output_memory["test"][0]
-            == workflow.tool_memory
-        )
+        assert workflow.tasks[0].tools[0].output_memory["test"][0] == workflow.tool_memory
 
     def test_embedding_driver(self):
         embedding_driver = MockEmbeddingDriver()
@@ -98,9 +79,7 @@ class TestWorkflow:
 
         storage = list(workflow.tool_memory.artifact_storages.values())[0]
         assert isinstance(storage, TextArtifactStorage)
-        memory_embedding_driver = (
-            storage.query_engine.vector_store_driver.embedding_driver
-        )
+        memory_embedding_driver = storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
 

--- a/tests/unit/tasks/test_base_text_input_task.py
+++ b/tests/unit/tasks/test_base_text_input_task.py
@@ -28,10 +28,7 @@ class TestBaseTextInputTask:
 
     def test_rulesets(self):
         prompt_task = MockTextInputTask(
-            rulesets=[
-                Ruleset("Foo", [Rule("foo test")]),
-                Ruleset("Bar", [Rule("bar test")]),
-            ]
+            rulesets=[Ruleset("Foo", [Rule("foo test")]), Ruleset("Bar", [Rule("bar test")])]
         )
 
         assert len(prompt_task.all_rulesets) == 2
@@ -39,8 +36,6 @@ class TestBaseTextInputTask:
         assert prompt_task.all_rulesets[1].name == "Bar"
 
     def test_rules(self):
-        prompt_task = MockTextInputTask(
-            rules=[Rule("foo test"), Rule("bar test")]
-        )
+        prompt_task = MockTextInputTask(rules=[Rule("foo test"), Rule("bar test")])
 
         assert prompt_task.all_rulesets[0].name == "Default Ruleset"

--- a/tests/unit/tasks/test_extraction_task.py
+++ b/tests/unit/tasks/test_extraction_task.py
@@ -9,10 +9,7 @@ class TestTextQueryTask:
     @pytest.fixture
     def task(self):
         return ExtractionTask(
-            extraction_engine=CsvExtractionEngine(
-                prompt_driver=MockPromptDriver()
-            ),
-            args={"column_names": ["test1"]},
+            extraction_engine=CsvExtractionEngine(prompt_driver=MockPromptDriver()), args={"column_names": ["test1"]}
         )
 
     def test_run(self, task):

--- a/tests/unit/tasks/test_text_query_task.py
+++ b/tests/unit/tasks/test_text_query_task.py
@@ -13,9 +13,7 @@ class TestTextQueryTask:
         return TextQueryTask(
             "test",
             query_engine=VectorQueryEngine(
-                vector_store_driver=LocalVectorStoreDriver(
-                    embedding_driver=MockEmbeddingDriver()
-                ),
+                vector_store_driver=LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver()),
                 prompt_driver=MockPromptDriver(),
             ),
             namespace="test",
@@ -39,9 +37,4 @@ class TestTextQueryTask:
     def test_load(self, task):
         artifact = task.load("foobar baz")[0]
 
-        assert (
-            list(task.query_engine.vector_store_driver.entries.values())[
-                0
-            ].meta["artifact"]
-            == artifact.to_json()
-        )
+        assert list(task.query_engine.vector_store_driver.entries.values())[0].meta["artifact"] == artifact.to_json()

--- a/tests/unit/tasks/test_text_summary_task.py
+++ b/tests/unit/tasks/test_text_summary_task.py
@@ -6,12 +6,7 @@ from griptape.structures import Agent
 
 class TestTextSummaryTask:
     def test_run(self):
-        task = TextSummaryTask(
-            "test",
-            summary_engine=PromptSummaryEngine(
-                prompt_driver=MockPromptDriver()
-            ),
-        )
+        task = TextSummaryTask("test", summary_engine=PromptSummaryEngine(prompt_driver=MockPromptDriver()))
         agent = Agent()
 
         agent.add_task(task)

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -9,14 +9,8 @@ from tests.mocks.mock_tool.tool import MockTool
 class TestToolTask:
     @pytest.fixture
     def agent(self):
-        output_dict = {
-            "name": "MockTool",
-            "path": "test",
-            "input": {"values": {"test": "foobar"}},
-        }
-        return Agent(
-            prompt_driver=MockPromptDriver(mock_output=json.dumps(output_dict))
-        )
+        output_dict = {"name": "MockTool", "path": "test", "input": {"values": {"test": "foobar"}}}
+        return Agent(prompt_driver=MockPromptDriver(mock_output=json.dumps(output_dict)))
 
     def test_run(self, agent):
         task = ToolTask(tool=MockTool())

--- a/tests/unit/tasks/test_toolkit_task.py
+++ b/tests/unit/tasks/test_toolkit_task.py
@@ -16,21 +16,11 @@ class TestToolkitSubtask:
     def query_engine(self):
         return VectorQueryEngine(
             prompt_driver=MockPromptDriver(),
-            vector_store_driver=LocalVectorStoreDriver(
-                embedding_driver=MockEmbeddingDriver()
-            ),
+            vector_store_driver=LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver()),
         )
 
     def test_init(self):
-        assert (
-            len(
-                ToolkitTask(
-                    "test",
-                    tools=[MockTool(name="Tool1"), MockTool(name="Tool2")],
-                ).tools
-            )
-            == 2
-        )
+        assert len(ToolkitTask("test", tools=[MockTool(name="Tool1"), MockTool(name="Tool2")]).tools) == 2
 
         try:
             ToolkitTask("test", tools=[MockTool(), MockTool()])
@@ -41,9 +31,7 @@ class TestToolkitSubtask:
     def test_run(self):
         output = """Answer: done"""
 
-        task = ToolkitTask(
-            "test", tools=[MockTool(name="Tool1"), MockTool(name="Tool2")]
-        )
+        task = ToolkitTask("test", tools=[MockTool(name="Tool1"), MockTool(name="Tool2")])
         agent = Agent(prompt_driver=MockValuePromptDriver(output))
 
         agent.add_task(task)
@@ -57,9 +45,7 @@ class TestToolkitSubtask:
     def test_run_max_subtasks(self):
         output = """Action: {"name": "blah"}"""
 
-        task = ToolkitTask(
-            "test", tools=[MockTool(name="Tool1")], max_subtasks=3
-        )
+        task = ToolkitTask("test", tools=[MockTool(name="Tool1")], max_subtasks=3)
         agent = Agent(prompt_driver=MockValuePromptDriver(output))
 
         agent.add_task(task)
@@ -105,18 +91,8 @@ class TestToolkitSubtask:
 
     def test_add_subtask(self):
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
-        subtask1 = ActionSubtask(
-            "test1",
-            action_name="test",
-            action_path="test",
-            action_input={"values": {"f": "b"}},
-        )
-        subtask2 = ActionSubtask(
-            "test2",
-            action_name="test",
-            action_path="test",
-            action_input={"values": {"f": "b"}},
-        )
+        subtask1 = ActionSubtask("test1", action_name="test", action_path="test", action_input={"values": {"f": "b"}})
+        subtask2 = ActionSubtask("test2", action_name="test", action_path="test", action_input={"values": {"f": "b"}})
 
         Agent().add_task(task)
 
@@ -135,18 +111,8 @@ class TestToolkitSubtask:
 
     def test_find_subtask(self):
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
-        subtask1 = ActionSubtask(
-            "test1",
-            action_name="test",
-            action_path="test",
-            action_input={"values": {"f": "b"}},
-        )
-        subtask2 = ActionSubtask(
-            "test2",
-            action_name="test",
-            action_path="test",
-            action_input={"values": {"f": "b"}},
-        )
+        subtask1 = ActionSubtask("test1", action_name="test", action_path="test", action_input={"values": {"f": "b"}})
+        subtask2 = ActionSubtask("test2", action_name="test", action_path="test", action_input={"values": {"f": "b"}})
 
         Agent().add_task(task)
 
@@ -179,22 +145,12 @@ class TestToolkitSubtask:
     def test_memory(self, query_engine):
         tool1 = MockTool(
             name="Tool1",
-            output_memory={
-                "test": [
-                    defaults.text_tool_memory("Memory1"),
-                    defaults.text_tool_memory("Memory2"),
-                ]
-            },
+            output_memory={"test": [defaults.text_tool_memory("Memory1"), defaults.text_tool_memory("Memory2")]},
         )
 
         tool2 = MockTool(
             name="Tool2",
-            output_memory={
-                "test": [
-                    defaults.text_tool_memory("Memory1"),
-                    defaults.text_tool_memory("Memory3"),
-                ]
-            },
+            output_memory={"test": [defaults.text_tool_memory("Memory1"), defaults.text_tool_memory("Memory3")]},
         )
 
         task = ToolkitTask(tools=[tool1, tool2])

--- a/tests/unit/tokenizers/test_bedrock_claude_tokenizer.py
+++ b/tests/unit/tokenizers/test_bedrock_claude_tokenizer.py
@@ -5,9 +5,7 @@ from griptape.tokenizers import BedrockClaudeTokenizer
 class TestBedrockClaudeTokenizer:
     @pytest.fixture
     def tokenizer(self):
-        return BedrockClaudeTokenizer(
-            model=BedrockClaudeTokenizer.DEFAULT_MODEL
-        )
+        return BedrockClaudeTokenizer(model=BedrockClaudeTokenizer.DEFAULT_MODEL)
 
     def test_token_count(self, tokenizer):
         assert tokenizer.count_tokens("foo bar huzzah") == 5

--- a/tests/unit/tokenizers/test_bedrock_jurassic_tokenizer.py
+++ b/tests/unit/tokenizers/test_bedrock_jurassic_tokenizer.py
@@ -20,8 +20,5 @@ class TestBedrockJurassicTokenizer:
 
     def test_titan_tokens_left(self):
         assert (
-            BedrockJurassicTokenizer(
-                model=BedrockJurassicTokenizer.DEFAULT_MODEL
-            ).count_tokens_left("foo bar")
-            == 8189
+            BedrockJurassicTokenizer(model=BedrockJurassicTokenizer.DEFAULT_MODEL).count_tokens_left("foo bar") == 8189
         )

--- a/tests/unit/tokenizers/test_bedrock_titan_tokenizer.py
+++ b/tests/unit/tokenizers/test_bedrock_titan_tokenizer.py
@@ -19,9 +19,4 @@ class TestBedrockTitanTokenizer:
         mock_session_class.return_value = mock_session_object
 
     def test_titan_tokens_left(self):
-        assert (
-            BedrockTitanTokenizer(
-                model=BedrockTitanTokenizer.DEFAULT_MODEL
-            ).count_tokens_left("foo bar")
-            == 4083
-        )
+        assert BedrockTitanTokenizer(model=BedrockTitanTokenizer.DEFAULT_MODEL).count_tokens_left("foo bar") == 4083

--- a/tests/unit/tokenizers/test_cohere_tokenizer.py
+++ b/tests/unit/tokenizers/test_cohere_tokenizer.py
@@ -6,9 +6,7 @@ from griptape.tokenizers import CohereTokenizer
 class TestCohereTokenizer:
     @pytest.fixture
     def tokenizer(self):
-        return CohereTokenizer(
-            model=CohereTokenizer.DEFAULT_MODEL, client=cohere.Client("foobar")
-        )
+        return CohereTokenizer(model=CohereTokenizer.DEFAULT_MODEL, client=cohere.Client("foobar"))
 
     def test_init(self, tokenizer):
         assert tokenizer

--- a/tests/unit/tokenizers/test_hugging_face_tokenizer.py
+++ b/tests/unit/tokenizers/test_hugging_face_tokenizer.py
@@ -10,9 +10,7 @@ from griptape.tokenizers import HuggingFaceTokenizer
 class TestHuggingFaceTokenizer:
     @pytest.fixture
     def tokenizer(self):
-        return HuggingFaceTokenizer(
-            tokenizer=GPT2Tokenizer.from_pretrained("gpt2")
-        )
+        return HuggingFaceTokenizer(tokenizer=GPT2Tokenizer.from_pretrained("gpt2"))
 
     def test_token_count(self, tokenizer):
         assert tokenizer.count_tokens("foo bar huzzah") == 5

--- a/tests/unit/tokenizers/test_openai_tokenizer.py
+++ b/tests/unit/tokenizers/test_openai_tokenizer.py
@@ -5,9 +5,7 @@ from griptape.tokenizers import OpenAiTokenizer
 class TestOpenAiTokenizer:
     @pytest.fixture
     def tokenizer(self):
-        return OpenAiTokenizer(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL
-        )
+        return OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
     @pytest.fixture
     def tokenizer_32k(self):
@@ -19,10 +17,7 @@ class TestOpenAiTokenizer:
     def test_token_count_for_messages(self, tokenizer):
         assert (
             tokenizer.count_tokens(
-                [
-                    {"role": "system", "content": "foobar baz"},
-                    {"role": "user", "content": "how foobar am I?"},
-                ],
+                [{"role": "system", "content": "foobar baz"}, {"role": "user", "content": "how foobar am I?"}],
                 model="gpt-4",
             )
             == 19
@@ -30,10 +25,7 @@ class TestOpenAiTokenizer:
 
         assert (
             tokenizer.count_tokens(
-                [
-                    {"role": "system", "content": "foobar baz"},
-                    {"role": "user", "content": "how foobar am I?"},
-                ],
+                [{"role": "system", "content": "foobar baz"}, {"role": "user", "content": "how foobar am I?"}],
                 model="gpt-3.5-turbo-0301",
             )
             == 21
@@ -41,10 +33,7 @@ class TestOpenAiTokenizer:
 
         assert (
             tokenizer.count_tokens(
-                [
-                    {"role": "system", "content": "foobar baz"},
-                    {"role": "user", "content": "how foobar am I?"},
-                ],
+                [{"role": "system", "content": "foobar baz"}, {"role": "user", "content": "how foobar am I?"}],
                 model="gpt-35-turbo",
             )
             == 19

--- a/tests/unit/tools/test_aws_iam.py
+++ b/tests/unit/tools/test_aws_iam.py
@@ -13,28 +13,18 @@ class TestAwsIamClient:
         value = {"user_name": "test_user", "policy_name": "test_policy"}
         assert (
             "error returning policy document"
-            in AwsIamClient(session=boto3.Session())
-            .get_user_policy({"values": value})
-            .value
+            in AwsIamClient(session=boto3.Session()).get_user_policy({"values": value}).value
         )
 
     def test_list_mfa_devices(self):
-        assert (
-            "error listing mfa devices"
-            in AwsIamClient(session=boto3.Session()).list_mfa_devices({}).value
-        )
+        assert "error listing mfa devices" in AwsIamClient(session=boto3.Session()).list_mfa_devices({}).value
 
     def test_list_user_policies(self):
         value = {"user_name": "test_user"}
         assert (
             "error listing iam user policies"
-            in AwsIamClient(session=boto3.Session())
-            .list_user_policies({"values": value})
-            .value
+            in AwsIamClient(session=boto3.Session()).list_user_policies({"values": value}).value
         )
 
     def test_list_users(self):
-        assert (
-            "error listing s3 users"
-            in AwsIamClient(session=boto3.Session()).list_users({}).value
-        )
+        assert "error listing s3 users" in AwsIamClient(session=boto3.Session()).list_users({}).value

--- a/tests/unit/tools/test_aws_s3.py
+++ b/tests/unit/tools/test_aws_s3.py
@@ -12,43 +12,30 @@ class TestAwsS3Client:
     def test_get_bucket_acl(self):
         value = {"bucket_name": "bucket_test"}
         assert (
-            "error getting bucket acl"
-            in AwsS3Client(session=boto3.Session())
-            .get_bucket_acl({"values": value})
-            .value
+            "error getting bucket acl" in AwsS3Client(session=boto3.Session()).get_bucket_acl({"values": value}).value
         )
 
     def test_get_bucket_policy(self):
         value = {"bucket_name": "bucket_test"}
         assert (
             "error getting bucket policy"
-            in AwsS3Client(session=boto3.Session())
-            .get_bucket_policy({"values": value})
-            .value
+            in AwsS3Client(session=boto3.Session()).get_bucket_policy({"values": value}).value
         )
 
     def test_get_object_acl(self):
         value = {"bucket_name": "bucket_test", "object_key": "key_test"}
         assert (
-            "error getting object acl"
-            in AwsS3Client(session=boto3.Session())
-            .get_object_acl({"values": value})
-            .value
+            "error getting object acl" in AwsS3Client(session=boto3.Session()).get_object_acl({"values": value}).value
         )
 
     def test_list_s3_buckets(self):
-        assert (
-            "error listing s3 buckets"
-            in AwsS3Client(session=boto3.Session()).list_s3_buckets({}).value
-        )
+        assert "error listing s3 buckets" in AwsS3Client(session=boto3.Session()).list_s3_buckets({}).value
 
     def test_list_objects(self):
         value = {"bucket_name": "bucket_test"}
         assert (
             "error listing objects in bucket"
-            in AwsS3Client(session=boto3.Session())
-            .list_objects({"values": value})
-            .value
+            in AwsS3Client(session=boto3.Session()).list_objects({"values": value}).value
         )
 
     def test_upload_memory_artifacts_to_s3(self):
@@ -60,17 +47,9 @@ class TestAwsS3Client:
         }
         assert (
             "memory not found"
-            in AwsS3Client(session=boto3.Session())
-            .upload_memory_artifacts_to_s3({"values": value})
-            .value
+            in AwsS3Client(session=boto3.Session()).upload_memory_artifacts_to_s3({"values": value}).value
         )
 
     def test_upload_content_to_s3(self):
-        value = {
-            "content": "foobar",
-            "bucket_name": "bucket_test",
-            "object_key": "test.txt",
-        }
-        assert AwsS3Client(session=boto3.Session()).upload_content_to_s3(
-            {"values": value}
-        )
+        value = {"content": "foobar", "bucket_name": "bucket_test", "object_key": "test.txt"}
+        assert AwsS3Client(session=boto3.Session()).upload_content_to_s3({"values": value})

--- a/tests/unit/tools/test_base_tool.py
+++ b/tests/unit/tools/test_base_tool.py
@@ -11,47 +11,31 @@ from tests.utils import defaults
 class TestBaseTool:
     @pytest.fixture
     def tool(self):
-        return MockTool(
-            test_field="hello", test_int=5, test_dict={"foo": "bar"}
-        )
+        return MockTool(test_field="hello", test_int=5, test_dict={"foo": "bar"})
 
     def test_off_prompt(self, tool):
         assert (
-            ToolkitTask(
-                tool_memory=defaults.text_tool_memory("TestMemory"),
-                tools=[MockTool()],
-            )
-            .tools[0]
-            .output_memory
+            ToolkitTask(tool_memory=defaults.text_tool_memory("TestMemory"), tools=[MockTool()]).tools[0].output_memory
         )
 
         assert (
-            not ToolkitTask(
-                tool_memory=defaults.text_tool_memory("TestMemory"),
-                tools=[MockTool(off_prompt=False)],
-            )
+            not ToolkitTask(tool_memory=defaults.text_tool_memory("TestMemory"), tools=[MockTool(off_prompt=False)])
             .tools[0]
             .output_memory
         )
 
     def test_manifest_path(self, tool):
-        assert tool.manifest_path == os.path.join(
-            tool.abs_dir_path, tool.MANIFEST_FILE
-        )
+        assert tool.manifest_path == os.path.join(tool.abs_dir_path, tool.MANIFEST_FILE)
 
     def test_requirements_path(self, tool):
-        assert tool.requirements_path == os.path.join(
-            tool.abs_dir_path, tool.REQUIREMENTS_FILE
-        )
+        assert tool.requirements_path == os.path.join(tool.abs_dir_path, tool.REQUIREMENTS_FILE)
 
     def test_manifest(self, tool):
         with open(tool.manifest_path, "r") as yaml_file:
             assert tool.manifest == yaml.safe_load(yaml_file)
 
     def test_abs_file_path(self, tool):
-        assert tool.abs_file_path == os.path.abspath(
-            inspect.getfile(tool.__class__)
-        )
+        assert tool.abs_file_path == os.path.abspath(inspect.getfile(tool.__class__))
 
     def test_abs_dir_path(self, tool):
         assert tool.abs_dir_path == os.path.dirname(tool.abs_file_path)
@@ -77,12 +61,7 @@ class TestBaseTool:
 
     def test_memory(self):
         tool = MockTool(
-            output_memory={
-                "test": [
-                    defaults.text_tool_memory("Memory1"),
-                    defaults.text_tool_memory("Memory2"),
-                ]
-            }
+            output_memory={"test": [defaults.text_tool_memory("Memory1"), defaults.text_tool_memory("Memory2")]}
         )
 
         assert len(tool.output_memory["test"]) == 2
@@ -90,20 +69,11 @@ class TestBaseTool:
     def test_memory_validation(self):
         with pytest.raises(ValueError):
             MockTool(
-                output_memory={
-                    "test": [
-                        defaults.text_tool_memory("Memory1"),
-                        defaults.text_tool_memory("Memory1"),
-                    ]
-                }
+                output_memory={"test": [defaults.text_tool_memory("Memory1"), defaults.text_tool_memory("Memory1")]}
             )
 
         with pytest.raises(ValueError):
-            MockTool(
-                output_memory={
-                    "output_memory": [defaults.text_tool_memory("Memory1")]
-                }
-            )
+            MockTool(output_memory={"output_memory": [defaults.text_tool_memory("Memory1")]})
 
         assert MockTool(
             output_memory={
@@ -114,15 +84,7 @@ class TestBaseTool:
 
     def test_find_input_memory(self):
         assert MockTool().find_input_memory("foo") is None
-        assert (
-            MockTool(
-                input_memory=[defaults.text_tool_memory("foo")]
-            ).find_input_memory("foo")
-            is not None
-        )
+        assert MockTool(input_memory=[defaults.text_tool_memory("foo")]).find_input_memory("foo") is not None
 
     def test_execute(self, tool):
-        assert (
-            tool.execute(tool.test_list_output, ActionSubtask("foo")).to_text()
-            == "foo\n\nbar"
-        )
+        assert tool.execute(tool.test_list_output, ActionSubtask("foo")).to_text() == "foo\n\nbar"

--- a/tests/unit/tools/test_calculator.py
+++ b/tests/unit/tools/test_calculator.py
@@ -3,7 +3,4 @@ from griptape.tools import Calculator
 
 class TestCalculator:
     def test_calculate(self):
-        assert (
-            Calculator().calculate({"values": {"expression": "5 * 5"}}).value
-            == "25"
-        )
+        assert Calculator().calculate({"values": {"expression": "5 * 5"}}).value == "25"

--- a/tests/unit/tools/test_computer.py
+++ b/tests/unit/tools/test_computer.py
@@ -6,20 +6,10 @@ from griptape.tools import Computer
 class TestComputer:
     @pytest.fixture
     def computer(self):
-        return Computer(
-            docker_client=make_fake_client(), install_dependencies_on_init=False
-        )
+        return Computer(docker_client=make_fake_client(), install_dependencies_on_init=False)
 
     def test_execute_code(self, computer):
-        assert (
-            computer.execute_code(
-                {"values": {"code": "print(1)", "filename": "foo.py"}}
-            ).value
-            == "hello world"
-        )
+        assert computer.execute_code({"values": {"code": "print(1)", "filename": "foo.py"}}).value == "hello world"
 
     def test_execute_command(self, computer):
-        assert (
-            computer.execute_command({"values": {"command": "ls"}}).value
-            == "hello world"
-        )
+        assert computer.execute_command({"values": {"command": "ls"}}).value == "hello world"

--- a/tests/unit/tools/test_date_time.py
+++ b/tests/unit/tools/test_date_time.py
@@ -5,43 +5,23 @@ from datetime import datetime
 class TestDateTime:
     def test_get_current_datetime(self):
         result = DateTime().get_current_datetime({})
-        time_delta = (
-            datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f")
-            - datetime.now()
-        )
+        time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
         assert abs(time_delta.total_seconds()) <= 1000
 
     def test_get_past_relative_datetime(self):
-        result = DateTime().get_relative_datetime(
-            {"values": {"relative_date_string": "5 min ago"}}
-        )
-        time_delta = (
-            datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f")
-            - datetime.now()
-        )
+        result = DateTime().get_relative_datetime({"values": {"relative_date_string": "5 min ago"}})
+        time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
         assert abs(time_delta.total_seconds()) <= 1000
 
-        result = DateTime().get_relative_datetime(
-            {"values": {"relative_date_string": "2 min ago, 12 seconds"}}
-        )
-        time_delta = (
-            datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f")
-            - datetime.now()
-        )
+        result = DateTime().get_relative_datetime({"values": {"relative_date_string": "2 min ago, 12 seconds"}})
+        time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
         assert abs(time_delta.total_seconds()) <= 1000
 
     def test_get_future_relative_datetime(self):
-        result = DateTime().get_relative_datetime(
-            {"values": {"relative_date_string": "in 1 min, 36 seconds"}}
-        )
-        time_delta = (
-            datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f")
-            - datetime.now()
-        )
+        result = DateTime().get_relative_datetime({"values": {"relative_date_string": "in 1 min, 36 seconds"}})
+        time_delta = datetime.strptime(result.value, "%Y-%m-%d %H:%M:%S.%f") - datetime.now()
         assert abs(time_delta.total_seconds()) <= 1000
 
     def test_get_invalid_relative_datetime(self):
-        result = DateTime().get_relative_datetime(
-            {"values": {"relative_date_string": "3 days from now"}}
-        )
+        result = DateTime().get_relative_datetime({"values": {"relative_date_string": "3 days from now"}})
         assert result.type == "ErrorArtifact"

--- a/tests/unit/tools/test_email_client.py
+++ b/tests/unit/tools/test_email_client.py
@@ -29,44 +29,22 @@ class TestEmailClient:
 
     @pytest.fixture
     def client(self):
-        return EmailClient(
-            username="fake-username", password="fake-password", smtp_port=86
-        )
+        return EmailClient(username="fake-username", password="fake-password", smtp_port=86)
 
     @pytest.fixture
     def send_params(self):
-        return {
-            "values": {
-                "to": "fake@fake.fake",
-                "subject": "fake-subject",
-                "body": "fake-body",
-            }
-        }
+        return {"values": {"to": "fake@fake.fake", "subject": "fake-subject", "body": "fake-body"}}
 
     @pytest.mark.parametrize(
         "values,query",
         [
+            ({"label": "fake-label"}, EmailLoader.EmailQuery(label="fake-label")),
+            ({"label": "fake-label", "key": "fake-key"}, EmailLoader.EmailQuery(label="fake-label", key="fake-key")),
             (
-                {"label": "fake-label"},
-                EmailLoader.EmailQuery(label="fake-label"),
+                {"label": "fake-label", "search_criteria": "fake-search-criteria"},
+                EmailLoader.EmailQuery(label="fake-label", search_criteria="fake-search-criteria"),
             ),
-            (
-                {"label": "fake-label", "key": "fake-key"},
-                EmailLoader.EmailQuery(label="fake-label", key="fake-key"),
-            ),
-            (
-                {
-                    "label": "fake-label",
-                    "search_criteria": "fake-search-criteria",
-                },
-                EmailLoader.EmailQuery(
-                    label="fake-label", search_criteria="fake-search-criteria"
-                ),
-            ),
-            (
-                {"label": "fake-label", "max_count": "32"},
-                EmailLoader.EmailQuery(label="fake-label", max_count=32),
-            ),
+            ({"label": "fake-label", "max_count": "32"}, EmailLoader.EmailQuery(label="fake-label", max_count=32)),
         ],
     )
     def test_retrieve(self, client, mock_email_loader, values, query):
@@ -77,9 +55,7 @@ class TestEmailClient:
         mock_email_loader.load.assert_called_once_with(query)
         assert artifact.value == "fake-email-content"
 
-    def test_retrieve_when_email_max_retrieve_count_set(
-        self, mock_email_loader
-    ):
+    def test_retrieve_when_email_max_retrieve_count_set(self, mock_email_loader):
         # Given
         client = EmailClient(email_max_retrieve_count=84)
 
@@ -87,9 +63,7 @@ class TestEmailClient:
         client.retrieve({"values": {"label": "fake-label"}})
 
         # Then
-        mock_email_loader.load.assert_called_once_with(
-            EmailLoader.EmailQuery(label="fake-label", max_count=84)
-        )
+        mock_email_loader.load.assert_called_once_with(EmailLoader.EmailQuery(label="fake-label", max_count=84))
 
     def test_retrieve_activity_description_includes_available_mailboxes(self):
         # Given
@@ -97,10 +71,7 @@ class TestEmailClient:
             username="fake-username",
             password="fake-password",
             smtp_port=86,
-            mailboxes={
-                "INBOX": "default mailbox for incoming email",
-                "SENT": "default mailbox for sent email",
-            },
+            mailboxes={"INBOX": "default mailbox for incoming email", "SENT": "default mailbox for sent email"},
         )
 
         # When
@@ -108,25 +79,13 @@ class TestEmailClient:
 
         # Then
         retrieve_description = next(
-            line
-            for line in llm_input.split("\n")
-            if line.startswith("retrieve path description:")
+            line for line in llm_input.split("\n") if line.startswith("retrieve path description:")
         )
-        assert (
-            "'INBOX': 'default mailbox for incoming email'"
-            in retrieve_description
-        )
-        assert (
-            "'SENT': 'default mailbox for sent email'" in retrieve_description
-        )
+        assert "'INBOX': 'default mailbox for incoming email'" in retrieve_description
+        assert "'SENT': 'default mailbox for sent email'" in retrieve_description
 
     @pytest.mark.parametrize(
-        "params",
-        [
-            {},
-            {"values": {}},
-            {"values": {"label": "fake-label", "max_count": "not-an-int"}},
-        ],
+        "params", [{}, {"values": {}}, {"values": {"label": "fake-label", "max_count": "not-an-int"}}]
     )
     def test_retrieve_throws_when_params_invalid(self, client, params):
         # When
@@ -179,9 +138,7 @@ class TestEmailClient:
         # Then
         assert isinstance(e.value, Exception)
 
-    def test_send_returns_error_artifact_when_sendmail_throws(
-        self, client, mock_smtp_ssl, send_params
-    ):
+    def test_send_returns_error_artifact_when_sendmail_throws(self, client, mock_smtp_ssl, send_params):
         # Given
         mock_smtp_ssl.sendmail.side_effect = Exception("sendmail-failed")
 

--- a/tests/unit/tools/test_file_manager.py
+++ b/tests/unit/tools/test_file_manager.py
@@ -16,19 +16,14 @@ class TestFileManager:
 
     def test_load_files_from_disk(self):
         result = FileManager(
-            input_memory=[defaults.text_tool_memory("Memory1")],
-            workdir=os.path.abspath(os.path.dirname(__file__)),
-        ).load_files_from_disk(
-            {"values": {"paths": ["../../resources/bitcoin.pdf"]}}
-        )
+            input_memory=[defaults.text_tool_memory("Memory1")], workdir=os.path.abspath(os.path.dirname(__file__))
+        ).load_files_from_disk({"values": {"paths": ["../../resources/bitcoin.pdf"]}})
 
         assert isinstance(result, ListArtifact)
         assert len(result.value) == 4
 
     def test_load_files_from_disk_with_encoding(self):
-        result = FileManager(
-            workdir=os.path.abspath(os.path.dirname(__file__))
-        ).load_files_from_disk(
+        result = FileManager(workdir=os.path.abspath(os.path.dirname(__file__))).load_files_from_disk(
             {"values": {"paths": ["../../resources/test.txt"]}}
         )
 
@@ -38,12 +33,8 @@ class TestFileManager:
 
     def test_load_files_from_disk_with_encoding_failure(self):
         result = FileManager(
-            workdir=os.path.abspath(os.path.dirname(__file__)),
-            default_loader=FileLoader(encoding="utf-8"),
-            loaders={},
-        ).load_files_from_disk(
-            {"values": {"paths": ["../../resources/bitcoin.pdf"]}}
-        )
+            workdir=os.path.abspath(os.path.dirname(__file__)), default_loader=FileLoader(encoding="utf-8"), loaders={}
+        ).load_files_from_disk({"values": {"paths": ["../../resources/bitcoin.pdf"]}})
 
         assert isinstance(result.value[0], ErrorArtifact)
 
@@ -54,9 +45,7 @@ class TestFileManager:
 
             memory.store_artifact("foobar", artifact)
 
-            result = FileManager(
-                workdir=temp_dir, input_memory=[memory]
-            ).save_memory_artifacts_to_disk(
+            result = FileManager(workdir=temp_dir, input_memory=[memory]).save_memory_artifacts_to_disk(
                 {
                     "values": {
                         "dir_name": "test",
@@ -67,10 +56,7 @@ class TestFileManager:
                 }
             )
 
-            assert (
-                Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text()
-                == "foobar"
-            )
+            assert Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text() == "foobar"
             assert result.value == "saved successfully"
 
     def test_save_memory_artifacts_to_disk_for_multiple_artifacts(self):
@@ -83,9 +69,7 @@ class TestFileManager:
             for a in artifacts:
                 memory.store_artifact("foobar", a)
 
-            result = FileManager(
-                workdir=temp_dir, input_memory=[memory]
-            ).save_memory_artifacts_to_disk(
+            result = FileManager(workdir=temp_dir, input_memory=[memory]).save_memory_artifacts_to_disk(
                 {
                     "values": {
                         "dir_name": "test",
@@ -96,86 +80,40 @@ class TestFileManager:
                 }
             )
 
-            assert (
-                Path(
-                    os.path.join(
-                        temp_dir, "test", f"{artifacts[0].name}-{file_name}"
-                    )
-                ).read_text()
-                == "foobar"
-            )
-            assert (
-                Path(
-                    os.path.join(
-                        temp_dir, "test", f"{artifacts[1].name}-{file_name}"
-                    )
-                ).read_text()
-                == "baz"
-            )
+            assert Path(os.path.join(temp_dir, "test", f"{artifacts[0].name}-{file_name}")).read_text() == "foobar"
+            assert Path(os.path.join(temp_dir, "test", f"{artifacts[1].name}-{file_name}")).read_text() == "baz"
             assert result.value == "saved successfully"
 
     def test_save_content_to_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             result = FileManager(workdir=temp_dir).save_content_to_file(
-                {
-                    "values": {
-                        "path": os.path.join("test", "foobar.txt"),
-                        "content": "foobar",
-                    }
-                }
+                {"values": {"path": os.path.join("test", "foobar.txt"), "content": "foobar"}}
             )
 
-            assert (
-                Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text()
-                == "foobar"
-            )
+            assert Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text() == "foobar"
             assert result.value == "saved successfully"
 
     def test_save_content_to_file_with_encoding(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            result = FileManager(
-                workdir=temp_dir, save_file_encoding="utf-8"
-            ).save_content_to_file(
-                {
-                    "values": {
-                        "path": os.path.join("test", "foobar.txt"),
-                        "content": "foobar",
-                    }
-                }
+            result = FileManager(workdir=temp_dir, save_file_encoding="utf-8").save_content_to_file(
+                {"values": {"path": os.path.join("test", "foobar.txt"), "content": "foobar"}}
             )
 
-            assert (
-                Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text()
-                == "foobar"
-            )
+            assert Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text() == "foobar"
             assert result.value == "saved successfully"
 
     def test_save_and_load_content_to_file_with_encoding(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            result = FileManager(
-                workdir=temp_dir, save_file_encoding="ascii"
-            ).save_content_to_file(
-                {
-                    "values": {
-                        "path": os.path.join("test", "foobar.txt"),
-                        "content": "foobar",
-                    }
-                }
+            result = FileManager(workdir=temp_dir, save_file_encoding="ascii").save_content_to_file(
+                {"values": {"path": os.path.join("test", "foobar.txt"), "content": "foobar"}}
             )
 
-            assert (
-                Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text()
-                == "foobar"
-            )
+            assert Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text() == "foobar"
             assert result.value == "saved successfully"
 
             result = FileManager(
-                workdir=temp_dir,
-                default_loader=FileLoader(encoding="ascii"),
-                loaders={},
-            ).load_files_from_disk(
-                {"values": {"paths": [os.path.join("test", "foobar.txt")]}}
-            )
+                workdir=temp_dir, default_loader=FileLoader(encoding="ascii"), loaders={}
+            ).load_files_from_disk({"values": {"paths": [os.path.join("test", "foobar.txt")]}})
 
             assert isinstance(result, ListArtifact)
             assert len(result.value) == 1

--- a/tests/unit/tools/test_google_docs_client.py
+++ b/tests/unit/tools/test_google_docs_client.py
@@ -6,33 +6,19 @@ class TestGoogleDocsClient:
     def mock_docs_client(self):
         from griptape.tools import GoogleDocsClient
 
-        return GoogleDocsClient(
-            owner_email="tony@griptape.ai", service_account_credentials={}
-        )
+        return GoogleDocsClient(owner_email="tony@griptape.ai", service_account_credentials={})
 
     def test_append_text(self, mock_docs_client):
-        params = {
-            "file_path": "test_folder/test_document",
-            "text": "Appending this text",
-        }
-        result = mock_docs_client.append_text_to_google_doc(
-            {"values": params}
-        ).value
+        params = {"file_path": "test_folder/test_document", "text": "Appending this text"}
+        result = mock_docs_client.append_text_to_google_doc({"values": params}).value
         assert "error appending text to Google Doc with path" in result
 
     def test_prepend_text(self, mock_docs_client):
-        params = {
-            "file_path": "test_folder/test_document",
-            "text": "Prepending this text",
-        }
-        result = mock_docs_client.prepend_text_to_google_doc(
-            {"values": params}
-        ).value
+        params = {"file_path": "test_folder/test_document", "text": "Prepending this text"}
+        result = mock_docs_client.prepend_text_to_google_doc({"values": params}).value
         assert "error prepending text to Google Doc with path" in result
 
     def test_save_content_to_google_doc(self, mock_docs_client):
         params = {"file_path": "test_document", "content": "Sample content"}
-        result = mock_docs_client.save_content_to_google_doc(
-            {"values": params}
-        ).value
+        result = mock_docs_client.save_content_to_google_doc({"values": params}).value
         assert "Error creating/saving Google Doc:" in result

--- a/tests/unit/tools/test_google_drive_client.py
+++ b/tests/unit/tools/test_google_drive_client.py
@@ -4,23 +4,16 @@ from griptape.artifacts import ErrorArtifact
 
 class TestGoogleDriveClient:
     def test_list_files(self):
-        value = {
-            "folder_path": "root"
-        }  # This can be any folder path you want to test
-        result = GoogleDriveClient(
-            owner_email="tony@griptape.ai", service_account_credentials={}
-        ).list_files({"values": value})
-
-        assert isinstance(result, ErrorArtifact)
-        assert (
-            "error listing files due to malformed credentials" in result.value
+        value = {"folder_path": "root"}  # This can be any folder path you want to test
+        result = GoogleDriveClient(owner_email="tony@griptape.ai", service_account_credentials={}).list_files(
+            {"values": value}
         )
 
+        assert isinstance(result, ErrorArtifact)
+        assert "error listing files due to malformed credentials" in result.value
+
     def test_save_content_to_drive(self):
-        value = {
-            "path": "/path/to/your/file.txt",
-            "content": "Sample content for the file.",
-        }
+        value = {"path": "/path/to/your/file.txt", "content": "Sample content for the file."}
         result = GoogleDriveClient(
             owner_email="tony@griptape.ai", service_account_credentials={}
         ).save_content_to_drive({"values": value})
@@ -30,39 +23,29 @@ class TestGoogleDriveClient:
 
     def test_download_files(self):
         value = {"file_paths": ["example_folder/example_file.txt"]}
-        result = GoogleDriveClient(
-            owner_email="tony@griptape.ai", service_account_credentials={}
-        ).download_files({"values": value})
+        result = GoogleDriveClient(owner_email="tony@griptape.ai", service_account_credentials={}).download_files(
+            {"values": value}
+        )
 
         assert isinstance(result, ErrorArtifact)
 
-        assert (
-            "error downloading file due to malformed credentials"
-            in result.value
-        )
+        assert "error downloading file due to malformed credentials" in result.value
 
     def test_search_files(self):
         value = {"search_mode": "name", "file_name": "search_file_name.txt"}
-        result = GoogleDriveClient(
-            owner_email="tony@griptape.ai", service_account_credentials={}
-        ).search_files({"values": value})
+        result = GoogleDriveClient(owner_email="tony@griptape.ai", service_account_credentials={}).search_files(
+            {"values": value}
+        )
 
         assert isinstance(result, ErrorArtifact)
 
-        assert (
-            "error searching for file due to malformed credentials"
-            in result.value
-        )
+        assert "error searching for file due to malformed credentials" in result.value
 
     def test_share_file(self):
-        value = {
-            "file_path": "/path/to/your/file.txt",
-            "email_address": "sample_email@example.com",
-            "role": "reader",
-        }
-        result = GoogleDriveClient(
-            owner_email="tony@griptape.ai", service_account_credentials={}
-        ).share_file({"values": value})
+        value = {"file_path": "/path/to/your/file.txt", "email_address": "sample_email@example.com", "role": "reader"}
+        result = GoogleDriveClient(owner_email="tony@griptape.ai", service_account_credentials={}).share_file(
+            {"values": value}
+        )
 
         assert isinstance(result, ErrorArtifact)
 

--- a/tests/unit/tools/test_google_gmail_client.py
+++ b/tests/unit/tools/test_google_gmail_client.py
@@ -3,16 +3,10 @@ from griptape.tools import GoogleGmailClient
 
 class TestGoogleGmailClient:
     def test_create_draft_email(self):
-        value = {
-            "subject": "stacey's mom",
-            "from": "test@test.com",
-            "body": "got it going on",
-        }
+        value = {"subject": "stacey's mom", "from": "test@test.com", "body": "got it going on"}
         assert (
             "error creating draft email"
-            in GoogleGmailClient(
-                service_account_credentials={}, owner_email="tony@griptape.ai"
-            )
+            in GoogleGmailClient(service_account_credentials={}, owner_email="tony@griptape.ai")
             .create_draft_email({"values": value})
             .value
         )

--- a/tests/unit/tools/test_openweather_client.py
+++ b/tests/unit/tools/test_openweather_client.py
@@ -30,10 +30,7 @@ def mock_requests_get(*args, **kwargs):
 def test_get_coordinates_by_location(mock_get, client):
     params = {"values": {"location": "New York, NY"}}
     result = client.get_coordinates_by_location(params)
-    assert (
-        result.to_text()
-        == "Coordinates for New York, NY: Latitude: 40.7128, Longitude: -74.0061"
-    )
+    assert result.to_text() == "Coordinates for New York, NY: Latitude: 40.7128, Longitude: -74.0061"
 
 
 @patch("requests.get", side_effect=mock_requests_get)
@@ -62,10 +59,7 @@ def test_invalid_api_key(mock_get, client):
     params = {"values": {"location": "New York, NY"}}
     result = client.get_coordinates_by_location(params)
     assert isinstance(result, ErrorArtifact)
-    assert (
-        "Error fetching coordinates for location: New York, NY"
-        in result.to_text()
-    )
+    assert "Error fetching coordinates for location: New York, NY" in result.to_text()
 
 
 @patch("requests.get", return_value=MockResponse(None, 404))
@@ -73,7 +67,4 @@ def test_invalid_location(mock_get, client):
     params = {"values": {"location": "InvalidCity, XX"}}
     result = client.get_coordinates_by_location(params)
     assert isinstance(result, ErrorArtifact)
-    assert (
-        "Error fetching coordinates for location: InvalidCity, XX"
-        in result.to_text()
-    )
+    assert "Error fetching coordinates for location: InvalidCity, XX" in result.to_text()

--- a/tests/unit/tools/test_proxycurl_client.py
+++ b/tests/unit/tools/test_proxycurl_client.py
@@ -13,9 +13,7 @@ class TestProxycurlClient:
         params = {"values": {"profile_id": profile_id}}
         result = client.get_profile(params)
 
-        assert isinstance(
-            result, list
-        ), "Expected list of TextArtifact instances"
+        assert isinstance(result, list), "Expected list of TextArtifact instances"
 
     @patch("griptape.tools.ProxycurlClient.get_job")
     def test_get_job(self, mock_get_job):
@@ -26,9 +24,7 @@ class TestProxycurlClient:
         params = {"values": {"job_id": job_id}}
         result = client.get_job(params)
 
-        assert isinstance(
-            result, list
-        ), "Expected list of TextArtifact instances"
+        assert isinstance(result, list), "Expected list of TextArtifact instances"
 
     @patch("griptape.tools.ProxycurlClient.get_company")
     def test_get_company(self, mock_get_company):
@@ -39,9 +35,7 @@ class TestProxycurlClient:
         params = {"values": {"company_id": company_id}}
         result = client.get_company(params)
 
-        assert isinstance(
-            result, list
-        ), "Expected list of TextArtifact instances"
+        assert isinstance(result, list), "Expected list of TextArtifact instances"
 
     @patch("griptape.tools.ProxycurlClient.get_school")
     def test_get_school(self, mock_get_school):
@@ -52,9 +46,7 @@ class TestProxycurlClient:
         params = {"values": {"school_id": school_id}}
         result = client.get_school(params)
 
-        assert isinstance(
-            result, list
-        ), "Expected list of TextArtifact instances"
+        assert isinstance(result, list), "Expected list of TextArtifact instances"
 
     @patch("griptape.tools.ProxycurlClient.get_profile")
     def test_get_profile_with_invalid_api_key(self, mock_get_profile):
@@ -66,6 +58,4 @@ class TestProxycurlClient:
         params = {"values": {"profile_id": profile_id}}
         result = client.get_profile(params)
 
-        assert isinstance(
-            result, ErrorArtifact
-        ), "Expected ErrorArtifact instance"
+        assert isinstance(result, ErrorArtifact), "Expected ErrorArtifact instance"

--- a/tests/unit/tools/test_rest_api_client.py
+++ b/tests/unit/tools/test_rest_api_client.py
@@ -7,9 +7,7 @@ class TestRestApi:
     def client(self):
         from griptape.tools import RestApiClient
 
-        return RestApiClient(
-            base_url="http://www.griptape.ai", description="Griptape website."
-        )
+        return RestApiClient(base_url="http://www.griptape.ai", description="Griptape website.")
 
     def test_put(self, client):
         assert isinstance(client.post({"values": {"body": {}}}), BaseArtifact)
@@ -18,35 +16,22 @@ class TestRestApi:
         assert isinstance(client.post({"values": {"body": {}}}), BaseArtifact)
 
     def test_get_one(self, client):
-        assert isinstance(
-            client.get({"values": {"path_params": ["1"]}}), BaseArtifact
-        )
+        assert isinstance(client.get({"values": {"path_params": ["1"]}}), BaseArtifact)
 
     def test_get_all(self, client):
         assert isinstance(client.get({"values": {}}), BaseArtifact)
 
     def test_get_filtered(self, client):
-        assert isinstance(
-            client.get({"values": {"query_params": {"limit": 10}}}),
-            BaseArtifact,
-        )
+        assert isinstance(client.get({"values": {"query_params": {"limit": 10}}}), BaseArtifact)
 
     def test_delete_one(self, client):
-        assert isinstance(
-            client.delete({"values": {"path_params": ["1"]}}), BaseArtifact
-        )
+        assert isinstance(client.delete({"values": {"path_params": ["1"]}}), BaseArtifact)
 
     def test_delete_multiple(self, client):
-        assert isinstance(
-            client.delete({"values": {"query_params": {"ids": [1, 2]}}}),
-            BaseArtifact,
-        )
+        assert isinstance(client.delete({"values": {"query_params": {"ids": [1, 2]}}}), BaseArtifact)
 
     def test_patch(self, client):
-        assert isinstance(
-            client.patch({"values": {"path_params": ["1"], "body": {}}}),
-            BaseArtifact,
-        )
+        assert isinstance(client.patch({"values": {"path_params": ["1"], "body": {}}}), BaseArtifact)
 
     def test_build_url(self, client):
         url = client._build_url("https://foo.bar")
@@ -61,16 +46,10 @@ class TestRestApi:
 
         assert url == "https://foo.bar/1/fizz"
 
-        url = client._build_url(
-            "https://foo.bar",
-            path="foo/",
-            path_params=["fizz", "buzz", 1, 2, 3],
-        )
+        url = client._build_url("https://foo.bar", path="foo/", path_params=["fizz", "buzz", 1, 2, 3])
 
         assert url == "https://foo.bar/foo/fizz/buzz/1/2/3"
 
-        url = client._build_url(
-            "https://foo.bar", path_params=["fizz", "buzz", 1, 2, 3]
-        )
+        url = client._build_url("https://foo.bar", path_params=["fizz", "buzz", 1, 2, 3])
 
         assert url == "https://foo.bar/fizz/buzz/1/2/3"

--- a/tests/unit/tools/test_sql_client.py
+++ b/tests/unit/tools/test_sql_client.py
@@ -14,30 +14,17 @@ class TestSqlClient:
             "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER, city TEXT);"
         )
 
-        new_driver.execute_query(
-            "INSERT INTO test_table (name, age, city) VALUES ('Alice', 25, 'New York');"
-        )
+        new_driver.execute_query("INSERT INTO test_table (name, age, city) VALUES ('Alice', 25, 'New York');")
 
         return new_driver
 
     def test_execute_query(self, driver):
         with sqlite3.connect(":memory:"):
-            client = SqlClient(
-                sql_loader=SqlLoader(sql_driver=driver),
-                table_name="test_table",
-                engine_name="sqlite",
-            )
-            result = client.execute_query(
-                {"values": {"sql_query": "SELECT * from test_table;"}}
-            )
+            client = SqlClient(sql_loader=SqlLoader(sql_driver=driver), table_name="test_table", engine_name="sqlite")
+            result = client.execute_query({"values": {"sql_query": "SELECT * from test_table;"}})
 
             assert len(result.value) == 1
-            assert result.value[0].value == {
-                "id": 1,
-                "name": "Alice",
-                "age": 25,
-                "city": "New York",
-            }
+            assert result.value[0].value == {"id": 1, "name": "Alice", "age": 25, "city": "New York"}
 
     def test_execute_query_description(self, driver):
         client = SqlClient(
@@ -48,10 +35,7 @@ class TestSqlClient:
         )
         description = client.activity_description(client.execute_query)
 
-        assert (
-            "Can be used to execute sqlite SQL SELECT queries in table test_table"
-            in description
-        )
+        assert "Can be used to execute sqlite SQL SELECT queries in table test_table" in description
         assert (
             "test_table schema: [('id', INTEGER()), ('name', TEXT()), ('age', INTEGER()), ('city', TEXT())]"
             in description

--- a/tests/unit/tools/test_tool_memory_client.py
+++ b/tests/unit/tools/test_tool_memory_client.py
@@ -7,22 +7,13 @@ from tests.utils import defaults
 class TestToolMemoryClient:
     @pytest.fixture
     def tool(self):
-        return ToolMemoryClient(
-            input_memory=[defaults.text_tool_memory("TestMemory")]
-        )
+        return ToolMemoryClient(input_memory=[defaults.text_tool_memory("TestMemory")])
 
     def test_summarize(self, tool):
         tool.input_memory[0].store_artifact("foo", TextArtifact("test"))
 
         assert (
-            tool.summarize(
-                {
-                    "values": {
-                        "memory_name": tool.input_memory[0].name,
-                        "artifact_namespace": "foo",
-                    }
-                }
-            ).value
+            tool.summarize({"values": {"memory_name": tool.input_memory[0].name, "artifact_namespace": "foo"}}).value
             == "mock output"
         )
 
@@ -31,13 +22,7 @@ class TestToolMemoryClient:
 
         assert (
             tool.query(
-                {
-                    "values": {
-                        "query": "foobar",
-                        "memory_name": tool.input_memory[0].name,
-                        "artifact_namespace": "foo",
-                    }
-                }
+                {"values": {"query": "foobar", "memory_name": tool.input_memory[0].name, "artifact_namespace": "foo"}}
             ).value
             == "mock output"
         )

--- a/tests/unit/tools/test_vector_store_client.py
+++ b/tests/unit/tools/test_vector_store_client.py
@@ -10,24 +10,16 @@ from tests.mocks.mock_prompt_driver import MockPromptDriver
 class TestVectorStoreClient:
     @pytest.fixture(autouse=True)
     def mock_try_runt(self, mocker):
-        mocker.patch(
-            "griptape.drivers.OpenAiChatPromptDriver.try_run",
-            return_value=TextArtifact("foobar"),
-        )
+        mocker.patch("griptape.drivers.OpenAiChatPromptDriver.try_run", return_value=TextArtifact("foobar"))
 
-        mocker.patch(
-            "griptape.drivers.OpenAiEmbeddingDriver.try_embed_chunk",
-            return_value=[0, 1],
-        )
+        mocker.patch("griptape.drivers.OpenAiEmbeddingDriver.try_embed_chunk", return_value=[0, 1])
 
     def test_search(self):
         tool = VectorStoreClient(
             description="Test",
             query_engine=VectorQueryEngine(
                 prompt_driver=MockPromptDriver(mock_output="foobar"),
-                vector_store_driver=LocalVectorStoreDriver(
-                    embedding_driver=MockEmbeddingDriver()
-                ),
+                vector_store_driver=LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver()),
             ),
         )
 

--- a/tests/unit/tools/test_web_scraper.py
+++ b/tests/unit/tools/test_web_scraper.py
@@ -11,16 +11,10 @@ class TestWebScraper:
 
     def test_get_content(self, scraper):
         assert isinstance(
-            scraper.get_content(
-                {"values": {"url": "https://github.com/griptape-ai/griptape"}}
-            ),
-            ListArtifact,
+            scraper.get_content({"values": {"url": "https://github.com/griptape-ai/griptape"}}), ListArtifact
         )
 
     def test_get_authors(self, scraper):
         assert isinstance(
-            scraper.get_author(
-                {"values": {"url": "https://github.com/griptape-ai/griptape"}}
-            ),
-            BaseArtifact,
+            scraper.get_author({"values": {"url": "https://github.com/griptape-ai/griptape"}}), BaseArtifact
         )

--- a/tests/unit/tools/test_web_search.py
+++ b/tests/unit/tools/test_web_search.py
@@ -6,6 +6,4 @@ class TestWebSearch:
     def test_search(self):
         tool = WebSearch(google_api_key="foo", google_api_search_id="bar")
 
-        assert isinstance(
-            tool.search({"values": {"query": "foo bar"}}), BaseArtifact
-        )
+        assert isinstance(tool.search({"values": {"query": "foo bar"}}), BaseArtifact)

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -8,9 +8,7 @@ class TestConversation:
     def test_init(self):
         import logging
 
-        agent = Agent(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         chat = Chat(
             agent,

--- a/tests/unit/utils/test_conversation.py
+++ b/tests/unit/utils/test_conversation.py
@@ -1,8 +1,5 @@
 from tests.mocks.mock_prompt_driver import MockPromptDriver
-from griptape.memory.structure import (
-    ConversationMemory,
-    SummaryConversationMemory,
-)
+from griptape.memory.structure import ConversationMemory, SummaryConversationMemory
 from griptape.tasks import PromptTask
 from griptape.structures import Pipeline
 from griptape.utils import Conversation
@@ -10,9 +7,7 @@ from griptape.utils import Conversation
 
 class TestConversation:
     def test_lines(self):
-        pipeline = Pipeline(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        pipeline = Pipeline(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         pipeline.add_tasks(PromptTask("question 1"))
 
@@ -27,9 +22,7 @@ class TestConversation:
         assert lines[3] == "A: mock output"
 
     def test_prompt_stack_conversation_memory(self):
-        pipeline = Pipeline(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        pipeline = Pipeline(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         pipeline.add_tasks(PromptTask("question 1"))
 
@@ -44,9 +37,7 @@ class TestConversation:
     def test_prompt_stack_summary_conversation_memory(self):
         pipeline = Pipeline(
             prompt_driver=MockPromptDriver(),
-            memory=SummaryConversationMemory(
-                summary="foobar", prompt_driver=MockPromptDriver()
-            ),
+            memory=SummaryConversationMemory(summary="foobar", prompt_driver=MockPromptDriver()),
         )
 
         pipeline.add_tasks(PromptTask("question 1"))
@@ -56,16 +47,12 @@ class TestConversation:
 
         lines = Conversation(pipeline.memory).prompt_stack()
 
-        assert (
-            lines[0] == "user: Summary of the conversation so far: mock output"
-        )
+        assert lines[0] == "user: Summary of the conversation so far: mock output"
         assert lines[1] == "user: question 1"
         assert lines[2] == "assistant: mock output"
 
     def test___str__(self):
-        pipeline = Pipeline(
-            prompt_driver=MockPromptDriver(), memory=ConversationMemory()
-        )
+        pipeline = Pipeline(prompt_driver=MockPromptDriver(), memory=ConversationMemory())
 
         pipeline.add_tasks(PromptTask("question 1"))
 

--- a/tests/unit/utils/test_dict_utils.py
+++ b/tests/unit/utils/test_dict_utils.py
@@ -3,14 +3,8 @@ from griptape.utils import remove_null_values_in_dict_recursively
 
 class TestDictUtils:
     def test_remove_null_values_in_dict_recursively(self):
-        dict_with_nones = {
-            "foo": None,
-            "bar": {"baz": {"foo": [1, 2, 3], "bar": None}},
-        }
+        dict_with_nones = {"foo": None, "bar": {"baz": {"foo": [1, 2, 3], "bar": None}}}
 
         dict_without_nones = {"bar": {"baz": {"foo": [1, 2, 3]}}}
 
-        assert (
-            remove_null_values_in_dict_recursively(dict_with_nones)
-            == dict_without_nones
-        )
+        assert remove_null_values_in_dict_recursively(dict_with_nones) == dict_without_nones

--- a/tests/unit/utils/test_futures.py
+++ b/tests/unit/utils/test_futures.py
@@ -6,10 +6,7 @@ class TestFutures:
     def test_execute_futures_dict(self):
         with futures.ThreadPoolExecutor() as executor:
             result = utils.execute_futures_dict(
-                {
-                    "foo": executor.submit(self.foobar, "foo"),
-                    "baz": executor.submit(self.foobar, "baz"),
-                }
+                {"foo": executor.submit(self.foobar, "foo"), "baz": executor.submit(self.foobar, "baz")}
             )
 
             assert result["foo"] == "foo-bar"

--- a/tests/unit/utils/test_hash.py
+++ b/tests/unit/utils/test_hash.py
@@ -3,11 +3,5 @@ from griptape import utils
 
 class TestHash:
     def test_str_to_hash(self):
-        assert (
-            utils.str_to_hash("foo")
-            == "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
-        )
-        assert (
-            utils.str_to_hash("foo", "md5")
-            == "acbd18db4cc2f85cedef654fccc4a4d8"
-        )
+        assert utils.str_to_hash("foo") == "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+        assert utils.str_to_hash("foo", "md5") == "acbd18db4cc2f85cedef654fccc4a4d8"

--- a/tests/unit/utils/test_prompt_stack.py
+++ b/tests/unit/utils/test_prompt_stack.py
@@ -66,11 +66,7 @@ class TestPromptStack:
 
     def test_add_conversation_memory_autopruing_enabled(self):
         # All memory is pruned.
-        agent = Agent(
-            prompt_driver=MockPromptDriver(
-                tokenizer=MockTokenizer(model="foo", max_tokens=0)
-            )
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(tokenizer=MockTokenizer(model="foo", max_tokens=0)))
         memory = ConversationMemory(
             autoprune=True,
             runs=[
@@ -91,11 +87,7 @@ class TestPromptStack:
         assert len(prompt_stack.inputs) == 3
 
         # No memory is pruned.
-        agent = Agent(
-            prompt_driver=MockPromptDriver(
-                tokenizer=MockTokenizer(model="foo", max_tokens=1000)
-            )
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(tokenizer=MockTokenizer(model="foo", max_tokens=1000)))
         memory = ConversationMemory(
             autoprune=True,
             runs=[
@@ -118,11 +110,7 @@ class TestPromptStack:
         # One memory is pruned.
         # MockTokenizer's max_tokens set to one below the sum of memory + system prompt tokens
         # so that a single memory is pruned.
-        agent = Agent(
-            prompt_driver=MockPromptDriver(
-                tokenizer=MockTokenizer(model="foo", max_tokens=160)
-            )
-        )
+        agent = Agent(prompt_driver=MockPromptDriver(tokenizer=MockTokenizer(model="foo", max_tokens=160)))
         memory = ConversationMemory(
             autoprune=True,
             runs=[

--- a/tests/unit/utils/test_python_runner.py
+++ b/tests/unit/utils/test_python_runner.py
@@ -3,16 +3,8 @@ from griptape.utils import PythonRunner
 
 class TestPythonRunner:
     def test_run(self):
-        assert (
-            PythonRunner(libs={"math": "math"}).run("""math.sqrt(9)""") == "3.0"
-        )
-        assert (
-            PythonRunner(libs={"numpy": "np"}).run("""np.array([1, 2, 3])""")
-            == "[1 2 3]"
-        )
+        assert PythonRunner(libs={"math": "math"}).run("""math.sqrt(9)""") == "3.0"
+        assert PythonRunner(libs={"numpy": "np"}).run("""np.array([1, 2, 3])""") == "[1 2 3]"
 
     def test_run_fail(self):
-        assert (
-            PythonRunner().run("""np.array([1, 2, 3])""")
-            == "name 'np' is not defined"
-        )
+        assert PythonRunner().run("""np.array([1, 2, 3])""") == "name 'np' is not defined"

--- a/tests/utils/defaults.py
+++ b/tests/utils/defaults.py
@@ -1,16 +1,8 @@
 from griptape.artifacts import TextArtifact, BlobArtifact
 from griptape.drivers import LocalVectorStoreDriver
-from griptape.engines import (
-    VectorQueryEngine,
-    PromptSummaryEngine,
-    CsvExtractionEngine,
-    JsonExtractionEngine,
-)
+from griptape.engines import VectorQueryEngine, PromptSummaryEngine, CsvExtractionEngine, JsonExtractionEngine
 from griptape.memory import ToolMemory
-from griptape.memory.tool.storage import (
-    TextArtifactStorage,
-    BlobArtifactStorage,
-)
+from griptape.memory.tool.storage import TextArtifactStorage, BlobArtifactStorage
 from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 
@@ -18,26 +10,16 @@ from tests.mocks.mock_prompt_driver import MockPromptDriver
 def text_tool_artifact_storage():
     return TextArtifactStorage(
         query_engine=VectorQueryEngine(
-            vector_store_driver=LocalVectorStoreDriver(
-                embedding_driver=MockEmbeddingDriver()
-            ),
+            vector_store_driver=LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver()),
             prompt_driver=MockPromptDriver(),
         ),
         summary_engine=PromptSummaryEngine(prompt_driver=MockPromptDriver()),
-        csv_extraction_engine=CsvExtractionEngine(
-            prompt_driver=MockPromptDriver()
-        ),
-        json_extraction_engine=JsonExtractionEngine(
-            prompt_driver=MockPromptDriver()
-        ),
+        csv_extraction_engine=CsvExtractionEngine(prompt_driver=MockPromptDriver()),
+        json_extraction_engine=JsonExtractionEngine(prompt_driver=MockPromptDriver()),
     )
 
 
 def text_tool_memory(name):
     return ToolMemory(
-        name=name,
-        artifact_storages={
-            TextArtifact: text_tool_artifact_storage(),
-            BlobArtifact: BlobArtifactStorage(),
-        },
+        name=name, artifact_storages={TextArtifact: text_tool_artifact_storage(), BlobArtifact: BlobArtifactStorage()}
     )

--- a/tests/utils/postgres.py
+++ b/tests/utils/postgres.py
@@ -1,17 +1,9 @@
 from psycopg2 import connect, OperationalError
 
 
-def can_connect_to_postgres(
-    user="postgres",
-    password="postgres",
-    host="localhost",
-    port="5432",
-    database="postgres",
-):
+def can_connect_to_postgres(user="postgres", password="postgres", host="localhost", port="5432", database="postgres"):
     try:
-        connection = connect(
-            f"postgresql://{user}:{password}@{host}:{port}/{database}"
-        )
+        connection = connect(f"postgresql://{user}:{password}@{host}:{port}/{database}")
         connection.close()
 
         return True

--- a/tests/utils/structure_runner.py
+++ b/tests/utils/structure_runner.py
@@ -35,12 +35,8 @@ OUTPUT_RULESET = Ruleset(
 
 
 PROMPT_DRIVERS = {
-    "OPENAI_CHAT_35": OpenAiChatPromptDriver(
-        model="gpt-3.5-turbo", api_key=os.environ["OPENAI_API_KEY"]
-    ),
-    "OPENAI_CHAT_4": OpenAiChatPromptDriver(
-        model="gpt-4", api_key=os.environ["OPENAI_API_KEY"]
-    ),
+    "OPENAI_CHAT_35": OpenAiChatPromptDriver(model="gpt-3.5-turbo", api_key=os.environ["OPENAI_API_KEY"]),
+    "OPENAI_CHAT_4": OpenAiChatPromptDriver(model="gpt-4", api_key=os.environ["OPENAI_API_KEY"]),
     "OPENAI_COMPLETION_DAVINCI": OpenAiCompletionPromptDriver(
         api_key=os.environ["OPENAI_API_KEY"], model="text-davinci-003"
     ),
@@ -68,31 +64,23 @@ PROMPT_DRIVERS = {
         deployment_id=os.environ["AZURE_OPENAI_4_32k_DEPLOYMENT_ID"],
         api_base=os.environ["AZURE_OPENAI_API_BASE_2"],
     ),
-    "ANTHROPIC_CLAUDE_2": AnthropicPromptDriver(
-        model="claude-2", api_key=os.environ["ANTHROPIC_API_KEY"]
-    ),
-    "COHERE_COMMAND": CoherePromptDriver(
-        model="command", api_key=os.environ["COHERE_API_KEY"]
-    ),
+    "ANTHROPIC_CLAUDE_2": AnthropicPromptDriver(model="claude-2", api_key=os.environ["ANTHROPIC_API_KEY"]),
+    "COHERE_COMMAND": CoherePromptDriver(model="command", api_key=os.environ["COHERE_API_KEY"]),
     "BEDROCK_TITAN": AmazonBedrockPromptDriver(
-        model="amazon.titan-tg1-large",
-        prompt_model_driver=BedrockTitanPromptModelDriver(),
+        model="amazon.titan-tg1-large", prompt_model_driver=BedrockTitanPromptModelDriver()
     ),
     "BEDROCK_CLAUDE_2": AmazonBedrockPromptDriver(
-        model="anthropic.claude-v2",
-        prompt_model_driver=BedrockClaudePromptModelDriver(),
+        model="anthropic.claude-v2", prompt_model_driver=BedrockClaudePromptModelDriver()
     ),
     "BEDROCK_J2": AmazonBedrockPromptDriver(
-        model="ai21.j2-ultra",
-        prompt_model_driver=BedrockJurassicPromptModelDriver(),
+        model="ai21.j2-ultra", prompt_model_driver=BedrockJurassicPromptModelDriver()
     ),
     "SAGEMAKER_LLAMA_7B": AmazonSageMakerPromptDriver(
         model=os.environ["SAGEMAKER_LLAMA_ENDPOINT_NAME"],
         prompt_model_driver=SageMakerLlamaPromptModelDriver(max_tokens=4096),
     ),
     "SAGEMAKER_FALCON_7b": AmazonSageMakerPromptDriver(
-        model=os.environ["SAGEMAKER_FALCON_ENDPOINT_NAME"],
-        prompt_model_driver=SageMakerFalconPromptModelDriver(),
+        model=os.environ["SAGEMAKER_FALCON_ENDPOINT_NAME"], prompt_model_driver=SageMakerFalconPromptModelDriver()
     ),
 }
 


### PR DESCRIPTION
Adds local pre-commit configuration to enforce Black formatting. If code is not formatted appropriately, the Code Checks workflow will fail. The README has been updated with info on formatting expectations and how to configure `pre-commit`, which has been added as a dependency using `poetry`. 

Configure `pre-commit` using `poetry`:

```
poetry run pre-commit install
```

⚠️ Note: this PR also increases the line length configuration from 80 to 120. The large diff is due to running Black after making this change.

Closes #426 