### PR TITLE
Add simple tokenizer

### DIFF
--- a/griptape/drivers/embedding/bedrock_titan_embedding_driver.py
+++ b/griptape/drivers/embedding/bedrock_titan_embedding_driver.py
@@ -28,8 +28,7 @@ class BedrockTitanEmbeddingDriver(BaseEmbeddingDriver):
     dimensions: int = field(default=DEFAULT_MAX_TOKENS, kw_only=True)
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     tokenizer: BedrockTitanTokenizer = field(
-        default=Factory(lambda self: BedrockTitanTokenizer(model=self.model, session=self.session), takes_self=True),
-        kw_only=True,
+        default=Factory(lambda self: BedrockTitanTokenizer(model=self.model), takes_self=True), kw_only=True
     )
     bedrock_client: Any = field(
         default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True

--- a/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
@@ -34,9 +34,7 @@ class BedrockJurassicPromptModelDriver(BasePromptModelDriver):
         if self._tokenizer:
             return self._tokenizer
         else:
-            self._tokenizer = BedrockJurassicTokenizer(
-                model=self.prompt_driver.model, session=self.prompt_driver.session
-            )
+            self._tokenizer = BedrockJurassicTokenizer(model=self.prompt_driver.model)
             return self._tokenizer
 
     def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> dict:

--- a/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
@@ -34,7 +34,7 @@ class BedrockTitanPromptModelDriver(BasePromptModelDriver):
         if self._tokenizer:
             return self._tokenizer
         else:
-            self._tokenizer = BedrockTitanTokenizer(model=self.prompt_driver.model, session=self.prompt_driver.session)
+            self._tokenizer = BedrockTitanTokenizer(model=self.prompt_driver.model)
             return self._tokenizer
 
     def prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> dict:

--- a/griptape/tokenizers/__init__.py
+++ b/griptape/tokenizers/__init__.py
@@ -6,6 +6,7 @@ from griptape.tokenizers.anthropic_tokenizer import AnthropicTokenizer
 from griptape.tokenizers.bedrock_titan_tokenizer import BedrockTitanTokenizer
 from griptape.tokenizers.bedrock_jurassic_tokenizer import BedrockJurassicTokenizer
 from griptape.tokenizers.bedrock_claude_tokenizer import BedrockClaudeTokenizer
+from griptape.tokenizers.simple_tokenizer import SimpleTokenizer
 
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "BedrockTitanTokenizer",
     "BedrockJurassicTokenizer",
     "BedrockClaudeTokenizer",
+    "SimpleTokenizer",
 ]

--- a/griptape/tokenizers/bedrock_jurassic_tokenizer.py
+++ b/griptape/tokenizers/bedrock_jurassic_tokenizer.py
@@ -1,24 +1,14 @@
 from __future__ import annotations
 from attr import define, field
-from .base_tokenizer import BaseTokenizer
 from .simple_tokenizer import SimpleTokenizer
 
 
 @define(frozen=True)
-class BedrockJurassicTokenizer(BaseTokenizer):
+class BedrockJurassicTokenizer(SimpleTokenizer):
     DEFAULT_MODEL = "ai21.j2-ultra-v1"
     DEFAULT_MAX_TOKENS = 8192
     DEFAULT_CHARACTERS_PER_TOKEN = 6  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html#model-customization-prepare-finetuning
 
+    characters_per_token: int = field(default=DEFAULT_CHARACTERS_PER_TOKEN, kw_only=True)
+    max_tokens: int = field(default=DEFAULT_MAX_TOKENS, kw_only=True)
     model: str = field(kw_only=True)
-    tokenizer: SimpleTokenizer = field(
-        default=SimpleTokenizer(max_tokens=DEFAULT_MAX_TOKENS, characters_per_token=DEFAULT_CHARACTERS_PER_TOKEN),
-        kw_only=True,
-    )
-
-    @property
-    def max_tokens(self) -> int:
-        return self.DEFAULT_MAX_TOKENS
-
-    def count_tokens(self, text: str) -> int:
-        return self.tokenizer.count_tokens(text)

--- a/griptape/tokenizers/bedrock_jurassic_tokenizer.py
+++ b/griptape/tokenizers/bedrock_jurassic_tokenizer.py
@@ -1,23 +1,17 @@
 from __future__ import annotations
-import json
-from attr import define, field, Factory
-from typing import TYPE_CHECKING, Any
-from griptape.utils import import_optional_dependency
-from griptape.tokenizers import BaseTokenizer
-
-if TYPE_CHECKING:
-    import boto3
+from attr import define, field
+from griptape.tokenizers import BaseTokenizer, SimpleTokenizer
 
 
 @define(frozen=True)
 class BedrockJurassicTokenizer(BaseTokenizer):
     DEFAULT_MODEL = "ai21.j2-ultra-v1"
     DEFAULT_MAX_TOKENS = 8192
