### PR TITLE
Base64 encode ImageArtifacts during serialization

### DIFF
--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -2,15 +2,32 @@ from __future__ import annotations
 from typing import Optional
 from attr import define, field
 from griptape.artifacts import BlobArtifact
+import base64
 
 
 @define(frozen=True)
 class ImageArtifact(BlobArtifact):
+    """ImageArtifact is a type of BlobArtifact that represents an image.
+
+    Attributes:
+        value: Raw bytes representing the image.
+        name: Artifact name, generated using creation time and a random string.
+        mime_type: The mime type of the image, like image/png or image/jpeg.
+        width: The width of the image in pixels.
+        height: The height of the image in pixels.
+        model: Optionally specify the model used to generate the image.
+        prompt: Optionally specify the prompt used to generate the image.
+    """
+
     mime_type: str = field(kw_only=True)
     width: int = field(kw_only=True)
     height: int = field(kw_only=True)
     model: Optional[str] = field(default=None, kw_only=True)
     prompt: Optional[str] = field(default=None, kw_only=True)
+
+    @property
+    def base64(self) -> str:
+        return base64.b64encode(self.value).decode("utf-8")
 
     def to_text(self) -> str:
         return f"Image, dimensions: {self.width}x{self.height}, type: {self.mime_type}, size: {len(self.value)} bytes"

--- a/griptape/schemas/artifacts/image_artifact_schema.py
+++ b/griptape/schemas/artifacts/image_artifact_schema.py
@@ -3,7 +3,7 @@ from griptape.schemas import BaseArtifactSchema
 
 
 class ImageArtifactSchema(BaseArtifactSchema):
-    value = fields.Str()
+    base64 = fields.Str()
     mime_type = fields.Str()
     width = fields.Int()
     height = fields.Int()
@@ -13,5 +13,12 @@ class ImageArtifactSchema(BaseArtifactSchema):
     @post_load
     def make_obj(self, data, **kwargs):
         from griptape.artifacts import ImageArtifact
+
+        if "base64" in data:
+            import base64
+
+            image_bytes = base64.b64decode(data["base64"])
+            data["value"] = image_bytes
+            del data["base64"]
 
         return ImageArtifact(**data)

--- a/tests/unit/artifacts/test_base_artifact.py
+++ b/tests/unit/artifacts/test_base_artifact.py
@@ -49,7 +49,7 @@ class TestBaseArtifact:
     def test_image_artifact_from_dict(self):
         dict_value = {
             "type": "ImageArtifact",
-            "value": b"aW1hZ2UgZGF0YQ==",
+            "base64": b"aW1hZ2UgZGF0YQ==",
             "mime_type": "image/png",
             "width": 256,
             "height": 256,
@@ -59,7 +59,8 @@ class TestBaseArtifact:
         artifact = BaseArtifact.from_dict(dict_value)
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.to_text() == "Image, dimensions: 256x256, type: image/png, size: 16 bytes"
+        assert artifact.to_text() == "Image, dimensions: 256x256, type: image/png, size: 10 bytes"
+        assert artifact.value == b"image data"
 
     def test_unsupported_from_dict(self):
         dict_value = {"type": "foo", "value": "foobar"}

--- a/tests/unit/artifacts/test_base_artifact.py
+++ b/tests/unit/artifacts/test_base_artifact.py
@@ -1,5 +1,13 @@
 import pytest
-from griptape.artifacts import BaseArtifact, TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact, BlobArtifact
+from griptape.artifacts import (
+    BaseArtifact,
+    TextArtifact,
+    ErrorArtifact,
+    InfoArtifact,
+    ListArtifact,
+    BlobArtifact,
+    ImageArtifact,
+)
 
 
 class TestBaseArtifact:
@@ -37,6 +45,21 @@ class TestBaseArtifact:
 
         assert isinstance(artifact, BlobArtifact)
         assert artifact.to_text() == "foobar"
+
+    def test_image_artifact_from_dict(self):
+        dict_value = {
+            "type": "ImageArtifact",
+            "value": b"aW1hZ2UgZGF0YQ==",
+            "mime_type": "image/png",
+            "width": 256,
+            "height": 256,
+            "model": "test-model",
+            "prompt": "some prompt",
+        }
+        artifact = BaseArtifact.from_dict(dict_value)
+
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.to_text() == "Image, dimensions: 256x256, type: image/png, size: 16 bytes"
 
     def test_unsupported_from_dict(self):
         dict_value = {"type": "foo", "value": "foobar"}

--- a/tests/unit/artifacts/test_image_artifact.py
+++ b/tests/unit/artifacts/test_image_artifact.py
@@ -1,9 +1,11 @@
+import base64
+
 import pytest
 from griptape.artifacts import ImageArtifact, BaseArtifact
 from griptape.schemas import ImageArtifactSchema
 
 
-class TestBlobArtifact:
+class TestImageArtifact:
     @pytest.fixture
     def image_artifact(self):
         return ImageArtifact(
@@ -26,6 +28,8 @@ class TestBlobArtifact:
         assert image_dict["height"] == 512
         assert image_dict["model"] == "openai/dalle2"
         assert image_dict["prompt"] == "a cute cat"
+        assert image_dict["base64"] == "c29tZSBiaW5hcnkgcG5nIGltYWdlIGRhdGE="
+        assert "value" not in image_dict
 
     def test_deserialization(self, image_artifact):
         artifact_dict = ImageArtifactSchema().dump(image_artifact)
@@ -37,3 +41,4 @@ class TestBlobArtifact:
         assert deserialized_artifact.height == 512
         assert deserialized_artifact.model == "openai/dalle2"
         assert deserialized_artifact.prompt == "a cute cat"
+        assert deserialized_artifact.base64 == "c29tZSBiaW5hcnkgcG5nIGltYWdlIGRhdGE="


### PR DESCRIPTION
This PR overhauls ImageArtifact serialization/deserialization to encode the underlying image bytes as base64 when serializing and decode back to raw bytes when deserializing. While it was tempting to just work with base64 image data from end to end, it's important that `ImageArtifact.value` contains raw bytes for access by downstream tools. For example, FileManager needs access to raw image byte data to write a valid image file.

Unit tests have been updated to confirm bidirectional functionality.