### PR TITLE
Update README with contribution guidelines for new tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Thank you for considering contributing to Griptape! Before you start, please rea
 
 If you have identified a bug, want to propose a new feature, or have a question, please submit an issue through our public [issue tracker](https://github.com/griptape-ai/griptape/issues). Before submitting a new issue, please check the existing issues to ensure it hasn't been reported or discussed before.
 
+### New Griptape Tools
+
+Griptape's extensibility allows anyone to develop and distribute tools independently. With rare exceptions for tools providing broadly applicable functionality, new Griptape tools should be managed as their own projects and not submitted to the core framework. Pull requests for new tools (unless addressing an [existing issue](https://github.com/griptape-ai/griptape/issues)) will be closed.
+
+The [Griptape Tool Template](https://github.com/griptape-ai/tool-template) provides the recommended structure, step-by-step instructions, basic automation, and usage examples for new tools. 
+
 ### Submitting Pull Requests
 
 We welcome and encourage pull requests. To streamline the process, please follow these guidelines:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you have identified a bug, want to propose a new feature, or have a question,
 
 Griptape's extensibility allows anyone to develop and distribute tools independently. With rare exceptions for tools providing broadly applicable functionality, new Griptape tools should be managed as their own projects and not submitted to the core framework. Pull requests for new tools (unless addressing an [existing issue](https://github.com/griptape-ai/griptape/issues)) will be closed.
 
-The [Griptape Tool Template](https://github.com/griptape-ai/tool-template) provides the recommended structure, step-by-step instructions, basic automation, and usage examples for new tools. 
+The [Griptape Tool Template](https://github.com/griptape-ai/tool-template) provides the recommended structure, step-by-step instructions, basic automation, and usage examples for new tools. In the Template, select **Use this template** then **Create a new repository** to begin a new tool project.
 
 ### Submitting Pull Requests
 


### PR DESCRIPTION
New contributing guidelines outline our policy that new tools should be managed independently and not submitted to the core framework (unless we've explicitly asked for it in an issue). 