### PR TITLE
Update tj-actions to address dependabot alert for GHSL-2023-271

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/init-environment
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v40
+        uses: tj-actions/changed-files@v41
         with:
           files: |
             **/*.py


### PR DESCRIPTION
Addressing Dependabot warning here: https://github.com/griptape-ai/griptape/security/dependabot/23