### PR TITLE
Lock openai at ^0.28

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4209,4 +4209,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "6d42a2604e8764d716b288a1c171b93df4f3af28824d0bae52a7100da6a10546"
+content-hash = "3df46fb7722697d0d91d2dc1e7a6980f20bff9e991bb8154326794c5473f127a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 python-dotenv = ">=0.21"
-openai = ">=0.27"
+openai = "^0.28"
 cohere = ">=4"
 attrs = ">=22"
 jinja2 = ">=3.1"


### PR DESCRIPTION
Locking at `^0.28` until https://github.com/griptape-ai/griptape/issues/420 is implemented.