### PR TITLE
Add MediaArtifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `input_task_input` and `input_task_output` fields to `StartStructureRunEvent`.
 - `output_task_input` and `output_task_output` fields to `FinishStructureRunEvent`.
 - `AmazonS3FileManagerDriver` for managing files on Amazon S3.
-- `MediaArtifact` as a base class for `ImageArtifact` and future media types.
+- `MediaArtifact` as a base class for `ImageArtifact` and future media Artifacts.
 
 ### Changed
 - **BREAKING**: Secret fields (ex: api_key) removed from serialized Drivers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `input_task_input` and `input_task_output` fields to `StartStructureRunEvent`.
 - `output_task_input` and `output_task_output` fields to `FinishStructureRunEvent`.
 - `AmazonS3FileManagerDriver` for managing files on Amazon S3.
+- `MediaArtifact` as a base class for `ImageArtifact` and future media types.
 
 ### Changed
 - **BREAKING**: Secret fields (ex: api_key) removed from serialized Drivers.
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Replaced `EventListener.handler` with `EventListener.driver` and `LocalEventListenerDriver`.
 - Improved RAG performance in `VectorQueryEngine`.
 - **BREAKING**: Removed `workdir`, `loaders`, `default_loader`, and `save_file_encoding` fields from `FileManager` and added `file_manager_driver`.
+- **BREADKING**: Removed `mime_type` field from `ImageArtifact`. `mime_type` is now a property constructed using the Artifact type and `format` field.
 
 ## [0.24.2] - 2024-04-04
 

--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -5,7 +5,7 @@ from .text_artifact import TextArtifact
 from .blob_artifact import BlobArtifact
 from .csv_row_artifact import CsvRowArtifact
 from .list_artifact import ListArtifact
-from .base_media_artifact import MediaArtifact
+from .media_artifact import MediaArtifact
 from .image_artifact import ImageArtifact
 
 

--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -5,7 +5,7 @@ from .text_artifact import TextArtifact
 from .blob_artifact import BlobArtifact
 from .csv_row_artifact import CsvRowArtifact
 from .list_artifact import ListArtifact
-from .base_media_artifact import BaseMediaArtifact
+from .base_media_artifact import MediaArtifact
 from .image_artifact import ImageArtifact
 
 
@@ -18,5 +18,5 @@ __all__ = [
     "CsvRowArtifact",
     "ListArtifact",
     "ImageArtifact",
-    "BaseMediaArtifact",
+    "MediaArtifact",
 ]

--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -5,6 +5,7 @@ from .text_artifact import TextArtifact
 from .blob_artifact import BlobArtifact
 from .csv_row_artifact import CsvRowArtifact
 from .list_artifact import ListArtifact
+from .base_media_artifact import BaseMediaArtifact
 from .image_artifact import ImageArtifact
 
 
@@ -17,4 +18,5 @@ __all__ = [
     "CsvRowArtifact",
     "ListArtifact",
     "ImageArtifact",
+    "BaseMediaArtifact",
 ]

--- a/griptape/artifacts/base_media_artifact.py
+++ b/griptape/artifacts/base_media_artifact.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from abc import abstractmethod, ABC
+
+import string
+import time
+import random
+from typing import Optional
+
+from attr import define, field, Factory
+from griptape.artifacts import BlobArtifact
+import base64
+
+
+@define
+class BaseMediaArtifact(BlobArtifact, ABC):
+    """MediaArtifact is a type of BlobArtifact that represents media (image, audio, video, etc.).
+
+    Attributes:
+        value: Raw bytes representing the media.
+        name: Artifact name, generated using creation time and a random string.
+        mime_type: The mime type of the image, like image/png or audio/wav.
+        model: Optionally specify the model used to generate the media.
+        prompt: Optionally specify the prompt used to generate the media.
+    """
+
+    artifact_type: str = field(default="media", kw_only=True, metadata={"serializable": True})
+    format: str = field(kw_only=True, metadata={"serializable": True})
+    model: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+    prompt: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+
+    def __attrs_post_init__(self):
+        if self.name == self.id:
+            self.name = self.make_name()
+
+    @property
+    def mime_type(self) -> str:
+        return f"{self.artifact_type}/{self.format}"
+
+    def make_name(self) -> str:
+        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
+
+        return f"{self.artifact_type}_artifact_{fmt_time}_{entropy}.{self.format}"
+
+    @property
+    def base64(self) -> str:
+        return base64.b64encode(self.value).decode("utf-8")
+
+    def to_text(self) -> str:
+        return f"Media, type: {self.mime_type}, size: {len(self.value)} bytes"

