### PR TITLE
Replace positional args with named args

### DIFF
--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -31,7 +31,7 @@ class VectorQueryEngine(BaseQueryEngine):
         rulesets: Optional[str] = None,
     ) -> TextArtifact:
         tokenizer = self.prompt_driver.tokenizer
-        result = self.vector_store_driver.query(query, top_n, namespace)
+        result = self.vector_store_driver.query(query, top_n=top_n, namespace=namespace)
         artifacts = [
             a for a in [BaseArtifact.from_json(r.meta["artifact"]) for r in result] if isinstance(a, TextArtifact)
         ]


### PR DESCRIPTION
Base Vector Store Driver expects only a single positional arg ([query](https://github.com/griptape-ai/griptape/blob/dev/griptape/drivers/vector/base_vector_store_driver.py#L97)). The rest should be named.