### PR TITLE
Accept `TextArtifact` Input in `BaseTextInputTask`

### DIFF
--- a/griptape/artifacts/list_artifact.py
+++ b/griptape/artifacts/list_artifact.py
@@ -23,6 +23,9 @@ class ListArtifact(BaseArtifact):
         else:
             return None
 
+    def __getitem__(self, key: int) -> BaseArtifact:
+        return self.value[key]
+
     def __bool__(self) -> bool:
         return len(self) > 0
 

--- a/griptape/memory/task/task_memory.py
+++ b/griptape/memory/task/task_memory.py
@@ -67,7 +67,7 @@ class TaskMemory(ActivityMixin):
                         ActionSubtaskMetaEntry(thought=subtask.thought, action=subtask.action_to_json(), answer=output)
                     )
 
-                return InfoArtifact(output)
+                return InfoArtifact(output, name=namespace)
         else:
             return InfoArtifact("tool output is empty")
 

--- a/griptape/tasks/action_subtask.py
+++ b/griptape/tasks/action_subtask.py
@@ -33,6 +33,7 @@ class ActionSubtask(PromptTask):
         },
     )
 
+    _input: str | None = field(default=None)
     parent_task_id: str | None = field(default=None, kw_only=True)
     thought: str | None = field(default=None, kw_only=True)
     action_name: str | None = field(default=None, kw_only=True)
@@ -41,6 +42,10 @@ class ActionSubtask(PromptTask):
 
     _tool: BaseTool | None = None
     _memory: TaskMemory | None = None
+
+    @property
+    def input(self) -> TextArtifact:
+        return TextArtifact(self._input)
 
     @property
     def origin_task(self) -> ActionSubtaskOriginMixin | None:

--- a/griptape/tasks/action_subtask.py
+++ b/griptape/tasks/action_subtask.py
@@ -43,10 +43,6 @@ class ActionSubtask(PromptTask):
     _memory: TaskMemory | None = None
 
     @property
-    def input(self) -> TextArtifact:
-        return TextArtifact(self.input_template)
-
-    @property
     def origin_task(self) -> ActionSubtaskOriginMixin | None:
         return self.structure.find_task(self.parent_task_id)
 

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -15,7 +15,6 @@ class BaseTextInputTask(BaseTask, ABC):
     DEFAULT_RULESET_NAME = "Default Ruleset"
     ADDITIONAL_RULESET_NAME = "Additional Ruleset"
 
-    input_artifact_namespace: str | None = field(default=None, kw_only=True)
     input_template: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(default=DEFAULT_INPUT_TEMPLATE)
     context: dict[str, Any] = field(factory=dict, kw_only=True)
     rulesets: list[Ruleset] = field(factory=list, kw_only=True)

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import Any, Optional, Callable
+from typing import Any, Callable
 
 from attr import define, field
 from griptape.artifacts import TextArtifact

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -15,19 +15,23 @@ class BaseTextInputTask(BaseTask, ABC):
     DEFAULT_RULESET_NAME = "Default Ruleset"
     ADDITIONAL_RULESET_NAME = "Additional Ruleset"
 
-    input_template: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(default=DEFAULT_INPUT_TEMPLATE)
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(default=DEFAULT_INPUT_TEMPLATE)
     context: dict[str, Any] = field(factory=dict, kw_only=True)
     rulesets: list[Ruleset] = field(factory=list, kw_only=True)
     rules: list[Rule] = field(factory=list, kw_only=True)
 
     @property
     def input(self) -> TextArtifact:
-        if isinstance(self.input_template, TextArtifact):
-            return self.input_template
-        elif isinstance(self.input_template, Callable):
-            return self.input_template(self)
+        if isinstance(self._input, TextArtifact):
+            return self._input
+        elif isinstance(self._input, Callable):
+            return self._input(self)
         else:
-            return TextArtifact(J2().render_from_string(self.input_template, **self.full_context))
+            return TextArtifact(J2().render_from_string(self._input, **self.full_context))
+
+    @input.setter
+    def input(self, value: str | TextArtifact | Callable[[BaseTask], TextArtifact]) -> None:
+        self._input = value
 
     @property
     def full_context(self) -> dict[str, Any]:

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -123,7 +123,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
                     subtask.output = ErrorArtifact(f"Exceeded tool limit of {self.max_subtasks} subtasks per task")
                 elif subtask.action_name is None:
                     # handle case when the LLM failed to follow the ReAct prompt and didn't return a proper action
-                    subtask.output = TextArtifact(subtask.input_template)
+                    subtask.output = self.input
                 else:
                     subtask.before_run()
                     subtask.run()

--- a/tests/unit/artifacts/test_list_artifact.py
+++ b/tests/unit/artifacts/test_list_artifact.py
@@ -10,6 +10,10 @@ class TestListArtifact:
     def test_to_dict(self):
         assert ListArtifact([TextArtifact("foobar")]).to_dict()["value"][0]["value"] == "foobar"
 
