### PR TITLE
Specify image output file directly in image generation tool/task

### DIFF
--- a/griptape/tasks/image_generation_task.py
+++ b/griptape/tasks/image_generation_task.py
@@ -18,12 +18,14 @@ class ImageGenerationTask(BaseTextInputTask):
     Attributes:
         image_generation_engine: The engine used to generate the image.
         output_dir: If provided, the generated image will be written to disk in output_dir.
+        output_file: If provided, the generated image will be written to disk as output_file.
     """
 
     NEGATIVE_RULESET_NAME = "Negative Ruleset"
 
     image_generation_engine: ImageGenerationEngine = field(kw_only=True)
     output_dir: Optional[str] = field(default=None, kw_only=True)
+    output_file: Optional[str] = field(default=None, kw_only=True)
     negative_rulesets: list[Ruleset] = field(factory=list, kw_only=True)
     negative_rules: list[Rule] = field(factory=list, kw_only=True)
 
@@ -43,6 +45,22 @@ class ImageGenerationTask(BaseTextInputTask):
         if self.negative_rulesets:
             raise ValueError("Can't have both negative_rules and negative_rulesets specified.")
 
+    @output_dir.validator
+    def validate_output_dir(self, _, output_dir: str) -> None:
+        if not output_dir:
+            return
+
+        if self.output_file:
+            raise ValueError("Can't have both output_dir and output_file specified.")
+
+    @output_file.validator
+    def validate_output_file(self, _, output_file: str) -> None:
+        if not output_file:
+            return
+
+        if self.output_dir:
+            raise ValueError("Can't have both output_dir and output_file specified.")
+
     @property
     def all_negative_rulesets(self) -> list[Ruleset]:
         task_rulesets = []
@@ -59,7 +77,7 @@ class ImageGenerationTask(BaseTextInputTask):
             prompts=[self.input.to_text()], rulesets=self.all_rulesets, negative_rulesets=self.negative_rulesets
         )
 
-        if self.output_dir is not None:
+        if self.output_dir or self.output_file:
             self._write_to_file(image_artifact)
 
         return image_artifact
@@ -67,8 +85,12 @@ class ImageGenerationTask(BaseTextInputTask):
     def _write_to_file(self, image_artifact: ImageArtifact) -> None:
         # Save image to file. This is a temporary workaround until we update Task and Meta
         # Memory to persist artifacts from tasks.
-        outfile = path.join(self.output_dir, image_artifact.name)
+        if self.output_file:
+            outfile = self.output_file
+        else:
+            outfile = path.join(self.output_dir, image_artifact.name)
 
+        os.makedirs(self.output_dir, exist_ok=True)
         with open(outfile, "wb") as f:
             self.structure.logger.info(f"Saving [{image_artifact.to_text()}] to {os.path.abspath(outfile)}")
             f.write(image_artifact.value)

--- a/griptape/tasks/image_generation_task.py
+++ b/griptape/tasks/image_generation_task.py
@@ -90,7 +90,7 @@ class ImageGenerationTask(BaseTextInputTask):
         else:
             outfile = path.join(self.output_dir, image_artifact.name)
 
-        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(path.dirname(outfile), exist_ok=True)
         with open(outfile, "wb") as f:
             self.structure.logger.info(f"Saving [{image_artifact.to_text()}] to {os.path.abspath(outfile)}")
             f.write(image_artifact.value)

--- a/tests/unit/tasks/test_image_generation_task.py
+++ b/tests/unit/tasks/test_image_generation_task.py
@@ -53,3 +53,7 @@ class TestImageGenerationTask:
 
         assert task.all_negative_rulesets[0].name == task.NEGATIVE_RULESET_NAME
         assert task.all_negative_rulesets[0].rules[0] == rule
+
+    def test_validate_output_dir(self, engine):
+        with pytest.raises(ValueError):
+            ImageGenerationTask(image_generation_engine=engine, output_dir="some/dir", output_file="some/file")

--- a/tests/unit/tools/test_image_generator.py
+++ b/tests/unit/tools/test_image_generator.py
@@ -1,4 +1,7 @@
+import os
+import tempfile
 import unittest
+import uuid
 from unittest.mock import Mock
 
 import pytest
@@ -15,6 +18,10 @@ class TestImageGenerator:
     def image_generator(self, image_generation_engine):
         return ImageGenerator(image_generation_engine=image_generation_engine)
 
+    def test_validate_output_configs(self, image_generation_engine):
+        with pytest.raises(ValueError):
+            ImageGenerator(image_generation_engine=image_generation_engine, output_dir="test", output_file="test")
+
     def test_generate_image(self, image_generator):
         image_generator.image_generation_engine.generate_image.return_value = Mock(
             value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
@@ -25,6 +32,21 @@ class TestImageGenerator:
         )
 
         assert image_artifact
+
+    def test_generate_image_with_outfile(self, image_generation_engine):
+        outfile = f"{tempfile.gettempdir()}/{str(uuid.uuid4())}.png"
+        image_generator = ImageGenerator(image_generation_engine=image_generation_engine, output_file=outfile)
+
+        image_generator.image_generation_engine.generate_image.return_value = Mock(
+            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+        )
+
+        image_artifact = image_generator.generate_image(
+            params={"values": {"prompts": ["test prompt"], "negative_prompts": ["test negative prompt"]}}
+        )
+
+        assert image_artifact
+        assert os.path.exists(outfile)
 
     def test_generate_image_returns_error_artifact_on_exception(self, image_generator):
         image_generator.image_generation_engine.generate_image.side_effect = Exception("test exception")


### PR DESCRIPTION
Previously, the image generation tool and task accepted an output directory, but filenames were generated based on the artifact creation time. This allows a developer to specify the output filename directly, which helps when incorporating a generated image into the rest of a program.