--- a/griptape/artifacts/base_media_artifact.py
+++ b/griptape/artifacts/base_media_artifact.py
@@ -13,8 +13,9 @@ import base64
 
 
 @define
-class BaseMediaArtifact(BlobArtifact, ABC):
-    """BaseMediaArtifact is a type of BlobArtifact that represents media (image, audio, video, etc.).
+class MediaArtifact(BlobArtifact):
+    """MediaArtifact is a type of BlobArtifact that represents media (image, audio, video, etc.)
+    and can be extended to support a specific media type.
 
     Attributes:
         value: Raw bytes representing media data.
@@ -39,15 +40,15 @@ class BaseMediaArtifact(BlobArtifact, ABC):
     def mime_type(self) -> str:
         return f"{self.artifact_type}/{self.format}"
 
-    def make_name(self) -> str:
-        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
-        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
-
-        return f"{self.artifact_type}_artifact_{fmt_time}_{entropy}.{self.format}"
-
     @property
     def base64(self) -> str:
         return base64.b64encode(self.value).decode("utf-8")
 
     def to_text(self) -> str:
         return f"Media, type: {self.mime_type}, size: {len(self.value)} bytes"
+
+    def make_name(self) -> str:
+        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
+
+        return f"{self.artifact_type}_artifact_{fmt_time}_{entropy}.{self.format}"

--- a/griptape/artifacts/base_media_artifact.py
+++ b/griptape/artifacts/base_media_artifact.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-from abc import abstractmethod, ABC
+from abc import ABC
 
 import string
 import time
 import random
 from typing import Optional
 
-from attr import define, field, Factory
+from attr import define, field
 from griptape.artifacts import BlobArtifact
 import base64
 
 
 @define
 class BaseMediaArtifact(BlobArtifact, ABC):
-    """MediaArtifact is a type of BlobArtifact that represents media (image, audio, video, etc.).
+    """BaseMediaArtifact is a type of BlobArtifact that represents media (image, audio, video, etc.).
 
     Attributes:
-        value: Raw bytes representing the media.
+        value: Raw bytes representing media data.
         name: Artifact name, generated using creation time and a random string.
         mime_type: The mime type of the image, like image/png or audio/wav.
         model: Optionally specify the model used to generate the media.
@@ -30,6 +30,8 @@ class BaseMediaArtifact(BlobArtifact, ABC):
     prompt: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
 
     def __attrs_post_init__(self):
+        # Generating the name string requires attributes set by child classes.
+        # This waits until all attributes are available before generating a name.
         if self.name == self.id:
             self.name = self.make_name()
 

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import base64
-
-from attr import define, field, Factory
+from attr import define, field
 
 from griptape.artifacts import BaseMediaArtifact
 
 
 @define
 class ImageArtifact(BaseMediaArtifact):
-    """ImageArtifact is a type of BaseMediaArtifact that represents an image.
+    """ImageArtifact is a type of BaseMediaArtifact representing an image.
 
     Attributes:
         value: Raw bytes representing the image.
@@ -25,7 +23,3 @@ class ImageArtifact(BaseMediaArtifact):
     artifact_type: str = "image"
     width: int = field(kw_only=True, metadata={"serializable": True})
     height: int = field(kw_only=True, metadata={"serializable": True})
-
-    @property
-    def base64(self) -> str:
-        return base64.b64encode(self.value).decode("utf-8")

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
 import base64
-import string
-import time
-import random
-from typing import Optional
+
 from attr import define, field, Factory
-from griptape.artifacts import BlobArtifact
+
+from griptape.artifacts import BaseMediaArtifact
 
 
 @define
-class ImageArtifact(BlobArtifact):
-    """ImageArtifact is a type of BlobArtifact that represents an image.
+class ImageArtifact(BaseMediaArtifact):
+    """ImageArtifact is a type of BaseMediaArtifact that represents an image.
 
     Attributes:
         value: Raw bytes representing the image.
         name: Artifact name, generated using creation time and a random string.
+        format: The format of the image, like png or jpeg.
         mime_type: The mime type of the image, like image/png or image/jpeg.
         width: The width of the image in pixels.
         height: The height of the image in pixels.
