### PR TITLE
Makefile: split publish target to version + publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-publish:
+version:
 	@poetry version $(v)
 	@git add pyproject.toml
 	@git commit -m "Version bump v$$(poetry version -s)"
-	@git tag v$$(poetry version -s)
 	@git push
+
+publish:
+	@git tag v$$(poetry version -s)
 	@git push --tags
 	@poetry build
 	@poetry publish

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ version:
 	@poetry version $(v)
 	@git add pyproject.toml
 	@git commit -m "Version bump v$$(poetry version -s)"
-	@git push
+	@git push origin release/v$$(poetry version -s)
 
 publish:
 	@git tag v$$(poetry version -s)


### PR DESCRIPTION
Update Makefile to avoid commits directly to `main`, which is disallowed by branch protection rules.