### PR TITLE
Add driver support for Azure-hosted OpenAI DALL-E models

### DIFF
--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -47,6 +47,7 @@ from .image_generation.base_multi_model_image_generation_driver import BaseMulti
 from .image_generation.openai_dalle_image_generation_driver import OpenAiDalleImageGenerationDriver
 from .image_generation.leonardo_image_generation_driver import LeonardoImageGenerationDriver
 from .image_generation.amazon_bedrock_image_generation_driver import AmazonBedrockImageGenerationDriver
+from .image_generation.azure_openai_dalle_image_generation import AzureOpenAiDalleImageGenerationDriver
 
 from .image_generation_model.base_image_generation_model_driver import BaseImageGenerationModelDriver
 from .image_generation_model.amazon_bedrock_titan_image_generation_model_driver import (
@@ -103,4 +104,5 @@ __all__ = [
     "BaseImageGenerationModelDriver",
     "AmazonBedrockTitanImageGenerationModelDriver",
     "AmazonBedrockStableDiffusionImageGenerationModelDriver",
+    "AzureOpenAiDalleImageGenerationDriver",
 ]

--- a/griptape/drivers/image_generation/azure_openai_dalle_image_generation.py
+++ b/griptape/drivers/image_generation/azure_openai_dalle_image_generation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import openai
+from typing import Optional
+from attr import field, Factory, define
+from griptape.drivers import OpenAiDalleImageGenerationDriver
+
+
+@define
+class AzureOpenAiDalleImageGenerationDriver(OpenAiDalleImageGenerationDriver):
+    """Driver for Azure-hosted OpenAI DALLE image generation API.
+
+    Attributes:
+        azure_deployment: An Azure OpenAi deployment id.
+        azure_endpoint: An Azure OpenAi endpoint.
+        azure_ad_token: An optional Azure Active Directory token.
+        azure_ad_token_provider: An optional Azure Active Directory token provider.
+        api_version: An Azure OpenAi API version.
+        client: An `openai.AzureOpenAI` client.
+    """
+
+    azure_deployment: str = field(kw_only=True)
+    azure_endpoint: str = field(kw_only=True)
+    azure_ad_token: Optional[str] = field(kw_only=True, default=None)
+    azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None)
+    api_version: str = field(default="2023-12-01-preview", kw_only=True)
+    client: openai.AzureOpenAI = field(
+        default=Factory(
+            lambda self: openai.AzureOpenAI(
+                organization=self.organization,
+                api_key=self.api_key,
+                api_version=self.api_version,
+                azure_endpoint=self.azure_endpoint,
+                azure_deployment=self.azure_deployment,
+                azure_ad_token=self.azure_ad_token,
+                azure_ad_token_provider=self.azure_ad_token_provider,
+            ),
+            takes_self=True,
+        )
+    )

--- a/tests/unit/drivers/image_generation/test_azure_openai_dalle_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_azure_openai_dalle_image_generation_driver.py
@@ -1,0 +1,44 @@
+from typing import Literal
+
+import pytest
+from unittest.mock import Mock
+from griptape.drivers import AzureOpenAiDalleImageGenerationDriver
+
+
+class TestAzureOpenAiDalleImageGenerationDriver:
+    @pytest.fixture
+    def driver(self):
+        return AzureOpenAiDalleImageGenerationDriver(
+            model="dall-e-3",
+            client=Mock(),
+            azure_endpoint="https://dalle.example.com",
+            azure_deployment="dalle-deployment",
+            image_size="512x512",
+        )
+
+    def test_init(self, driver):
+        assert driver
+
+    def test_init_requires_endpoint(self):
+        with pytest.raises(TypeError):
+            AzureOpenAiDalleImageGenerationDriver(
+                model="dall-e-3", client=Mock(), azure_deployment="dalle-deployment", image_size="512x512"
+            )
+
+    def test_init_requires_deployment(self):
+        with pytest.raises(TypeError):
+            AzureOpenAiDalleImageGenerationDriver(
+                model="dall-e-3", client=Mock(), azure_endpoint="https://dalle.example.com", image_size="512x512"
+            )
+
+    def test_generate_image(self, driver):
+        driver.client.images.generate.return_value = Mock(data=[Mock(b64_json=b"aW1hZ2UgZGF0YQ==")])
+
+        image_artifact = driver.generate_image(prompts=["test prompt"])
+
+        assert image_artifact.value == b"image data"
+        assert image_artifact.mime_type == "image/png"
+        assert image_artifact.width == 512
+        assert image_artifact.height == 512
+        assert image_artifact.model == "dall-e-3"
+        assert image_artifact.prompt == "test prompt"


### PR DESCRIPTION
This PR adds first-class driver support for Azure-host OpenAI DALL-E models, reflecting the structure of OpenAI and Azure-hosted OpenAI prompt drivers. Tested locally and on Griptape Cloud 💪 

Closes #476