### PR TITLE
Add Driver parameters for Task Memory

### DIFF
--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -39,7 +39,12 @@ class Structure(ABC):
         ),
         kw_only=True,
     )
-    embedding_driver: BaseEmbeddingDriver = field(default=Factory(lambda: OpenAiEmbeddingDriver()), kw_only=True)
+    task_memory_prompt_driver: BasePromptDriver = field(
+        default=Factory(lambda self: self.prompt_driver, takes_self=True), kw_only=True
+    )
+    task_memory_embedding_driver: BaseEmbeddingDriver = field(
+        default=Factory(lambda: OpenAiEmbeddingDriver()), kw_only=True
+    )
     rulesets: list[Ruleset] = field(factory=list, kw_only=True)
     rules: list[Rule] = field(factory=list, kw_only=True)
     tasks: list[BaseTask] = field(factory=list, kw_only=True)
@@ -120,12 +125,12 @@ class Structure(ABC):
             artifact_storages={
                 TextArtifact: TextArtifactStorage(
                     query_engine=VectorQueryEngine(
-                        prompt_driver=self.prompt_driver,
-                        vector_store_driver=LocalVectorStoreDriver(embedding_driver=self.embedding_driver),
+                        prompt_driver=self.task_memory_prompt_driver,
+                        vector_store_driver=LocalVectorStoreDriver(embedding_driver=self.task_memory_embedding_driver),
                     ),
-                    summary_engine=PromptSummaryEngine(prompt_driver=self.prompt_driver),
-                    csv_extraction_engine=CsvExtractionEngine(prompt_driver=self.prompt_driver),
-                    json_extraction_engine=JsonExtractionEngine(prompt_driver=self.prompt_driver),
+                    summary_engine=PromptSummaryEngine(prompt_driver=self.task_memory_prompt_driver),
+                    csv_extraction_engine=CsvExtractionEngine(prompt_driver=self.task_memory_prompt_driver),
+                    json_extraction_engine=JsonExtractionEngine(prompt_driver=self.task_memory_prompt_driver),
                 ),
                 BlobArtifact: BlobArtifactStorage(),
             }

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -69,15 +69,25 @@ class TestAgent:
         assert agent.tools[0].input_memory[0] == agent.task_memory
         assert agent.tools[0].output_memory == {}
 
-    def test_embedding_driver(self):
+    def test_task_memory_embedding_driver(self):
         embedding_driver = MockEmbeddingDriver()
-        agent = Agent(tools=[MockTool()], embedding_driver=embedding_driver)
+        agent = Agent(tools=[MockTool()], task_memory_embedding_driver=embedding_driver)
 
         artifact_storage = list(agent.task_memory.artifact_storages.values())[0]
         assert isinstance(artifact_storage, TextArtifactStorage)
         memory_embedding_driver = artifact_storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
+
+    def test_task_memory_prompt_driver(self):
+        prompt_driver = MockPromptDriver()
+        agent = Agent(tools=[MockTool()], task_memory_prompt_driver=prompt_driver)
+
+        artifact_storage = list(agent.task_memory.artifact_storages.values())[0]
+        assert isinstance(artifact_storage, TextArtifactStorage)
+        memory_prompt_driver = artifact_storage.query_engine.prompt_driver
+
+        assert memory_prompt_driver == prompt_driver
 
     def test_without_default_task_memory(self):
         agent = Agent(task_memory=None, tools=[MockTool()])
@@ -224,7 +234,7 @@ class TestAgent:
     def test_task_memory_defaults(self):
         prompt_driver = MockPromptDriver()
         embedding_driver = MockEmbeddingDriver()
-        agent = Agent(prompt_driver=prompt_driver, embedding_driver=embedding_driver)
+        agent = Agent(prompt_driver=prompt_driver, task_memory_embedding_driver=embedding_driver)
 
         storage = list(agent.task_memory.artifact_storages.values())[0]
         assert isinstance(storage, TextArtifactStorage)

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -76,17 +76,27 @@ class TestPipeline:
         assert pipeline.tasks[0].tools[0].output_memory is not None
         assert pipeline.tasks[0].tools[0].output_memory["test"][0] == pipeline.task_memory
 
-    def test_embedding_driver(self):
+    def test_task_memory_embedding_driver(self):
         embedding_driver = MockEmbeddingDriver()
-        pipeline = Pipeline(embedding_driver=embedding_driver)
-
+        pipeline = Pipeline(task_memory_embedding_driver=embedding_driver)
         pipeline.add_task(ToolkitTask(tools=[MockTool()]))
 
