### PR TITLE
Fix ImageLoader, add to loaders module export

### DIFF
--- a/griptape/loaders/__init__.py
+++ b/griptape/loaders/__init__.py
@@ -7,6 +7,7 @@ from .csv_loader import CsvLoader
 from .dataframe_loader import DataFrameLoader
 from .file_loader import FileLoader
 from .email_loader import EmailLoader
+from .image_loader import ImageLoader
 
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "DataFrameLoader",
     "FileLoader",
     "EmailLoader",
+    "ImageLoader",
 ]

--- a/griptape/loaders/image_loader.py
+++ b/griptape/loaders/image_loader.py
@@ -35,11 +35,9 @@ class ImageLoader(BaseLoader):
 
         image = Image.open(path)
 
-        # Ensure image is in png format.
+        # Ensure image is in the specified format.
         byte_stream = BytesIO()
-
-        if image.format != self.format:
-            image.save(byte_stream, format=self.format)
+        image.save(byte_stream, format=self.format)
 
         return ImageArtifact(
             byte_stream.getvalue(),

--- a/griptape/tasks/base_image_generation_task.py
+++ b/griptape/tasks/base_image_generation_task.py
@@ -6,7 +6,7 @@ from abc import ABC
 from attr import field, define
 
 from griptape.artifacts import ImageArtifact
-from griptape.loaders.image_loader import ImageLoader
+from griptape.loaders import ImageLoader
 from griptape.mixins import RuleMixin, ImageArtifactFileOutputMixin
 from griptape.rules import Ruleset, Rule
 from griptape.tasks import BaseTask

--- a/griptape/tools/inpainting_image_generation_client/tool.py
+++ b/griptape/tools/inpainting_image_generation_client/tool.py
@@ -7,7 +7,7 @@ from schema import Schema, Literal
 
 from griptape.artifacts import ErrorArtifact, ImageArtifact
 from griptape.engines import InpaintingImageGenerationEngine
-from griptape.loaders.image_loader import ImageLoader
+from griptape.loaders import ImageLoader
 from griptape.mixins import ImageArtifactFileOutputMixin
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity

--- a/griptape/tools/outpainting_image_generation_client/tool.py
+++ b/griptape/tools/outpainting_image_generation_client/tool.py
@@ -7,7 +7,7 @@ from schema import Schema, Literal
 
 from griptape.artifacts import ErrorArtifact, ImageArtifact
 from griptape.engines import OutpaintingImageGenerationEngine
-from griptape.loaders.image_loader import ImageLoader
+from griptape.loaders import ImageLoader
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 from griptape.mixins import ImageArtifactFileOutputMixin

--- a/griptape/tools/variation_image_generation_client/tool.py
+++ b/griptape/tools/variation_image_generation_client/tool.py
@@ -7,7 +7,7 @@ from schema import Schema, Literal
 
 from griptape.artifacts import ErrorArtifact, ImageArtifact
 from griptape.engines import VariationImageGenerationEngine
-from griptape.loaders.image_loader import ImageLoader
+from griptape.loaders import ImageLoader
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 from griptape.mixins import ImageArtifactFileOutputMixin

--- a/tests/unit/loaders/test_image_loader.py
+++ b/tests/unit/loaders/test_image_loader.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from griptape.artifacts import ImageArtifact
-from griptape.loaders.image_loader import ImageLoader
+from griptape.loaders import ImageLoader
 
 
 class TestImageLoader:

--- a/tests/unit/loaders/test_image_loader.py
+++ b/tests/unit/loaders/test_image_loader.py
@@ -25,6 +25,7 @@ class TestImageLoader:
         assert artifact.height == 1024
         assert artifact.width == 1024
         assert artifact.mime_type == "image/png"
+        assert len(artifact.value) > 0
 
     def test_load_jpg(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/pig-balloon.jpg")
@@ -37,3 +38,4 @@ class TestImageLoader:
         assert artifact.height == 1024
         assert artifact.width == 1024
         assert artifact.mime_type == "image/png"
+        assert len(artifact.value) > 0


### PR DESCRIPTION
This PR fixes a bug in the ImageLoader that failed to include the image bytes in the loaded artifact when not updating the format.

Additionally, this PR fixes that by exporting the symbol in `griptape.loaders`. This fixes the issue where ImageLoader couldn't be imported as `from griptape.loaders import ImageLoader` like the others. 