### PR TITLE
Revert Named Args, Fix OpenSearch Positional Args

### DIFF
--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -122,10 +122,10 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
         self,
         query: str,
         count: Optional[int] = None,
-        field_name: str = "vector",
         namespace: Optional[str] = None,
         include_vectors: bool = False,
         include_metadata=True,
+        field_name: str = "vector",
         **kwargs,
     ) -> list[BaseVectorStoreDriver.QueryResult]:
         """Performs a nearest neighbor search on OpenSearch to find vectors similar to the provided query string.

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -31,7 +31,7 @@ class VectorQueryEngine(BaseQueryEngine):
         rulesets: Optional[str] = None,
     ) -> TextArtifact:
         tokenizer = self.prompt_driver.tokenizer
-        result = self.vector_store_driver.query(query, top_n=top_n, namespace=namespace)
+        result = self.vector_store_driver.query(query, top_n, namespace)
         artifacts = [
             a for a in [BaseArtifact.from_json(r.meta["artifact"]) for r in result] if isinstance(a, TextArtifact)
         ]


### PR DESCRIPTION
Reverts https://github.com/griptape-ai/griptape/commit/6c59ccc2762169f14c22bd3653741370fc3349f5 and applies what the original fix should've been.