@@ -23,25 +22,10 @@ class ImageArtifact(BlobArtifact):
         prompt: Optionally specify the prompt used to generate the image.
     """
 
-    mime_type: str = field(kw_only=True, default="image/png", metadata={"serializable": True})
+    artifact_type: str = "image"
     width: int = field(kw_only=True, metadata={"serializable": True})
     height: int = field(kw_only=True, metadata={"serializable": True})
-    model: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    prompt: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    name: str = field(
-        default=Factory(lambda self: self.make_name(), takes_self=True), kw_only=True, metadata={"serializable": True}
-    )
 
     @property
     def base64(self) -> str:
         return base64.b64encode(self.value).decode("utf-8")
-
-    def make_name(self) -> str:
-        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
-        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
-        extension = self.mime_type.split("/")[1].split("+")[0]
-
-        return f"image_artifact_{fmt_time}_{entropy}.{extension}"
-
-    def to_text(self) -> str:
-        return f"Image, dimensions: {self.width}x{self.height}, type: {self.mime_type}, size: {len(self.value)} bytes"

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -10,16 +10,14 @@ class ImageArtifact(MediaArtifact):
     """ImageArtifact is a type of MediaArtifact representing an image.
 
     Attributes:
-        value: Raw bytes representing the image.
+        value: Raw bytes representing media data.
+        media_type: The type of media, defaults to "image".
+        format: The format of the media, like png, jpeg, or gif.
         name: Artifact name, generated using creation time and a random string.
-        format: The format of the image, like png or jpeg.
-        mime_type: The mime type of the image, like image/png or image/jpeg.
-        width: The width of the image in pixels.
-        height: The height of the image in pixels.
-        model: Optionally specify the model used to generate the image.
-        prompt: Optionally specify the prompt used to generate the image.
+        model: Optionally specify the model used to generate the media.
+        prompt: Optionally specify the prompt used to generate the media.
     """
 
-    artifact_type: str = "image"
+    media_type: str = "image"
     width: int = field(kw_only=True, metadata={"serializable": True})
     height: int = field(kw_only=True, metadata={"serializable": True})

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from attr import define, field
 
-from griptape.artifacts import BaseMediaArtifact
+from griptape.artifacts import MediaArtifact
 
 
 @define
-class ImageArtifact(BaseMediaArtifact):
-    """ImageArtifact is a type of BaseMediaArtifact representing an image.
+class ImageArtifact(MediaArtifact):
+    """ImageArtifact is a type of MediaArtifact representing an image.
 
     Attributes:
         value: Raw bytes representing the image.

--- a/griptape/artifacts/media_artifact.py
+++ b/griptape/artifacts/media_artifact.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC
-
 import string
 import time
 import random
@@ -19,13 +17,14 @@ class MediaArtifact(BlobArtifact):
 
     Attributes:
         value: Raw bytes representing media data.
+        media_type: The type of media, like image, audio, or video.
+        format: The format of the media, like png, wav, or mp4.
         name: Artifact name, generated using creation time and a random string.
-        mime_type: The mime type of the image, like image/png or audio/wav.
         model: Optionally specify the model used to generate the media.
         prompt: Optionally specify the prompt used to generate the media.
     """
 
-    artifact_type: str = field(default="media", kw_only=True, metadata={"serializable": True})
+    media_type: str = field(default="media", kw_only=True, metadata={"serializable": True})
     format: str = field(kw_only=True, metadata={"serializable": True})
     model: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     prompt: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
@@ -38,7 +37,7 @@ class MediaArtifact(BlobArtifact):
 
     @property
     def mime_type(self) -> str:
-        return f"{self.artifact_type}/{self.format}"
+        return f"{self.media_type}/{self.format}"
 
     @property
     def base64(self) -> str:
@@ -51,4 +50,4 @@ class MediaArtifact(BlobArtifact):
         entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
         fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
 