+    def test__getitem__(self):
+        assert ListArtifact([TextArtifact("foo"), TextArtifact("bar")])[0].value == "foo"
+        assert ListArtifact([TextArtifact("foo"), TextArtifact("bar")])[1].value == "bar"
+
     def test___add__(self):
         artifact = ListArtifact([TextArtifact("foo")]) + ListArtifact([TextArtifact("bar")])
 

--- a/tests/unit/memory/tool/test_task_memory.py
+++ b/tests/unit/memory/tool/test_task_memory.py
@@ -36,6 +36,7 @@ class TestTaskMemory:
         assert memory.store_artifact("btest", BlobArtifact(b"foo4")) is None
         assert isinstance(memory.store_artifact("btest", TextArtifact("foo5")), ErrorArtifact)
         assert isinstance(memory.store_artifact("test", InfoArtifact("foo1")), InfoArtifact)
+        assert memory.store_artifact("test", InfoArtifact("foo1", name="foobar")).name == "foobar"
         assert memory.store_artifact("test", ListArtifact([TextArtifact("foo1")])) is None
 
     def test_find_input_memory(self, memory):

--- a/tests/unit/tasks/test_base_text_input_task.py
+++ b/tests/unit/tasks/test_base_text_input_task.py
@@ -1,12 +1,19 @@
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 from griptape.structures import Pipeline
+from griptape.artifacts import TextArtifact
 from griptape.rules import Ruleset, Rule
 from tests.mocks.mock_text_input_task import MockTextInputTask
 
 
 class TestBaseTextInputTask:
-    def test_input(self):
+    def test_string_input(self):
         assert MockTextInputTask("foobar").input.value == "foobar"
+
+    def test_artifact_input(self):
+        assert MockTextInputTask(TextArtifact("foobar")).input.value == "foobar"
+
+    def test_callable_input(self):
+        assert MockTextInputTask(lambda _: TextArtifact("foobar")).input.value == "foobar"
 
     def test_full_context(self):
         parent = MockTextInputTask("parent")

--- a/tests/unit/tasks/test_base_text_input_task.py
+++ b/tests/unit/tasks/test_base_text_input_task.py
@@ -9,11 +9,23 @@ class TestBaseTextInputTask:
     def test_string_input(self):
         assert MockTextInputTask("foobar").input.value == "foobar"
 
+        task = MockTextInputTask()
+        task.input = "foobar"
+        assert task.input.value == "foobar"
+
     def test_artifact_input(self):
         assert MockTextInputTask(TextArtifact("foobar")).input.value == "foobar"
 
+        task = MockTextInputTask()
+        task.input = TextArtifact("foobar")
+        assert task.input.value == "foobar"
+
     def test_callable_input(self):
         assert MockTextInputTask(lambda _: TextArtifact("foobar")).input.value == "foobar"
+
+        task = MockTextInputTask()
+        task.input = lambda _: TextArtifact("foobar")
+        assert task.input.value == "foobar"
 
     def test_full_context(self):
         parent = MockTextInputTask("parent")

--- a/tests/unit/tasks/test_text_query_task.py
+++ b/tests/unit/tasks/test_text_query_task.py
@@ -27,7 +27,7 @@ class TestTextQueryTask:
         assert task.run().to_text() == "mock output"
 
     def test_context_propagation(self, task):
-        task.input_template = "{{ test }}"
+        task.input = "{{ test }}"
         task.context = {"test": "test value"}
 
         Agent().add_task(task)


### PR DESCRIPTION
Adds support for passing in `TextArtifact` for `BaseTextInputTask.input_template` either directly for through a Callable. Sets up #425 nicely, and enables use-cases like this:

```python
from typing import cast
from griptape.drivers import OpenAiDalleImageGenerationDriver
from griptape.structures import Pipeline
from griptape.tools import WebScraper
from griptape.tasks import ToolTask, ImageGenerationTask
from griptape.engines import ImageGenerationEngine
from griptape.drivers import OpenAiChatPromptDriver
from griptape.artifacts import TextArtifact


pipeline = Pipeline(
    prompt_driver=OpenAiChatPromptDriver(model="gpt-3.5-turbo"),
    tasks=[
        ToolTask(
            "Scrape https://griptape.ai",
            tool=WebScraper(),
            id="WebResults",
        ),
        ImageGenerationTask(
            lambda task: cast(
                TextArtifact,
                pipeline.task_memory.summarize_namespace(task.parents[0].output.name),
            ),
            id="ImageGeneration",
            image_generation_engine=ImageGenerationEngine(
                image_generation_driver=OpenAiDalleImageGenerationDriver(
                    model="dall-e-3"
                )
            ),
        ),
    ],
)

pipeline.run()
```
