### PR TITLE
Add image gen modes for Amazon Titan

### DIFF
--- a/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
@@ -13,14 +13,14 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
     """Image Generation Model Driver for Amazon Bedrock Titan Image Generator.
 
     Attributes:
-        task_type: The type of image generation task to perform, defaults to TEXT_IMAGE (text-to-image).
         quality: The quality of the generated image, defaults to standard.
         cfg_scale: Specifies how strictly image generation follows the provided prompt. Defaults to 7, (1.0 to 10.0].
+        outpainting_mode: Specifies the outpainting mode, defaults to PRECISE.
     """
 
-    task_type: str = field(default="TEXT_IMAGE", kw_only=True)
     quality: str = field(default="standard", kw_only=True)
     cfg_scale: int = field(default=7, kw_only=True)
+    outpainting_mode: str = field(default="PRECISE", kw_only=True)
 
     def text_to_image_request_parameters(
         self,
@@ -33,7 +33,7 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompt = ", ".join(prompts)
 
         request = {
-            "taskType": self.task_type,
+            "taskType": "TEXT_IMAGE",
             "textToImageParams": {"text": prompt},
             "imageGenerationConfig": {
                 "numberOfImages": 1,
@@ -59,7 +59,27 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         negative_prompts: list[str] | None = None,
         seed: int | None = None,
     ) -> dict:
-        raise NotImplementedError(f"{self.__class__.__name__} does not support variation")
+        prompt = ", ".join(prompts)
+
+        request = {
+            "taskType": "IMAGE_VARIATION",
+            "imageVariationParams": {"text": prompt, "images": [image.base64]},
+            "imageGenerationConfig": {
+                "numberOfImages": 1,
+                "quality": self.quality,
+                "width": image.width,
+                "height": image.height,
+                "cfgScale": self.cfg_scale,
+            },
+        }
+
+        if negative_prompts:
+            request["imageVariationParams"]["negativeText"] = ", ".join(negative_prompts)
+
+        if seed:
+            request["imageGenerationConfig"]["seed"] = seed
+
+        return request
 
     def image_inpainting_request_parameters(
         self,
@@ -69,7 +89,27 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         negative_prompts: list[str] | None = None,
         seed: int | None = None,
     ) -> dict:
-        raise NotImplementedError(f"{self.__class__.__name__} does not support inpainting")
+        prompt = ", ".join(prompts)
+
+        request = {
+            "taskType": "INPAINTING",
+            "inPaintingParams": {"text": prompt, "image": image.base64, "maskImage": mask.base64},
+            "imageGenerationConfig": {
+                "numberOfImages": 1,
+                "quality": self.quality,
+                "width": image.width,
+                "height": image.height,
+                "cfgScale": self.cfg_scale,
+            },
+        }
+
+        if negative_prompts:
+            request["inPaintingParams"]["negativeText"] = ", ".join(negative_prompts)
+
+        if seed:
+            request["imageGenerationConfig"]["seed"] = seed
+
+        return request
 
     def image_outpainting_request_parameters(
         self,
@@ -79,7 +119,32 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         negative_prompts: list[str] | None = None,
         seed: int | None = None,
     ) -> dict:
-        raise NotImplementedError(f"{self.__class__.__name__} does not support outpainting")
+        prompt = ", ".join(prompts)
+
+        request = {
+            "taskType": "OUTPAINTING",
+            "outPaintingParams": {
+                "text": prompt,
+                "image": image.base64,
+                "maskImage": mask.base64,
+                "outPaintingMode": self.outpainting_mode,
+            },
+            "imageGenerationConfig": {
+                "numberOfImages": 1,
+                "quality": self.quality,
+                "width": image.width,
+                "height": image.height,
+                "cfgScale": self.cfg_scale,
+            },
+        }
+
+        if negative_prompts:
+            request["outPaintingParams"]["negativeText"] = ", ".join(negative_prompts)
+
+        if seed:
+            request["imageGenerationConfig"]["seed"] = seed
+
+        return request
 
     def get_generated_image(self, response: dict) -> bytes:
         b64_image_data = response["images"][0]

--- a/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
+++ b/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
@@ -1,5 +1,8 @@
+import base64
+
 import pytest
 
+from griptape.artifacts import ImageArtifact
 from griptape.drivers import BedrockTitanImageGenerationModelDriver
 
 
@@ -7,6 +10,14 @@ class TestBedrockTitanImageGenerationModelDriver:
     @pytest.fixture
     def model_driver(self):
         return BedrockTitanImageGenerationModelDriver()
+
+    @pytest.fixture
+    def image_artifact(self):
+        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=1024)
+
+    @pytest.fixture
+    def mask_artifact(self):
+        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=1024)
 
     def test_init(self, model_driver):
         assert model_driver
@@ -21,8 +32,59 @@ class TestBedrockTitanImageGenerationModelDriver:
         assert parameters["taskType"] == "TEXT_IMAGE"
         assert "textToImageParams" in parameters
         assert parameters["textToImageParams"] == {"text": "prompt1, prompt2", "negativeText": "nprompt1, nprompt2"}
+        assert parameters["textToImageParams"]["negativeText"] == "nprompt1, nprompt2"
         assert "imageGenerationConfig" in parameters
         assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
         assert parameters["imageGenerationConfig"]["width"] == 1024
         assert parameters["imageGenerationConfig"]["height"] == 1024
