### PR TITLE
Support writing image to disk directly in ImageGenerator tool

### DIFF
--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
+
+import string
+import time
+import random
 from typing import Optional
-from attr import define, field
+from attr import define, field, Factory
 from griptape.artifacts import BlobArtifact
 
 
@@ -11,6 +15,14 @@ class ImageArtifact(BlobArtifact):
     height: int = field(kw_only=True)
     model: Optional[str] = field(default=None, kw_only=True)
     prompt: Optional[str] = field(default=None, kw_only=True)
+    name: str = field(default=Factory(lambda self: self.make_name(), takes_self=True), kw_only=True)
+
+    def make_name(self) -> str:
+        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
+        extension = self.mime_type.split("/")[1].split("+")[0]
+
+        return f"image_artifact_{fmt_time}_{entropy}.{extension}"
 
     def to_text(self) -> str:
         return f"Image, dimensions: {self.width}x{self.height}, type: {self.mime_type}, size: {len(self.value)} bytes"

--- a/griptape/tools/image_generator/tool.py
+++ b/griptape/tools/image_generator/tool.py
@@ -1,4 +1,8 @@
 from __future__ import annotations
+
+from os import path
+from typing import Optional
+
 from attrs import define, field
 from schema import Schema, Literal
 from griptape.artifacts import ErrorArtifact, ImageArtifact
@@ -9,7 +13,16 @@ from griptape.utils.decorators import activity
 
 @define
 class ImageGenerator(BaseTool):
+    """ImageGenerator is a tool that can be used to generate an image.
+
+    Attributes:
+        image_generation_engine: The engine used to generate the image.
+        output_dir: If provided, the generated image will be written to disk in output_dir.
+
+    """
+
     image_generation_engine: ImageGenerationEngine = field(kw_only=True)
+    output_dir: Optional[str] = field(default=None, kw_only=True)
 
     @activity(
         config={
@@ -33,7 +46,19 @@ class ImageGenerator(BaseTool):
         negative_prompts = params["values"]["negative_prompts"]
 
         try:
-            return self.image_generation_engine.generate_image(prompts=prompts, negative_prompts=negative_prompts)
+            image_artifact = self.image_generation_engine.generate_image(
+                prompts=prompts, negative_prompts=negative_prompts
+            )
+
+            if self.output_dir is not None:
+                self._write_to_file(image_artifact)
+
+            return image_artifact
 
         except Exception as e:
             return ErrorArtifact(value=str(e))
+
+    def _write_to_file(self, image_artifact: ImageArtifact) -> None:
+        outfile = path.join(self.output_dir, image_artifact.name)
+        with open(outfile, "wb") as f:
+            f.write(image_artifact.value)


### PR DESCRIPTION
Updates ImageGenerator tool to support writing an image artifact to disk directly from the tool itself. This is important because FileManager is not deterministic and it can be difficult to convince the LLM to save data where you want it. Offloading that functionality back to Python saves time and tokens.