+    DEFAULT_CHARACTERS_PER_TOKEN = 6  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html#model-customization-prepare-finetuning
 
-    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    model: str = field(kw_only=True)
-    bedrock_client: Any = field(
-        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True), kw_only=True
+    tokenizer: SimpleTokenizer = field(
+        default=SimpleTokenizer(max_tokens=DEFAULT_MAX_TOKENS, characters_per_token=DEFAULT_CHARACTERS_PER_TOKEN),
+        kw_only=True,
     )
 
     @property
@@ -25,11 +19,4 @@ class BedrockJurassicTokenizer(BaseTokenizer):
         return self.DEFAULT_MAX_TOKENS
 
     def count_tokens(self, text: str) -> int:
-        payload = {"prompt": text}
-
-        response = self.bedrock_client.invoke_model(
-            body=json.dumps(payload), modelId=self.model, accept="application/json", contentType="application/json"
-        )
-        response_body = json.loads(response.get("body").read())
-
-        return len(response_body["prompt"]["tokens"])
+        return self.tokenizer.count_tokens(text)

--- a/griptape/tokenizers/bedrock_jurassic_tokenizer.py
+++ b/griptape/tokenizers/bedrock_jurassic_tokenizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from attr import define, field
-from griptape.tokenizers import BaseTokenizer, SimpleTokenizer
+from .base_tokenizer import BaseTokenizer
+from .simple_tokenizer import SimpleTokenizer
 
 
 @define(frozen=True)
@@ -9,6 +10,7 @@ class BedrockJurassicTokenizer(BaseTokenizer):
     DEFAULT_MAX_TOKENS = 8192
     DEFAULT_CHARACTERS_PER_TOKEN = 6  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html#model-customization-prepare-finetuning
 