+        assert parameters["imageGenerationConfig"]["seed"] == 1234
+
+    def test_image_variation_request_parameters(self, model_driver, image_artifact):
+        parameters = model_driver.image_variation_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert "taskType" in parameters
+        assert parameters["taskType"] == "IMAGE_VARIATION"
+        assert "imageVariationParams" in parameters
+        assert parameters["imageVariationParams"]["text"] == "prompt1, prompt2"
+        assert parameters["imageVariationParams"]["images"] == [image_artifact.base64]
+        assert parameters["imageVariationParams"]["negativeText"] == "nprompt1, nprompt2"
+        assert "imageGenerationConfig" in parameters
+        assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
+        assert parameters["imageGenerationConfig"]["seed"] == 1234
+
+    def test_image_inpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
+        parameters = model_driver.image_inpainting_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, mask_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert "taskType" in parameters
+        assert parameters["taskType"] == "INPAINTING"
+        assert "inPaintingParams" in parameters
+        assert parameters["inPaintingParams"]["text"] == "prompt1, prompt2"
+        assert parameters["inPaintingParams"]["image"] == image_artifact.base64
+        assert parameters["inPaintingParams"]["maskImage"] == mask_artifact.base64
+        assert parameters["inPaintingParams"]["negativeText"] == "nprompt1, nprompt2"
+        assert "imageGenerationConfig" in parameters
+        assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
+        assert parameters["imageGenerationConfig"]["seed"] == 1234
+
+    def test_image_outpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
+        parameters = model_driver.image_outpainting_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, mask_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert "taskType" in parameters
+        assert parameters["taskType"] == "OUTPAINTING"
+        assert "outPaintingParams" in parameters
+        assert parameters["outPaintingParams"]["text"] == "prompt1, prompt2"
+        assert parameters["outPaintingParams"]["image"] == image_artifact.base64
+        assert parameters["outPaintingParams"]["maskImage"] == mask_artifact.base64
+        assert parameters["outPaintingParams"]["negativeText"] == "nprompt1, nprompt2"
+        assert "imageGenerationConfig" in parameters
+        assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
         assert parameters["imageGenerationConfig"]["seed"] == 1234

--- a/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
+++ b/tests/unit/drivers/image_generation_model/test_bedrock_titan_image_model_driver.py
@@ -13,18 +13,18 @@ class TestBedrockTitanImageGenerationModelDriver:
 
     @pytest.fixture
     def image_artifact(self):
-        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=1024)
+        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=512)
 
     @pytest.fixture
     def mask_artifact(self):
-        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=1024)
+        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=512)
 
     def test_init(self, model_driver):
         assert model_driver
 
     def test_text_to_image_request_parameters(self, model_driver):
         parameters = model_driver.text_to_image_request_parameters(
-            ["prompt1", "prompt2"], 1024, 1024, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+            ["prompt1", "prompt2"], 1024, 512, negative_prompts=["nprompt1", "nprompt2"], seed=1234
         )
 
         assert isinstance(parameters, dict)
@@ -36,7 +36,7 @@ class TestBedrockTitanImageGenerationModelDriver:
         assert "imageGenerationConfig" in parameters
         assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
         assert parameters["imageGenerationConfig"]["width"] == 1024
-        assert parameters["imageGenerationConfig"]["height"] == 1024
+        assert parameters["imageGenerationConfig"]["height"] == 512
         assert parameters["imageGenerationConfig"]["seed"] == 1234
 
     def test_image_variation_request_parameters(self, model_driver, image_artifact):
@@ -53,6 +53,8 @@ class TestBedrockTitanImageGenerationModelDriver:
         assert parameters["imageVariationParams"]["negativeText"] == "nprompt1, nprompt2"
         assert "imageGenerationConfig" in parameters
         assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
+        assert parameters["imageGenerationConfig"]["width"] == 1024
+        assert parameters["imageGenerationConfig"]["height"] == 512
         assert parameters["imageGenerationConfig"]["seed"] == 1234
 
     def test_image_inpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
@@ -70,6 +72,8 @@ class TestBedrockTitanImageGenerationModelDriver:
         assert parameters["inPaintingParams"]["negativeText"] == "nprompt1, nprompt2"
         assert "imageGenerationConfig" in parameters
         assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
+        assert parameters["imageGenerationConfig"]["width"] == 1024
+        assert parameters["imageGenerationConfig"]["height"] == 512
         assert parameters["imageGenerationConfig"]["seed"] == 1234
 
     def test_image_outpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
@@ -87,4 +91,6 @@ class TestBedrockTitanImageGenerationModelDriver:
         assert parameters["outPaintingParams"]["negativeText"] == "nprompt1, nprompt2"
         assert "imageGenerationConfig" in parameters
         assert parameters["imageGenerationConfig"]["numberOfImages"] == 1
+        assert parameters["imageGenerationConfig"]["width"] == 1024
+        assert parameters["imageGenerationConfig"]["height"] == 512
         assert parameters["imageGenerationConfig"]["seed"] == 1234


### PR DESCRIPTION
The Bedrock Titan image generation model driver previously only supported text to image requests. This PR adds support for image variation, inpainting, and outpainting by generating request parameters for each generation mode.