-        return f"{self.artifact_type}_artifact_{fmt_time}_{entropy}.{self.format}"
+        return f"{self.media_type}_artifact_{fmt_time}_{entropy}.{self.format}"

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -44,7 +44,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         return ImageArtifact(
             prompt=", ".join(prompts),
             value=image_bytes,
-            mime_type="image/png",
+            format="png",
             width=self.image_width,
             height=self.image_height,
             model=self.model,
@@ -62,7 +62,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         return ImageArtifact(
             prompt=", ".join(prompts),
             value=image_bytes,
-            mime_type="image/png",
+            format="png",
             width=image.width,
             height=image.height,
             model=self.model,
@@ -84,7 +84,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         return ImageArtifact(
             prompt=", ".join(prompts),
             value=image_bytes,
-            mime_type="image/png",
+            format="png",
             width=image.width,
             height=image.height,
             model=self.model,
@@ -106,7 +106,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         return ImageArtifact(
             prompt=", ".join(prompts),
             value=image_bytes,
-            mime_type="image/png",
+            format="png",
             width=image.width,
             height=image.height,
             model=self.model,

--- a/griptape/drivers/image_generation/leonardo_image_generation_driver.py
+++ b/griptape/drivers/image_generation/leonardo_image_generation_driver.py
@@ -53,7 +53,7 @@ class LeonardoImageGenerationDriver(BaseImageGenerationDriver):
 
         return ImageArtifact(
             value=image_data,
-            mime_type="image/png",
+            format="png",
             width=self.image_width,
             height=self.image_height,
             model=self.model,
@@ -75,7 +75,7 @@ class LeonardoImageGenerationDriver(BaseImageGenerationDriver):
 
         return ImageArtifact(
             value=image_data,
-            mime_type="image/png",
+            format="png",
             width=self.image_width,
             height=self.image_height,
             model=self.model,

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -130,7 +130,7 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
 
         return ImageArtifact(
             value=image_data,
-            mime_type="image/png",
+            format="png",
             width=image_dimensions[0],
             height=image_dimensions[1],
             model=self.model,

--- a/griptape/loaders/image_loader.py
+++ b/griptape/loaders/image_loader.py
@@ -46,7 +46,7 @@ class ImageLoader(BaseLoader):
             source = byte_stream.getvalue()
 
         image_artifact = ImageArtifact(
-            source, mime_type=self._get_mime_type(image.format), width=image.width, height=image.height
+            source, format=image.format.lower(), width=image.width, height=image.height, artifact_type="image"
         )
 
         return image_artifact

--- a/griptape/loaders/image_loader.py
+++ b/griptape/loaders/image_loader.py
@@ -45,9 +45,7 @@ class ImageLoader(BaseLoader):
             image = Image.open(byte_stream)
             source = byte_stream.getvalue()
 
-        image_artifact = ImageArtifact(
-            source, format=image.format.lower(), width=image.width, height=image.height, artifact_type="image"
-        )
+        image_artifact = ImageArtifact(source, format=image.format.lower(), width=image.width, height=image.height)
 
         return image_artifact
 

--- a/tests/mocks/mock_image_generation_task.py
+++ b/tests/mocks/mock_image_generation_task.py
@@ -17,4 +17,4 @@ class MockImageGenerationTask(BaseImageGenerationTask):
         self._input = TextArtifact(value)
 
     def run(self) -> ImageArtifact:
-        return ImageArtifact(value=b"image data", mime_type="image/png", width=512, height=512)
+        return ImageArtifact(value=b"image data", format="png", width=512, height=512)

--- a/tests/unit/artifacts/test_base_artifact.py
+++ b/tests/unit/artifacts/test_base_artifact.py
@@ -50,8 +50,8 @@ class TestBaseArtifact:
         dict_value = {
             "type": "ImageArtifact",
             "value": b"aW1hZ2UgZGF0YQ==",
-            "mime_type": "image/png",
             "dir_name": "foo",
+            "format": "png",
             "width": 256,
             "height": 256,
             "model": "test-model",
@@ -60,7 +60,7 @@ class TestBaseArtifact:
         artifact = BaseArtifact.from_dict(dict_value)
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.to_text() == "Image, dimensions: 256x256, type: image/png, size: 10 bytes"
+        assert artifact.to_text() == "Media, type: image/png, size: 10 bytes"
         assert artifact.value == b"image data"
 
     def test_unsupported_from_dict(self):

--- a/tests/unit/artifacts/test_base_media_artifact.py
+++ b/tests/unit/artifacts/test_base_media_artifact.py
@@ -1,0 +1,31 @@
+import pytest
+
+from attr import define
+
+from griptape.artifacts import BaseMediaArtifact
+
+
+class TestBaseMediaArtifact:
+    @define
+    class ImaginaryMediaArtifact(BaseMediaArtifact):
+        artifact_type: str = "imagination"
+
+    @pytest.fixture
+    def media_artifact(self):
+        return self.ImaginaryMediaArtifact(value=b"some binary dream data", format="dream")
+
+    def test_to_dict(self, media_artifact):
+        image_dict = media_artifact.to_dict()
+
+        assert image_dict["format"] == "dream"
+        assert image_dict["value"] == "c29tZSBiaW5hcnkgZHJlYW0gZGF0YQ=="
+
+    def test_name(self, media_artifact):
+        assert media_artifact.name.startswith("imagination_artifact")
+        assert media_artifact.name.endswith(".dream")
+
+    def test_mime_type(self, media_artifact):
+        assert media_artifact.mime_type == "imagination/dream"
+
+    def test_to_text(self, media_artifact):
+        assert media_artifact.to_text() == "Media, type: imagination/dream, size: 22 bytes"

--- a/tests/unit/artifacts/test_base_media_artifact.py
+++ b/tests/unit/artifacts/test_base_media_artifact.py
@@ -2,12 +2,12 @@ import pytest
 
 from attr import define
 
-from griptape.artifacts import BaseMediaArtifact
+from griptape.artifacts import MediaArtifact
 
 
-class TestBaseMediaArtifact:
+class TestMediaArtifact:
     @define
-    class ImaginaryMediaArtifact(BaseMediaArtifact):
+    class ImaginaryMediaArtifact(MediaArtifact):
         artifact_type: str = "imagination"
 
     @pytest.fixture

--- a/tests/unit/artifacts/test_base_media_artifact.py
+++ b/tests/unit/artifacts/test_base_media_artifact.py
@@ -8,7 +8,7 @@ from griptape.artifacts import MediaArtifact
 class TestMediaArtifact:
     @define
     class ImaginaryMediaArtifact(MediaArtifact):
-        artifact_type: str = "imagination"
+        media_type: str = "imagination"
 
     @pytest.fixture
     def media_artifact(self):

--- a/tests/unit/artifacts/test_image_artifact.py
+++ b/tests/unit/artifacts/test_image_artifact.py
@@ -7,20 +7,20 @@ class TestImageArtifact:
     def image_artifact(self):
         return ImageArtifact(
             value=b"some binary png image data",
-            mime_type="image/png",
+            format="png",
             width=512,
             height=512,
             model="openai/dalle2",
             prompt="a cute cat",
         )
 
-    def test_to_text(self, image_artifact):
-        assert image_artifact.to_text() == "Image, dimensions: 512x512, type: image/png, size: 26 bytes"
+    def test_to_text(self, image_artifact: ImageArtifact):
+        assert image_artifact.to_text() == "Media, type: image/png, size: 26 bytes"
 
-    def test_to_dict(self, image_artifact):
+    def test_to_dict(self, image_artifact: ImageArtifact):
         image_dict = image_artifact.to_dict()
 
-        assert image_dict["mime_type"] == "image/png"
+        assert image_dict["format"] == "png"
         assert image_dict["width"] == 512
         assert image_dict["height"] == 512
         assert image_dict["model"] == "openai/dalle2"
@@ -35,6 +35,7 @@ class TestImageArtifact:
 
         assert deserialized_artifact.value == b"some binary png image data"
         assert deserialized_artifact.mime_type == "image/png"
+        assert deserialized_artifact.format == "png"
         assert deserialized_artifact.width == 512
         assert deserialized_artifact.height == 512
         assert deserialized_artifact.model == "openai/dalle2"

--- a/tests/unit/drivers/image_generation/test_amazon_bedrock_stable_diffusion_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_amazon_bedrock_stable_diffusion_image_generation_driver.py
@@ -37,7 +37,9 @@ class TestAmazonBedrockImageGenerationDriver:
 
     def test_init_requires_image_generation_model_driver(self, session):
         with pytest.raises(TypeError):
-            AmazonBedrockImageGenerationDriver(session=session, model="stability.stable-diffusion-xl-v1")
+            AmazonBedrockImageGenerationDriver(
+                session=session, model="stability.stable-diffusion-xl-v1"
+            )  # pyright: ignore
 
     def test_try_text_to_image(self, driver):
         driver.bedrock_client.invoke_model.return_value = {
@@ -56,6 +58,7 @@ class TestAmazonBedrockImageGenerationDriver:
         image_artifact = driver.try_text_to_image(prompts=["test prompt"], negative_prompts=["test negative prompt"])
 
         assert image_artifact.value == b"image data"
+        assert image_artifact.format == "png"
         assert image_artifact.mime_type == "image/png"
         assert image_artifact.width == 512
         assert image_artifact.height == 512

--- a/tests/unit/drivers/image_generation/test_dummy_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_dummy_image_generation_driver.py
@@ -21,22 +21,22 @@ class TestDummyImageGenerationDriver:
         with pytest.raises(DummyException):
             image_generation_driver.try_image_variation(
                 "prompt-stack",
-                ImageArtifact(value=b"", width=100, height=100),
-                ImageArtifact(value=b"", width=100, height=100),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
             )
 
     def test_try_image_inpainting(self, image_generation_driver):
         with pytest.raises(DummyException):
             image_generation_driver.try_image_inpainting(
                 "prompt-stack",
-                ImageArtifact(value=b"", width=100, height=100),
-                ImageArtifact(value=b"", width=100, height=100),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
             )
 
     def test_try_image_outpainting(self, image_generation_driver):
         with pytest.raises(DummyException):
             image_generation_driver.try_image_outpainting(
                 "prompt-stack",
-                ImageArtifact(value=b"", width=100, height=100),
-                ImageArtifact(value=b"", width=100, height=100),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
+                ImageArtifact(value=b"", width=100, height=100, format="png"),
             )

--- a/tests/unit/drivers/image_generation_model/test_bedrock_stable_diffusion_image_model_driver.py
+++ b/tests/unit/drivers/image_generation_model/test_bedrock_stable_diffusion_image_model_driver.py
@@ -13,11 +13,11 @@ class TestBedrockStableDiffusionImageGenerationModelDriver:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=1024)
+        return ImageArtifact(b"image", format="png", width=1024, height=1024)
 
     @pytest.fixture
     def mask_artifact(self):
-        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=1024)
+        return ImageArtifact(b"mask", format="png", width=1024, height=1024)
 
     def test_init(self, model_driver):
         assert model_driver

--- a/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
+++ b/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
@@ -11,11 +11,11 @@ class TestBedrockTitanImageGenerationModelDriver:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=512)
+        return ImageArtifact(b"image", format="png", width=1024, height=512)
 
     @pytest.fixture
     def mask_artifact(self):
-        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=512)
+        return ImageArtifact(b"mask", format="png", width=1024, height=512)
 
     def test_init(self, model_driver):
         assert model_driver

--- a/tests/unit/drivers/image_query/test_amazon_bedrock_image_query_driver.py
+++ b/tests/unit/drivers/image_query/test_amazon_bedrock_image_query_driver.py
@@ -36,7 +36,7 @@ class TestAmazonBedrockImageQueryDriver:
         image_query_driver.bedrock_client.invoke_model.return_value = {"body": io.BytesIO(b"""{"content": []}""")}
 
         text_artifact = image_query_driver.try_query(
-            "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100)]
+            "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100, format="png")]
         )
 
         assert text_artifact.value == "content"
@@ -45,4 +45,6 @@ class TestAmazonBedrockImageQueryDriver:
         image_query_driver.bedrock_client.invoke_model.return_value = {"body": io.BytesIO(b"")}
 
         with pytest.raises(ValueError):
-            image_query_driver.try_query("Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100)])
+            image_query_driver.try_query(
+                "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100, format="png")]
+            )

--- a/tests/unit/drivers/image_query/test_anthropic_image_query_driver.py
+++ b/tests/unit/drivers/image_query/test_anthropic_image_query_driver.py
@@ -26,7 +26,7 @@ class TestAnthropicImageQueryDriver:
         test_binary_data = b"test-data"
 
         text_artifact = driver.try_query(
-            test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100)]
+            test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100, format="png")]
         )
 
         expected_message = self._expected_message(test_binary_data, "image/png", test_prompt_string)
@@ -43,7 +43,7 @@ class TestAnthropicImageQueryDriver:
         test_binary_data = b"test-data"
 
         text_artifact = driver.try_query(
-            test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100)]
+            test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100, format="png")]
         )
 
         expected_message = self._expected_message(test_binary_data, "image/png", test_prompt_string)
