### PR TITLE
Add outpainting for Stable Diffusion

### DIFF
--- a/tests/unit/drivers/image_generation_model/test_bedrock_stable_diffusion_image_model_driver.py
+++ b/tests/unit/drivers/image_generation_model/test_bedrock_stable_diffusion_image_model_driver.py
@@ -1,5 +1,6 @@
 import pytest
 
+from griptape.artifacts import ImageArtifact
 from griptape.drivers import BedrockStableDiffusionImageGenerationModelDriver
 
 
@@ -7,6 +8,14 @@ class TestBedrockStableDiffusionImageGenerationModelDriver:
     @pytest.fixture
     def model_driver(self):
         return BedrockStableDiffusionImageGenerationModelDriver()
+
+    @pytest.fixture
+    def image_artifact(self):
+        return ImageArtifact(b"image", mime_type="image/png", width=1024, height=1024)
+
+    @pytest.fixture
+    def mask_artifact(self):
+        return ImageArtifact(b"mask", mime_type="image/png", width=1024, height=1024)
 
     def test_init(self, model_driver):
         assert model_driver
@@ -26,3 +35,58 @@ class TestBedrockStableDiffusionImageGenerationModelDriver:
             {"text": "nprompt1", "weight": -1.0},
             {"text": "nprompt2", "weight": -1.0},
         ]
+
+    def test_image_variation_request_parameters(self, model_driver, image_artifact):
+        parameters = model_driver.image_variation_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert parameters["seed"] == 1234
+        assert parameters["width"] == image_artifact.width
+        assert parameters["height"] == image_artifact.height
+        assert parameters["text_prompts"] == [
+            {"text": "prompt1", "weight": 1.0},
+            {"text": "prompt2", "weight": 1.0},
+            {"text": "nprompt1", "weight": -1.0},
+            {"text": "nprompt2", "weight": -1.0},
+        ]
+        assert parameters["init_image"] == image_artifact.base64
+
+    def test_image_inpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
+        parameters = model_driver.image_inpainting_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, mask_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert parameters["seed"] == 1234
+        assert parameters["width"] == image_artifact.width
+        assert parameters["height"] == image_artifact.height
+        assert parameters["text_prompts"] == [
+            {"text": "prompt1", "weight": 1.0},
+            {"text": "prompt2", "weight": 1.0},
+            {"text": "nprompt1", "weight": -1.0},
+            {"text": "nprompt2", "weight": -1.0},
+        ]
+        assert parameters["init_image"] == image_artifact.base64
+        assert parameters["mask_image"] == mask_artifact.base64
+        assert parameters["mask_source"] == "MASK_IMAGE_BLACK"
+
+    def test_image_outpainting_request_parameters(self, model_driver, image_artifact, mask_artifact):
+        parameters = model_driver.image_outpainting_request_parameters(
+            ["prompt1", "prompt2"], image_artifact, mask_artifact, negative_prompts=["nprompt1", "nprompt2"], seed=1234
+        )
+
+        assert isinstance(parameters, dict)
+        assert parameters["seed"] == 1234
+        assert parameters["width"] == image_artifact.width
+        assert parameters["height"] == image_artifact.height
+        assert parameters["text_prompts"] == [
+            {"text": "prompt1", "weight": 1.0},
+            {"text": "prompt2", "weight": 1.0},
+            {"text": "nprompt1", "weight": -1.0},
+            {"text": "nprompt2", "weight": -1.0},
+        ]
+        assert parameters["init_image"] == image_artifact.base64
+        assert parameters["mask_image"] == mask_artifact.base64
+        assert parameters["mask_source"] == "MASK_IMAGE_WHITE"


### PR DESCRIPTION
The Bedrock Stable Diffusion image generation model driver did not previously support image outpainting requests. This PR adds support for outpainting by generating outpainting request parameters. 

Note that the Stable Diffusion API doesn't differentiate between inpainting and outpainting -- both are subsets of the model's image-to-image/masking functionality. To standardize functionality across Griptape drivers, outpainting is implemented by inverting the mask source from MASK_IMAGE_BLACK to MASK_IMAGE_WHITE, meaning the opposite region of the mask image is used.

For example, assume a developer uses this mask image:

![example-mask](https://github.com/griptape-ai/griptape/assets/3770127/dd2ee114-e181-475c-83e0-5904030c5fd6)

If this is used for inpainting, the white region remains constant and the black square is replaced with the generation. If it's used for outpainting, the black square remains constant and the white region is replaced by the generation.