### PR TITLE
Rename OpenAiDalleImageGenerationDriver to OpenAiImageGenerationDriver

### DIFF
--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -58,10 +58,10 @@ from .image_generation_model.bedrock_titan_image_generation_model_driver import 
 
 from .image_generation.base_image_generation_driver import BaseImageGenerationDriver
 from .image_generation.base_multi_model_image_generation_driver import BaseMultiModelImageGenerationDriver
-from .image_generation.openai_dalle_image_generation_driver import OpenAiDalleImageGenerationDriver
+from .image_generation.openai_image_generation_driver import OpenAiImageGenerationDriver
 from .image_generation.leonardo_image_generation_driver import LeonardoImageGenerationDriver
 from .image_generation.amazon_bedrock_image_generation_driver import AmazonBedrockImageGenerationDriver
-from .image_generation.azure_openai_dalle_image_generation_driver import AzureOpenAiDalleImageGenerationDriver
+from .image_generation.azure_openai_image_generation_driver import AzureOpenAiImageGenerationDriver
 
 __all__ = [
     "BasePromptDriver",
@@ -114,8 +114,8 @@ __all__ = [
     "BedrockTitanImageGenerationModelDriver",
     "BaseImageGenerationDriver",
     "BaseMultiModelImageGenerationDriver",
-    "OpenAiDalleImageGenerationDriver",
+    "OpenAiImageGenerationDriver",
     "LeonardoImageGenerationDriver",
     "AmazonBedrockImageGenerationDriver",
-    "AzureOpenAiDalleImageGenerationDriver",
+    "AzureOpenAiImageGenerationDriver",
 ]

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -8,7 +8,7 @@ from griptape.drivers import OpenAiImageGenerationDriver
 
 @define
 class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
-    """Driver for Azure-hosted OpenAI DALLE image generation API.
+    """Driver for Azure-hosted OpenAI image generation API.
 
     Attributes:
         azure_deployment: An Azure OpenAi deployment id.

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import openai
 from attr import field, Factory, define
-from griptape.drivers import OpenAiDalleImageGenerationDriver
+
+from griptape.drivers import OpenAiImageGenerationDriver
 
 
 @define
-class AzureOpenAiDalleImageGenerationDriver(OpenAiDalleImageGenerationDriver):
+class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
     """Driver for Azure-hosted OpenAI DALLE image generation API.
 
     Attributes:

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -12,10 +12,10 @@ from griptape.drivers import BaseImageGenerationDriver
 
 @define
 class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
-    """Driver for OpenAI DALLE image generation API.
+    """Driver for the OpenAI image generation API.
 
     Attributes:
-        model: OpenAI DALLE model, for example 'dall-e-2' or 'dall-e-3'.
+        model: OpenAI model, for example 'dall-e-2' or 'dall-e-3'.
         api_type: OpenAI API type, for example 'open_ai' or 'azure'.
         api_version: API version.
         base_url: API URL.

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -11,7 +11,7 @@ from griptape.drivers import BaseImageGenerationDriver
 
 
 @define
-class OpenAiDalleImageGenerationDriver(BaseImageGenerationDriver):
+class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
     """Driver for OpenAI DALLE image generation API.
 
     Attributes:

--- a/tests/unit/drivers/image_generation/test_azure_openai_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_azure_openai_image_generation_driver.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest.mock import Mock
-from griptape.drivers import AzureOpenAiDalleImageGenerationDriver
+from griptape.drivers import AzureOpenAiImageGenerationDriver
 
 
-class TestAzureOpenAiDalleImageGenerationDriver:
+class TestAzureOpenAiImageGenerationDriver:
     @pytest.fixture
     def driver(self):
-        return AzureOpenAiDalleImageGenerationDriver(
+        return AzureOpenAiImageGenerationDriver(
             model="dall-e-3",
             client=Mock(),
             azure_endpoint="https://dalle.example.com",
@@ -19,15 +19,15 @@ class TestAzureOpenAiDalleImageGenerationDriver:
 
     def test_init_requires_endpoint(self):
         with pytest.raises(TypeError):
-            AzureOpenAiDalleImageGenerationDriver(
+            AzureOpenAiImageGenerationDriver(
                 model="dall-e-3", client=Mock(), azure_deployment="dalle-deployment", image_size="512x512"
-            )
+            )  # pyright: ignore
 
     def test_init_requires_deployment(self):
         with pytest.raises(TypeError):
-            AzureOpenAiDalleImageGenerationDriver(
+            AzureOpenAiImageGenerationDriver(
                 model="dall-e-3", client=Mock(), azure_endpoint="https://dalle.example.com", image_size="512x512"
-            )
+            )  # pyright: ignore
 
     def test_try_text_to_image(self, driver):
         driver.client.images.generate.return_value = Mock(data=[Mock(b64_json=b"aW1hZ2UgZGF0YQ==")])

--- a/tests/unit/drivers/image_generation/test_openai_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_openai_image_generation_driver.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest.mock import Mock
-from griptape.drivers import OpenAiDalleImageGenerationDriver
+from griptape.drivers import OpenAiImageGenerationDriver
 
 
-class TestOpenAiDalleImageGenerationDriver:
+class TestOpenAiImageGenerationDriver:
     @pytest.fixture
     def driver(self):
-        return OpenAiDalleImageGenerationDriver(model="dall-e-2", client=Mock(), quality="hd", image_size="512x512")
+        return OpenAiImageGenerationDriver(model="dall-e-2", client=Mock(), quality="hd", image_size="512x512")
 
     def test_init(self, driver):
         assert driver


### PR DESCRIPTION
Renames the OpenAiDalleImageGenerationDriver to OpenAiImageGenerationDriver to align more closely with the pattern established by other image generation drivers. Also updates the Azure driver and associated tests.