### PR TITLE
Don't clear execution args

### DIFF
--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -59,6 +59,4 @@ class Agent(Structure):
 
             self.conversation_memory.add_run(run)
 
-        self._execution_args = ()
-
         return self

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -54,8 +54,6 @@ class Pipeline(Structure):
 
             self.conversation_memory.add_run(run)
 
-        self._execution_args = ()
-
         return self
 
     def context(self, task: BaseTask) -> dict[str, Any]:

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -114,8 +114,6 @@ class Workflow(Structure):
 
             self.conversation_memory.add_run(run)
 
-        self._execution_args = ()
-
         return self
 
     def context(self, task: BaseTask) -> dict[str, Any]:


### PR DESCRIPTION
Removes clearing `execution_args` after Structure runs. Without this fix, users are unable to access a Task's `input` after the Structure finishes running since the args are wiped away. 