@@ -59,16 +59,18 @@ class TestAnthropicImageQueryDriver:
         test_prompt_string = "Prompt String"
         test_binary_data = b"test-data"
         with pytest.raises(TypeError):
-            driver.try_query(test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100)])
+            driver.try_query(
+                test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100, format="png")]
+            )
 
     def test_try_query_wrong_media_type(self, mock_client):
         driver = AnthropicImageQueryDriver(model="test-model")
         test_prompt_string = "Prompt String"
         test_binary_data = b"test-data"
 
-        # we expect this to pass Griptape code as the model will error approriately
+        # we expect this to pass Griptape code as the model will error appropriately
         text_artifact = driver.try_query(
-            test_prompt_string, [ImageArtifact(value=test_binary_data, mime_type="image/exr", width=100, height=100)]
+            test_prompt_string, [ImageArtifact(value=test_binary_data, width=100, height=100, format="exr")]
         )
 
         expected_message = self._expected_message(test_binary_data, "image/exr", test_prompt_string)

--- a/tests/unit/drivers/image_query/test_dummy_image_query_driver.py
+++ b/tests/unit/drivers/image_query/test_dummy_image_query_driver.py
@@ -15,4 +15,4 @@ class TestDummyImageQueryDriver:
 
     def test_try_query(self, image_query_driver):
         with pytest.raises(DummyException):