+    model: str = field(kw_only=True)
     tokenizer: SimpleTokenizer = field(
         default=SimpleTokenizer(max_tokens=DEFAULT_MAX_TOKENS, characters_per_token=DEFAULT_CHARACTERS_PER_TOKEN),
         kw_only=True,

--- a/griptape/tokenizers/bedrock_titan_tokenizer.py
+++ b/griptape/tokenizers/bedrock_titan_tokenizer.py
@@ -1,24 +1,14 @@
 from __future__ import annotations
 from attr import define, field
-from .base_tokenizer import BaseTokenizer
 from .simple_tokenizer import SimpleTokenizer
 
 
 @define(frozen=True)
-class BedrockTitanTokenizer(BaseTokenizer):
+class BedrockTitanTokenizer(SimpleTokenizer):
     DEFAULT_MODEL = "amazon.titan-text-express-v1"
     DEFAULT_CHARACTERS_PER_TOKEN = 6  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html#model-customization-prepare-finetuning
     DEFAULT_MAX_TOKENS = 4096
 
+    characters_per_token: int = field(default=DEFAULT_CHARACTERS_PER_TOKEN, kw_only=True)
+    max_tokens: int = field(default=DEFAULT_MAX_TOKENS, kw_only=True)
     model: str = field(kw_only=True)
-    tokenizer: SimpleTokenizer = field(
-        default=SimpleTokenizer(max_tokens=DEFAULT_MAX_TOKENS, characters_per_token=DEFAULT_CHARACTERS_PER_TOKEN),
-        kw_only=True,
-    )
-
-    @property
-    def max_tokens(self) -> int:
-        return self.DEFAULT_MAX_TOKENS
-
-    def count_tokens(self, text: str) -> int:
-        return self.tokenizer.count_tokens(text)

--- a/griptape/tokenizers/bedrock_titan_tokenizer.py
+++ b/griptape/tokenizers/bedrock_titan_tokenizer.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 from attr import define, field
-from griptape.tokenizers import BaseTokenizer, SimpleTokenizer
+from .base_tokenizer import BaseTokenizer
+from .simple_tokenizer import SimpleTokenizer
 
 
 @define(frozen=True)
 class BedrockTitanTokenizer(BaseTokenizer):
+    DEFAULT_MODEL = "amazon.titan-text-express-v1"
     DEFAULT_CHARACTERS_PER_TOKEN = 6  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html#model-customization-prepare-finetuning
     DEFAULT_MAX_TOKENS = 4096
 
-    DEFAULT_EMBEDDING_MODELS = "amazon.titan-embed-text-v1"
-
+    model: str = field(kw_only=True)
     tokenizer: SimpleTokenizer = field(
         default=SimpleTokenizer(max_tokens=DEFAULT_MAX_TOKENS, characters_per_token=DEFAULT_CHARACTERS_PER_TOKEN),
         kw_only=True,

--- a/griptape/tokenizers/simple_tokenizer.py
+++ b/griptape/tokenizers/simple_tokenizer.py
@@ -1,0 +1,13 @@
+from attr import define, field
+from griptape.tokenizers import BaseTokenizer
+
+
+@define(frozen=True)
+class SimpleTokenizer(BaseTokenizer):
+    characters_per_token: int = field(kw_only=True)
+    max_tokens: int = field(kw_only=True)
+
+    def count_tokens(self, text: str) -> int:
+        num_tokens = (len(text) + self.characters_per_token - 1) // self.characters_per_token
+
+        return num_tokens

--- a/tests/unit/drivers/prompt_models/test_bedrock_jurassic_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_jurassic_prompt_model_driver.py
@@ -62,7 +62,7 @@ class TestBedrockJurassicPromptModelDriver:
         assert model_input["prompt"].startswith("Instructions: foo\nUser: bar\nBot:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert driver.prompt_stack_to_model_params(stack)["maxTokens"] == 8189
+        assert driver.prompt_stack_to_model_params(stack)["maxTokens"] == 8186
         assert driver.prompt_stack_to_model_params(stack)["temperature"] == 0.12345
 
     def test_process_output(self, driver):
@@ -70,6 +70,3 @@ class TestBedrockJurassicPromptModelDriver:
             driver.process_output(json.dumps({"completions": [{"data": {"text": "foobar"}}]}).encode()).value
             == "foobar"
         )
-
-    def test_session_initialization(self, driver, mock_session):
-        assert driver.tokenizer.session == mock_session

--- a/tests/unit/drivers/prompt_models/test_bedrock_titan_prompt_model_driver.py
+++ b/tests/unit/drivers/prompt_models/test_bedrock_titan_prompt_model_driver.py
@@ -52,11 +52,8 @@ class TestBedrockTitanPromptModelDriver:
         assert model_input["inputText"].startswith("Instructions: foo\n\nUser: bar\n\nBot:")
 
     def test_prompt_stack_to_model_params(self, driver, stack):
-        assert driver.prompt_stack_to_model_params(stack)["textGenerationConfig"]["maxTokenCount"] == 4083
+        assert driver.prompt_stack_to_model_params(stack)["textGenerationConfig"]["maxTokenCount"] == 4090
         assert driver.prompt_stack_to_model_params(stack)["textGenerationConfig"]["temperature"] == 0.12345
 
     def test_process_output(self, driver):
         assert driver.process_output(json.dumps({"results": [{"outputText": "foobar"}]})).value == "foobar"
-
-    def test_session_initialization(self, driver, mock_session):
-        assert driver.tokenizer.session == mock_session

--- a/tests/unit/tokenizers/test_bedrock_jurassic_tokenizer.py
+++ b/tests/unit/tokenizers/test_bedrock_jurassic_tokenizer.py
@@ -20,5 +20,8 @@ class TestBedrockJurassicTokenizer:
 
     def test_titan_tokens_left(self):
         assert (
-            BedrockJurassicTokenizer(model=BedrockJurassicTokenizer.DEFAULT_MODEL).count_tokens_left("foo bar") == 8189
+            BedrockJurassicTokenizer(model=BedrockJurassicTokenizer.DEFAULT_MODEL).count_tokens_left(
+                "Instructions: foo\nUser: bar\nBot:"
+            )
+            == 8186
         )

--- a/tests/unit/tokenizers/test_bedrock_titan_tokenizer.py
+++ b/tests/unit/tokenizers/test_bedrock_titan_tokenizer.py
@@ -19,4 +19,9 @@ class TestBedrockTitanTokenizer:
         mock_session_class.return_value = mock_session_object
 
     def test_titan_tokens_left(self):
-        assert BedrockTitanTokenizer(model=BedrockTitanTokenizer.DEFAULT_MODEL).count_tokens_left("foo bar") == 4083
+        assert (
+            BedrockTitanTokenizer(model=BedrockTitanTokenizer.DEFAULT_MODEL).count_tokens_left(
+                "Instructions: foo\nUser: bar\nBot:"
+            )
+            == 4090
+        )

--- a/tests/unit/tokenizers/test_simple_tokenizer.py
+++ b/tests/unit/tokenizers/test_simple_tokenizer.py
@@ -1,0 +1,14 @@
+import pytest
+from griptape.tokenizers import SimpleTokenizer
+
+
+class TestSimpleTokenizer:
+    @pytest.fixture
+    def tokenizer(self):
+        return SimpleTokenizer(max_tokens=1024, characters_per_token=6)
+
+    def test_token_count(self, tokenizer):
+        assert tokenizer.count_tokens("foo bar huzzah") == 3
+
+    def test_tokens_left(self, tokenizer):
+        assert tokenizer.count_tokens_left("foo bar huzzah") == 1021


### PR DESCRIPTION
This PR adds `SimpleTokenizer` which serves as an approximate Tokenizer for LLM providers that do not provide Tokenization APIs (Bedrock). The tokenizer allows for users to specify `max_tokens` and `characters_per_token`.