### PR TITLE
Fix output file bug in image generation tool/task

### DIFF
--- a/griptape/tasks/image_generation_task.py
+++ b/griptape/tasks/image_generation_task.py
@@ -90,7 +90,9 @@ class ImageGenerationTask(BaseTextInputTask):
         else:
             outfile = path.join(self.output_dir, image_artifact.name)
 
-        os.makedirs(path.dirname(outfile), exist_ok=True)
+        if path.dirname(outfile):
+            os.makedirs(path.dirname(outfile), exist_ok=True)
+
         with open(outfile, "wb") as f:
             self.structure.logger.info(f"Saving [{image_artifact.to_text()}] to {os.path.abspath(outfile)}")
             f.write(image_artifact.value)

--- a/griptape/tools/image_generator/tool.py
+++ b/griptape/tools/image_generator/tool.py
@@ -82,6 +82,8 @@ class ImageGenerator(BaseTool):
         else:
             outfile = path.join(self.output_dir, image_artifact.name)
 
-        os.makedirs(path.dirname(outfile), exist_ok=True)
+        if path.dirname(outfile):
+            os.makedirs(path.dirname(outfile), exist_ok=True)
+
         with open(outfile, "wb") as f:
             f.write(image_artifact.value)


### PR DESCRIPTION
The image generation task and tool accept `output_file` configurations which specify where on the filesystem to store the generated image. This field can include a directory prefix like `images/image.png`, in which case `./images/` will be created if necessary. In the case where no directory prefix is provided, like `image.png`, the file should be placed in the current directory. Instead, the tool/task attempted to create a parent directory with empty name `""`, causing an exception. This updates the code paths to include a check, ignoring empty requests to mkdirs.