-            image_query_driver.try_query("Prompt", [ImageArtifact(value=b"", width=100, height=100)])
+            image_query_driver.try_query("Prompt", [ImageArtifact(value=b"", width=100, height=100, format="png")])

--- a/tests/unit/drivers/image_query/test_openai_image_query_driver.py
+++ b/tests/unit/drivers/image_query/test_openai_image_query_driver.py
@@ -19,7 +19,7 @@ class TestOpenAiVisionImageQueryDriver:
         driver = OpenAiVisionImageQueryDriver(model="gpt-4-vision-preview")
         test_prompt_string = "Prompt String"
         test_binary_data = b"test-data"
-        test_image = ImageArtifact(value=test_binary_data, width=100, height=100)
+        test_image = ImageArtifact(value=test_binary_data, width=100, height=100, format="png")
         text_artifact = driver.try_query(test_prompt_string, [test_image])
 
         messages = self._expected_messages(test_prompt_string, test_image.base64)
@@ -32,7 +32,7 @@ class TestOpenAiVisionImageQueryDriver:
         driver = OpenAiVisionImageQueryDriver(model="gpt-4-vision-preview", max_tokens=1024)
         test_prompt_string = "Prompt String"
         test_binary_data = b"test-data"
-        test_image = ImageArtifact(value=test_binary_data, width=100, height=100)
+        test_image = ImageArtifact(value=test_binary_data, width=100, height=100, format="png")
         driver.try_query(test_prompt_string, [test_image])
 
         messages = self._expected_messages(test_prompt_string, test_image.base64)
