### PR TITLE
Fix integration test prompt drivers

### DIFF
--- a/tests/integration/tasks/test_csv_extraction_task.py
+++ b/tests/integration/tasks/test_csv_extraction_task.py
@@ -13,14 +13,15 @@ class TestCsvExtractionTask:
         from griptape.structures import Agent
         from griptape.engines import CsvExtractionEngine
 
-        # Instantiate the CSV extraction engine
-        csv_extraction_engine = CsvExtractionEngine()
-
         columns = ["Name", "Age", "Address"]
 
         # Create an agent and add the ExtractionTask to it
         agent = Agent(prompt_driver=request.param)
-        agent.add_task(ExtractionTask(extraction_engine=csv_extraction_engine, args={"column_names": columns}))
+        agent.add_task(
+            ExtractionTask(
+                extraction_engine=CsvExtractionEngine(prompt_driver=request.param), args={"column_names": columns}
+            )
+        )
 
         return StructureTester(agent)
 

--- a/tests/integration/tasks/test_json_extraction_task.py
+++ b/tests/integration/tasks/test_json_extraction_task.py
@@ -18,7 +18,12 @@ class TestJsonExtractionTask:
         user_schema = Schema({"users": [{"name": str, "age": int, "location": str}]}).json_schema("UserSchema")
 
         agent = Agent(prompt_driver=request.param)
-        agent.add_task(ExtractionTask(extraction_engine=JsonExtractionEngine(), args={"template_schema": user_schema}))
+        agent.add_task(
+            ExtractionTask(
+                extraction_engine=JsonExtractionEngine(prompt_driver=request.param),
+                args={"template_schema": user_schema},
+            )
+        )
 
         return StructureTester(agent)
 

--- a/tests/integration/tasks/test_text_query_task.py
+++ b/tests/integration/tasks/test_text_query_task.py
@@ -19,7 +19,7 @@ class TestTextQueryTask:
 
         artifact = TextArtifact("John Doe works as as software engineer at Griptape.")
 
-        vector_query_engine = VectorQueryEngine(vector_store_driver=vector_store_driver)
+        vector_query_engine = VectorQueryEngine(prompt_driver=request.param, vector_store_driver=vector_store_driver)
         vector_query_engine.upsert_text_artifact(artifact=artifact)
 
         agent = Agent(prompt_driver=request.param)


### PR DESCRIPTION
Certain Tasks don't pull from their Structure's Prompt Driver. This should probably be fixed in a separate PR, but it'll likely change with upcoming defaults changes.