-        storage = list(pipeline.task_memory.artifact_storages.values())[0]
-        assert isinstance(storage, TextArtifactStorage)
-        memory_embedding_driver = storage.query_engine.vector_store_driver.embedding_driver
+        artifact_storage = list(pipeline.task_memory.artifact_storages.values())[0]
+        assert isinstance(artifact_storage, TextArtifactStorage)
+        memory_embedding_driver = artifact_storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
+
+    def test_task_memory_prompt_driver(self):
+        prompt_driver = MockPromptDriver()
+        pipeline = Pipeline(task_memory_prompt_driver=prompt_driver)
+        pipeline.add_task(ToolkitTask(tools=[MockTool()]))
+
+        artifact_storage = list(pipeline.task_memory.artifact_storages.values())[0]
+        assert isinstance(artifact_storage, TextArtifactStorage)
+        memory_prompt_driver = artifact_storage.query_engine.prompt_driver
+
+        assert memory_prompt_driver == prompt_driver
 
     def test_with_default_task_memory_and_empty_tool_output_memory(self):
         pipeline = Pipeline()

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -72,17 +72,27 @@ class TestWorkflow:
         assert workflow.tasks[0].tools[0].output_memory is not None
         assert workflow.tasks[0].tools[0].output_memory["test"][0] == workflow.task_memory
 
-    def test_embedding_driver(self):
+    def test_task_memory_embedding_driver(self):
         embedding_driver = MockEmbeddingDriver()
-        workflow = Workflow(embedding_driver=embedding_driver)
-
+        workflow = Workflow(task_memory_embedding_driver=embedding_driver)
         workflow.add_task(ToolkitTask(tools=[MockTool()]))
 
-        storage = list(workflow.task_memory.artifact_storages.values())[0]
-        assert isinstance(storage, TextArtifactStorage)
-        memory_embedding_driver = storage.query_engine.vector_store_driver.embedding_driver
+        artifact_storage = list(workflow.task_memory.artifact_storages.values())[0]
+        assert isinstance(artifact_storage, TextArtifactStorage)
+        memory_embedding_driver = artifact_storage.query_engine.vector_store_driver.embedding_driver
 
         assert memory_embedding_driver == embedding_driver
+
+    def test_task_memory_prompt_driver(self):
+        prompt_driver = MockPromptDriver()
+        workflow = Workflow(task_memory_prompt_driver=prompt_driver)
+        workflow.add_task(ToolkitTask(tools=[MockTool()]))
+
+        artifact_storage = list(workflow.task_memory.artifact_storages.values())[0]
+        assert isinstance(artifact_storage, TextArtifactStorage)
+        memory_prompt_driver = artifact_storage.query_engine.prompt_driver
+
+        assert memory_prompt_driver == prompt_driver
 
     def test_with_default_task_memory_and_empty_tool_output_memory(self):
         workflow = Workflow()

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -12,7 +12,9 @@ from tests.mocks.mock_tool.tool import MockTool
 class TestBaseTask:
     @pytest.fixture
     def task(self):
-        agent = Agent(prompt_driver=MockPromptDriver(), embedding_driver=MockEmbeddingDriver(), tools=[MockTool()])
+        agent = Agent(
+            prompt_driver=MockPromptDriver(), task_memory_embedding_driver=MockEmbeddingDriver(), tools=[MockTool()]
+        )
 
         agent.add_task(MockTask("foobar", max_meta_memory_entries=2))
 

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -15,7 +15,8 @@ class TestToolTask:
     def agent(self):
         output_dict = {"name": "MockTool", "path": "test", "input": {"values": {"test": "foobar"}}}
         return Agent(
-            prompt_driver=MockPromptDriver(mock_output=json.dumps(output_dict)), embedding_driver=MockEmbeddingDriver()
+            prompt_driver=MockPromptDriver(mock_output=json.dumps(output_dict)),
+            task_memory_embedding_driver=MockEmbeddingDriver(),
         )
 
     def test_run_without_memory(self, agent):


### PR DESCRIPTION
Enables the following syntax:

```python

prompt_driver = AmazonBedrockPromptDriver(
    model="anthropic.claude-v2",
    prompt_model_driver=BedrockClaudePromptModelDriver(),
    session=session,
)
task_memory_prompt_driver = AmazonBedrockPromptDriver(
    model="amazon.titan-text-express-v1",
    prompt_model_driver=BedrockTitanPromptModelDriver(),
    session=session,
)

task_memory_embedding_driver = BedrockTitanEmbeddingDriver(session=session)

agent = Agent(
    tools=[sql_tool, file_manager, task_memory_client],
    rulesets=[ruleset],
    prompt_driver=prompt_driver,
    task_memory_embedding_driver=task_memory_embedding_driver,
    task_memory_prompt_driver=task_memory_prompt_driver,
)
```