@@ -44,7 +44,7 @@ class TestOpenAiVisionImageQueryDriver:
         driver = OpenAiVisionImageQueryDriver(model="gpt-4-vision-preview")
 
         with pytest.raises(Exception):
-            driver.try_query("Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100)])
+            driver.try_query("Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100, format="png")])
 
     def _expected_messages(self, expected_prompt_string, expected_binary_data):
         return {

--- a/tests/unit/drivers/image_query_models/test_bedrock_claude_image_query_model_driver.py
+++ b/tests/unit/drivers/image_query_models/test_bedrock_claude_image_query_model_driver.py
@@ -10,7 +10,7 @@ class TestBedrockClaudeImageQueryModelDriver:
     def test_image_query_request_parameters(self):
         model_driver = BedrockClaudeImageQueryModelDriver()
         params = model_driver.image_query_request_parameters(
-            "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100)], 256
+            "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100, format="png")], 256
         )
 
         assert isinstance(params, dict)

--- a/tests/unit/mixins/test_image_artifact_file_output_mixin.py
+++ b/tests/unit/mixins/test_image_artifact_file_output_mixin.py
@@ -16,7 +16,7 @@ class TestImageArtifactFileOutputMixin:
         assert Test().output_dir is None
 
     def test_output_file(self):
-        artifact = ImageArtifact(name="test.png", value=b"test", height=1, width=1, mime_type="image/png")
+        artifact = ImageArtifact(name="test.png", value=b"test", height=1, width=1, format="png")
 
         class Test(ImageArtifactFileOutputMixin):
             def run(self):
@@ -31,7 +31,7 @@ class TestImageArtifactFileOutputMixin:
         assert os.path.exists(outfile)
 
     def test_output_dir(self):
-        artifact = ImageArtifact(name="test.png", value=b"test", height=1, width=1, mime_type="image/png")
+        artifact = ImageArtifact(name="test.png", value=b"test", height=1, width=1, format="png")
 
         class Test(ImageArtifactFileOutputMixin):
             def run(self):

--- a/tests/unit/tasks/test_image_query_task.py
+++ b/tests/unit/tasks/test_image_query_task.py
@@ -15,7 +15,7 @@ class TestImageQueryTask:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(value=b"some image data", mime_type="image/png", width=512, height=512)
+        return ImageArtifact(value=b"some image data", format="png", width=512, height=512)
 
     def test_text_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         task = ImageQueryTask((text_artifact.value, [image_artifact, image_artifact]))

--- a/tests/unit/tasks/test_inpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_inpainting_image_generation_task.py
@@ -17,7 +17,7 @@ class TestInpaintingImageGenerationTask:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(value=b"some image data", mime_type="image/png", width=512, height=512)
+        return ImageArtifact(value=b"some image data", format="png", width=512, height=512)
 
     def test_artifact_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         input_tuple = (text_artifact, image_artifact, image_artifact)

--- a/tests/unit/tasks/test_outpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_outpainting_image_generation_task.py
@@ -18,7 +18,7 @@ class TestOutpaintingImageGenerationTask:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(value=b"some image data", mime_type="image/png", width=512, height=512)
+        return ImageArtifact(value=b"some image data", format="png", width=512, height=512)
 
     def test_artifact_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         input_tuple = (text_artifact, image_artifact, image_artifact)

--- a/tests/unit/tasks/test_variation_image_generation_task.py
+++ b/tests/unit/tasks/test_variation_image_generation_task.py
@@ -17,7 +17,7 @@ class TestVariationImageGenerationTask:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(value=b"some image data", mime_type="image/png", width=512, height=512)
+        return ImageArtifact(value=b"some image data", format="png", width=512, height=512)
 
     def test_artifact_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         input_tuple = (text_artifact, image_artifact)

--- a/tests/unit/tools/test_inpainting_image_generation_client.py
+++ b/tests/unit/tools/test_inpainting_image_generation_client.py
@@ -17,7 +17,7 @@ class TestInpaintingImageGenerationClient:
     @pytest.fixture
     def image_loader(self) -> Mock:
         loader = Mock()
-        loader.load.return_value = ImageArtifact(value=b"image_data", mime_type="image/png", width=512, height=512)
+        loader.load.return_value = ImageArtifact(value=b"image_data", format="png", width=512, height=512)
 
         return loader
 
@@ -31,7 +31,7 @@ class TestInpaintingImageGenerationClient:
 
     def test_image_inpainting(self, image_generator) -> None:
         image_generator.engine.run.return_value = Mock(
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_inpainting_from_file(
@@ -54,7 +54,7 @@ class TestInpaintingImageGenerationClient:
         )
 
         image_generator.engine.run.return_value = Mock(  # pyright: ignore
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_inpainting_from_file(

--- a/tests/unit/tools/test_outpainting_image_variation_client.py
+++ b/tests/unit/tools/test_outpainting_image_variation_client.py
@@ -17,7 +17,7 @@ class TestOutpaintingImageGenerationClient:
     @pytest.fixture
     def image_loader(self) -> Mock:
         loader = Mock()
-        loader.load.return_value = ImageArtifact(value=b"image_data", mime_type="image/png", width=512, height=512)
+        loader.load.return_value = ImageArtifact(value=b"image_data", format="png", width=512, height=512)
 
         return loader
 
@@ -31,7 +31,7 @@ class TestOutpaintingImageGenerationClient:
 
     def test_image_outpainting(self, image_generator) -> None:
         image_generator.engine.run.return_value = Mock(
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_outpainting_from_file(
@@ -54,7 +54,7 @@ class TestOutpaintingImageGenerationClient:
         )
 
         image_generator.engine.run.return_value = Mock(  # pyright: ignore
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_outpainting_from_file(

--- a/tests/unit/tools/test_prompt_image_generation_client.py
+++ b/tests/unit/tools/test_prompt_image_generation_client.py
@@ -23,7 +23,7 @@ class TestPromptImageGenerationClient:
 
     def test_generate_image(self, image_generator) -> None:
         image_generator.engine.run.return_value = Mock(
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.generate_image(
@@ -37,7 +37,7 @@ class TestPromptImageGenerationClient:
         image_generator = PromptImageGenerationClient(engine=image_generation_engine, output_file=outfile)
 
         image_generator.engine.run.return_value = Mock(  # pyright: ignore
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.generate_image(

--- a/tests/unit/tools/test_variation_image_generation_client.py
+++ b/tests/unit/tools/test_variation_image_generation_client.py
@@ -17,7 +17,7 @@ class TestVariationImageGenerationClient:
     @pytest.fixture
     def image_loader(self) -> Mock:
         loader = Mock()
-        loader.load.return_value = ImageArtifact(value=b"image_data", mime_type="image/png", width=512, height=512)
+        loader.load.return_value = ImageArtifact(value=b"image_data", format="png", width=512, height=512)
 
         return loader
 
@@ -33,7 +33,7 @@ class TestVariationImageGenerationClient:
 
     def test_image_variation(self, image_generator) -> None:
         image_generator.engine.run.return_value = Mock(
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_variation_from_file(
@@ -55,7 +55,7 @@ class TestVariationImageGenerationClient:
         )
 
         image_generator.engine.run.return_value = Mock(  # pyright: ignore
-            value=b"image data", mime_type="image/png", width=512, height=512, model="test model", prompt="test prompt"
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
 
         image_artifact = image_generator.image_variation_from_file(

--- a/tests/unit/utils/test_load_artifact_from_memory.py
+++ b/tests/unit/utils/test_load_artifact_from_memory.py
@@ -17,7 +17,7 @@ class TestLoadImageArtifactFromMemory:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(value=b"image", name="image", mime_type="image/png", height=32, width=32)
+        return ImageArtifact(value=b"image", name="image", format="png", height=32, width=32)
 
     def test_no_memory(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Adds a MediaArtifact class. ImageArtifact as well as future types inherit from a common MediaArtifact to capture common fields and functionality like artifact naming and MIME type support.