### PR TITLE
Revert Pyupgrade Pep 604 Typing Rewrites

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
     rev: v3.15.0
     hooks:
     - id: pyupgrade
+      args: [--py39-plus, --keep-runtime-typing]
 -   repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.342
     hooks:
     - id: pyright
-      args: [--py39-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,4 @@ repos:
     rev: v1.1.342
     hooks:
     - id: pyright
+      args: [--py39-plus]

--- a/griptape/artifacts/blob_artifact.py
+++ b/griptape/artifacts/blob_artifact.py
@@ -8,7 +8,7 @@ from griptape.artifacts import BaseArtifact
 @define(frozen=True)
 class BlobArtifact(BaseArtifact):
     value: bytes = field(converter=BaseArtifact.value_to_bytes)
-    dir_name: str | None = field(default=None, kw_only=True)
+    dir_name: Optional[str] = field(default=None, kw_only=True)
     encoding: str = field(default="utf-8", kw_only=True)
     encoding_error_handler: str = field(default="strict", kw_only=True)
 

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -26,8 +26,8 @@ class ImageArtifact(BlobArtifact):
     mime_type: str = field(kw_only=True)
     width: int = field(kw_only=True)
     height: int = field(kw_only=True)
-    model: str | None = field(default=None, kw_only=True)
-    prompt: str | None = field(default=None, kw_only=True)
+    model: Optional[str] = field(default=None, kw_only=True)
+    prompt: Optional[str] = field(default=None, kw_only=True)
     name: str = field(default=Factory(lambda self: self.make_name(), takes_self=True), kw_only=True)
 
     def make_name(self) -> str:

--- a/griptape/artifacts/text_artifact.py
+++ b/griptape/artifacts/text_artifact.py
@@ -16,7 +16,7 @@ class TextArtifact(BaseArtifact):
     __embedding: list[float] = field(factory=list, kw_only=True)
 
     @property
-    def embedding(self) -> list[float] | None:
+    def embedding(self) -> Optional[list[float]]:
         return None if len(self.__embedding) == 0 else self.__embedding
 
     def __add__(self, other: TextArtifact) -> TextArtifact:

--- a/griptape/chunkers/base_chunker.py
+++ b/griptape/chunkers/base_chunker.py
@@ -24,7 +24,7 @@ class BaseChunker(ABC):
 
         return [TextArtifact(c) for c in self._chunk_recursively(text)]
 
-    def _chunk_recursively(self, chunk: str, current_separator: ChunkSeparator | None = None) -> list[str]:
+    def _chunk_recursively(self, chunk: str, current_separator: Optional[ChunkSeparator] = None) -> list[str]:
         token_count = self.tokenizer.count_tokens(chunk)
 
         if token_count <= self.max_tokens:

--- a/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 import json
 from typing import Any
 

--- a/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 import json
 from typing import Any
 

--- a/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_sagemaker_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 import json
 from typing import Any
 

--- a/griptape/drivers/embedding/azure_openai_embedding_driver.py
+++ b/griptape/drivers/embedding/azure_openai_embedding_driver.py
@@ -22,8 +22,8 @@ class AzureOpenAiEmbeddingDriver(OpenAiEmbeddingDriver):
 
     azure_deployment: str = field(kw_only=True)
     azure_endpoint: str = field(kw_only=True)
-    azure_ad_token: str | None = field(kw_only=True, default=None)
-    azure_ad_token_provider: str | None = field(kw_only=True, default=None)
+    azure_ad_token: Optional[str] = field(kw_only=True, default=None)
+    azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None)
     api_version: str = field(default="2023-05-15", kw_only=True)
     tokenizer: OpenAiTokenizer = field(
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True

--- a/griptape/drivers/embedding/base_embedding_driver.py
+++ b/griptape/drivers/embedding/base_embedding_driver.py
@@ -18,7 +18,7 @@ class BaseEmbeddingDriver(ExponentialBackoffMixin, ABC):
     """
 
     model: str = field(kw_only=True)
-    tokenizer: BaseTokenizer | None = field(default=None, kw_only=True)
+    tokenizer: Optional[BaseTokenizer] = field(default=None, kw_only=True)
     chunker: BaseChunker = field(init=False)
 
     def __attrs_post_init__(self) -> None:

--- a/griptape/drivers/embedding/base_embedding_driver.py
+++ b/griptape/drivers/embedding/base_embedding_driver.py
@@ -17,7 +17,7 @@ class BaseEmbeddingDriver(ExponentialBackoffMixin, ABC):
     """
 
     model: str = field(kw_only=True)
-    tokenizer: BaseTokenizer | None = field(default=None, kw_only=True)
+    tokenizer: Optional[BaseTokenizer] = field(default=None, kw_only=True)
     chunker: BaseChunker = field(init=False)
 
     def __attrs_post_init__(self) -> None:

--- a/griptape/drivers/embedding/base_embedding_driver.py
+++ b/griptape/drivers/embedding/base_embedding_driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import numpy as np
+from typing import Optional
 from abc import ABC, abstractmethod
 from attr import define, field
 from griptape.artifacts import TextArtifact
@@ -17,7 +18,7 @@ class BaseEmbeddingDriver(ExponentialBackoffMixin, ABC):
     """
 
     model: str = field(kw_only=True)
-    tokenizer: Optional[BaseTokenizer] = field(default=None, kw_only=True)
+    tokenizer: BaseTokenizer | None = field(default=None, kw_only=True)
     chunker: BaseChunker = field(init=False)
 
     def __attrs_post_init__(self) -> None:

--- a/griptape/drivers/embedding/base_multi_model_embedding_driver.py
+++ b/griptape/drivers/embedding/base_multi_model_embedding_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attr import define, field
 

--- a/griptape/drivers/embedding/base_multi_model_embedding_driver.py
+++ b/griptape/drivers/embedding/base_multi_model_embedding_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 
 from attr import define, field
 

--- a/griptape/drivers/embedding/base_multi_model_embedding_driver.py
+++ b/griptape/drivers/embedding/base_multi_model_embedding_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 
 from attr import define, field
 

--- a/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
+++ b/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from griptape.utils import import_optional_dependency
 from attr import define, field, Factory
 from griptape.drivers import BaseEmbeddingDriver

--- a/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
+++ b/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from griptape.utils import import_optional_dependency
 from attr import define, field, Factory
 from griptape.drivers import BaseEmbeddingDriver

--- a/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
+++ b/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from griptape.utils import import_optional_dependency
 from attr import define, field, Factory
 from griptape.drivers import BaseEmbeddingDriver

--- a/griptape/drivers/embedding/openai_embedding_driver.py
+++ b/griptape/drivers/embedding/openai_embedding_driver.py
@@ -27,8 +27,8 @@ class OpenAiEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(default=DEFAULT_MODEL, kw_only=True)
     base_url: str = field(default=None, kw_only=True)
-    api_key: str | None = field(default=None, kw_only=True)
-    organization: str | None = field(default=None, kw_only=True)
+    api_key: Optional[str] = field(default=None, kw_only=True)
+    organization: Optional[str] = field(default=None, kw_only=True)
     client: openai.OpenAI = field(
         default=Factory(
             lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -32,9 +32,9 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
     )
     image_width: int = field(default=512, kw_only=True)
     image_height: int = field(default=512, kw_only=True)
-    seed: int | None = field(default=None, kw_only=True)
+    seed: Optional[int] = field(default=None, kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         request = self.image_generation_model_driver.text_to_image_request_parameters(
             prompts, self.image_width, self.image_height, negative_prompts=negative_prompts, seed=self.seed
         )
@@ -51,7 +51,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_variation_request_parameters(
             prompts, image=image, negative_prompts=negative_prompts, seed=self.seed
@@ -69,7 +69,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_inpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed
@@ -87,7 +87,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_outpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -69,7 +69,11 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_inpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed
@@ -87,7 +91,11 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_outpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -32,9 +32,9 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
     )
     image_width: int = field(default=512, kw_only=True)
     image_height: int = field(default=512, kw_only=True)
-    seed: int | None = field(default=None, kw_only=True)
+    seed: Optional[int] = field(default=None, kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         request = self.image_generation_model_driver.text_to_image_request_parameters(
             prompts, self.image_width, self.image_height, negative_prompts=negative_prompts, seed=self.seed
         )
@@ -51,7 +51,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_variation_request_parameters(
             prompts, image=image, negative_prompts=negative_prompts, seed=self.seed
@@ -69,7 +69,11 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_inpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed
@@ -87,7 +91,11 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_outpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from attr import define, field, Factory
 
@@ -32,9 +32,9 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
     )
     image_width: int = field(default=512, kw_only=True)
     image_height: int = field(default=512, kw_only=True)
-    seed: Optional[int] = field(default=None, kw_only=True)
+    seed: int | None = field(default=None, kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
         request = self.image_generation_model_driver.text_to_image_request_parameters(
             prompts, self.image_width, self.image_height, negative_prompts=negative_prompts, seed=self.seed
         )
@@ -51,7 +51,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_variation_request_parameters(
             prompts, image=image, negative_prompts=negative_prompts, seed=self.seed
@@ -69,11 +69,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_inpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_inpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed
@@ -91,11 +87,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def try_image_outpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         request = self.image_generation_model_driver.image_outpainting_request_parameters(
             prompts, image=image, mask=mask, negative_prompts=negative_prompts, seed=self.seed

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -21,8 +21,8 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
 
     azure_deployment: str = field(kw_only=True)
     azure_endpoint: str = field(kw_only=True)
-    azure_ad_token: str | None = field(kw_only=True, default=None)
-    azure_ad_token_provider: str | None = field(kw_only=True, default=None)
+    azure_ad_token: Optional[str] = field(kw_only=True, default=None)
+    azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None)
     api_version: str = field(default="2023-12-01-preview", kw_only=True)
     client: openai.AzureOpenAI = field(
         default=Factory(

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import openai
 from attr import field, Factory, define
+from typing import Optional
 
 from griptape.drivers import OpenAiImageGenerationDriver
 
@@ -21,8 +22,8 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
 
     azure_deployment: str = field(kw_only=True)
     azure_endpoint: str = field(kw_only=True)
-    azure_ad_token: Optional[str] = field(kw_only=True, default=None)
-    azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None)
+    azure_ad_token: str | None = field(kw_only=True, default=None)
+    azure_ad_token_provider: str | None = field(kw_only=True, default=None)
     api_version: str = field(default="2023-12-01-preview", kw_only=True)
     client: openai.AzureOpenAI = field(
         default=Factory(

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -22,8 +22,8 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
 
     azure_deployment: str = field(kw_only=True)
     azure_endpoint: str = field(kw_only=True)
-    azure_ad_token: str | None = field(kw_only=True, default=None)
-    azure_ad_token_provider: str | None = field(kw_only=True, default=None)
+    azure_ad_token: Optional[str] = field(kw_only=True, default=None)
+    azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None)
     api_version: str = field(default="2023-12-01-preview", kw_only=True)
     client: openai.AzureOpenAI = field(
         default=Factory(

--- a/griptape/drivers/image_generation/base_image_generation_driver.py
+++ b/griptape/drivers/image_generation/base_image_generation_driver.py
@@ -53,7 +53,11 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to generate image variations")
 
     def run_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -67,7 +71,11 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image inpainting")
 
     def run_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -92,12 +100,20 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
 
     @abstractmethod
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         ...

--- a/griptape/drivers/image_generation/base_image_generation_driver.py
+++ b/griptape/drivers/image_generation/base_image_generation_driver.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 @define
 class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
     model: str = field(kw_only=True)
-    structure: Structure | None = field(default=None, kw_only=True)
+    structure: Optional[Structure] = field(default=None, kw_only=True)
 
-    def before_run(self, prompts: list[str], negative_prompts: list[str] | None = None) -> None:
+    def before_run(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> None:
         if self.structure:
             self.structure.publish_event(StartImageGenerationEvent(prompts=prompts, negative_prompts=negative_prompts))
 
@@ -26,7 +26,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
         if self.structure:
             self.structure.publish_event(FinishImageGenerationEvent())
 
-    def run_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def run_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
                 self.before_run(prompts, negative_prompts)
@@ -39,7 +39,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run text to image generation")
 
     def run_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -53,7 +53,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to generate image variations")
 
     def run_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -67,7 +67,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image inpainting")
 
     def run_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -81,23 +81,23 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image outpainting")
 
     @abstractmethod
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         ...

--- a/griptape/drivers/image_generation/base_image_generation_driver.py
+++ b/griptape/drivers/image_generation/base_image_generation_driver.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 @define
 class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
     model: str = field(kw_only=True)
-    structure: Structure | None = field(default=None, kw_only=True)
+    structure: Optional[Structure] = field(default=None, kw_only=True)
 
-    def before_run(self, prompts: list[str], negative_prompts: list[str] | None = None) -> None:
+    def before_run(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> None:
         if self.structure:
             self.structure.publish_event(StartImageGenerationEvent(prompts=prompts, negative_prompts=negative_prompts))
 
@@ -26,7 +26,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
         if self.structure:
             self.structure.publish_event(FinishImageGenerationEvent())
 
-    def run_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def run_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
                 self.before_run(prompts, negative_prompts)
@@ -39,7 +39,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run text to image generation")
 
     def run_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -53,7 +53,11 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to generate image variations")
 
     def run_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -67,7 +71,11 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image inpainting")
 
     def run_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -81,23 +89,31 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image outpainting")
 
     @abstractmethod
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         ...

--- a/griptape/drivers/image_generation/base_image_generation_driver.py
+++ b/griptape/drivers/image_generation/base_image_generation_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from attr import define, field
 
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 @define
 class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
     model: str = field(kw_only=True)
-    structure: Optional[Structure] = field(default=None, kw_only=True)
+    structure: Structure | None = field(default=None, kw_only=True)
 
-    def before_run(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> None:
+    def before_run(self, prompts: list[str], negative_prompts: list[str] | None = None) -> None:
         if self.structure:
             self.structure.publish_event(StartImageGenerationEvent(prompts=prompts, negative_prompts=negative_prompts))
 
@@ -26,7 +26,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
         if self.structure:
             self.structure.publish_event(FinishImageGenerationEvent())
 
-    def run_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
+    def run_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
                 self.before_run(prompts, negative_prompts)
@@ -39,7 +39,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run text to image generation")
 
     def run_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -53,11 +53,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to generate image variations")
 
     def run_image_inpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -71,11 +67,7 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image inpainting")
 
     def run_image_outpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         for attempt in self.retrying():
             with attempt:
@@ -89,31 +81,23 @@ class BaseImageGenerationDriver(ExponentialBackoffMixin, ABC):
             raise Exception("Failed to run image outpainting")
 
     @abstractmethod
-    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_inpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         ...
 
     @abstractmethod
     def try_image_outpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         ...

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -31,24 +31,24 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
     """
 
     api_type: str = field(default=openai.api_type, kw_only=True)
-    api_version: str | None = field(default=openai.api_version, kw_only=True)
+    api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     base_url: str = field(default=None, kw_only=True)
-    api_key: str | None = field(default=None, kw_only=True)
-    organization: str | None = field(default=openai.organization, kw_only=True)
+    api_key: Optional[str] = field(default=None, kw_only=True)
+    organization: Optional[str] = field(default=openai.organization, kw_only=True)
     client: openai.OpenAI = field(
         default=Factory(
             lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
             takes_self=True,
         )
     )
-    style: str | None = field(default=None, kw_only=True)
+    style: Optional[str] = field(default=None, kw_only=True)
     quality: Literal["standard"] | Literal["hd"] = field(default="standard", kw_only=True)
     image_size: (
         Literal["256x256"] | Literal["512x512"] | Literal["1024x1024"] | Literal["1024x1792"] | Literal["1792x1024"]
     ) = field(default="1024x1024", kw_only=True)
     response_format: Literal["b64_json"] = field(default="b64_json", kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         prompt = ", ".join(prompts)
 
         additional_params = {}
@@ -84,17 +84,17 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support variation")
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support inpainting")
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support outpainting")
 

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -89,12 +89,20 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
         raise NotImplementedError(f"{self.__class__.__name__} does not support variation")
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support inpainting")
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support outpainting")
 

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -31,24 +31,24 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
     """
 
     api_type: str = field(default=openai.api_type, kw_only=True)
-    api_version: str | None = field(default=openai.api_version, kw_only=True)
+    api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
     base_url: str = field(default=None, kw_only=True)
-    api_key: str | None = field(default=None, kw_only=True)
-    organization: str | None = field(default=openai.organization, kw_only=True)
+    api_key: Optional[str] = field(default=None, kw_only=True)
+    organization: Optional[str] = field(default=openai.organization, kw_only=True)
     client: openai.OpenAI = field(
         default=Factory(
             lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
             takes_self=True,
         )
     )
-    style: str | None = field(default=None, kw_only=True)
+    style: Optional[str] = field(default=None, kw_only=True)
     quality: Literal["standard"] | Literal["hd"] = field(default="standard", kw_only=True)
     image_size: (
         Literal["256x256"] | Literal["512x512"] | Literal["1024x1024"] | Literal["1024x1792"] | Literal["1792x1024"]
     ) = field(default="1024x1024", kw_only=True)
     response_format: Literal["b64_json"] = field(default="b64_json", kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         prompt = ", ".join(prompts)
 
         additional_params = {}
@@ -84,17 +84,25 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support variation")
 
     def try_image_inpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support inpainting")
 
     def try_image_outpainting(
-        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
+        self,
+        prompts: list[str],
+        image: ImageArtifact,
+        mask: ImageArtifact,
+        negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support outpainting")
 

--- a/griptape/drivers/image_generation/openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/openai_image_generation_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Literal
+from typing import Literal, Optional
 
 import openai
 from attr import field, Factory, define
@@ -31,24 +31,24 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
     """
 
     api_type: str = field(default=openai.api_type, kw_only=True)
-    api_version: Optional[str] = field(default=openai.api_version, kw_only=True)
+    api_version: str | None = field(default=openai.api_version, kw_only=True)
     base_url: str = field(default=None, kw_only=True)
-    api_key: Optional[str] = field(default=None, kw_only=True)
-    organization: Optional[str] = field(default=openai.organization, kw_only=True)
+    api_key: str | None = field(default=None, kw_only=True)
+    organization: str | None = field(default=openai.organization, kw_only=True)
     client: openai.OpenAI = field(
         default=Factory(
             lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
             takes_self=True,
         )
     )
-    style: Optional[str] = field(default=None, kw_only=True)
+    style: str | None = field(default=None, kw_only=True)
     quality: Literal["standard"] | Literal["hd"] = field(default="standard", kw_only=True)
     image_size: (
         Literal["256x256"] | Literal["512x512"] | Literal["1024x1024"] | Literal["1024x1792"] | Literal["1792x1024"]
     ) = field(default="1024x1024", kw_only=True)
     response_format: Literal["b64_json"] = field(default="b64_json", kw_only=True)
 
-    def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
+    def try_text_to_image(self, prompts: list[str], negative_prompts: list[str] | None = None) -> ImageArtifact:
         prompt = ", ".join(prompts)
 
         additional_params = {}
@@ -84,25 +84,17 @@ class OpenAiImageGenerationDriver(BaseImageGenerationDriver):
         )
 
     def try_image_variation(
-        self, prompts: list[str], image: ImageArtifact, negative_prompts: Optional[list[str]] = None
+        self, prompts: list[str], image: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support variation")
 
     def try_image_inpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support inpainting")
 
     def try_image_outpainting(
-        self,
-        prompts: list[str],
-        image: ImageArtifact,
-        mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
+        self, prompts: list[str], image: ImageArtifact, mask: ImageArtifact, negative_prompts: list[str] | None = None
     ) -> ImageArtifact:
         raise NotImplementedError(f"{self.__class__.__name__} does not support outpainting")
 

--- a/griptape/drivers/image_generation_model/base_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/base_image_generation_model_driver.py
@@ -20,8 +20,8 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict[str, Any]:
         ...
 
@@ -30,8 +30,8 @@ class BaseImageGenerationModelDriver(ABC):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict[str, Any]:
         ...
 
@@ -41,8 +41,8 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict[str, Any]:
         ...
 
@@ -52,7 +52,7 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict[str, Any]:
         ...

--- a/griptape/drivers/image_generation_model/base_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/base_image_generation_model_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 from attr import define
 
@@ -20,8 +20,8 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         ...
 
@@ -30,8 +30,8 @@ class BaseImageGenerationModelDriver(ABC):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         ...
 
@@ -41,8 +41,8 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         ...
 
@@ -52,7 +52,7 @@ class BaseImageGenerationModelDriver(ABC):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         ...

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -27,19 +27,19 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     """
 
     cfg_scale: int = field(default=7, kw_only=True)
-    style_preset: str | None = field(default=None, kw_only=True)
-    clip_guidance_preset: str | None = field(default=None, kw_only=True)
-    sampler: str | None = field(default=None, kw_only=True)
-    steps: int | None = field(default=None, kw_only=True)
-    start_schedule: float | None = field(default=None, kw_only=True)
+    style_preset: Optional[str] = field(default=None, kw_only=True)
+    clip_guidance_preset: Optional[str] = field(default=None, kw_only=True)
+    sampler: Optional[str] = field(default=None, kw_only=True)
+    steps: Optional[int] = field(default=None, kw_only=True)
+    start_schedule: Optional[float] = field(default=None, kw_only=True)
 
     def text_to_image_request_parameters(
         self,
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts, width=image_width, height=image_height, negative_prompts=negative_prompts, seed=seed
@@ -49,8 +49,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(prompts, image=image, negative_prompts=negative_prompts, seed=seed)
 
@@ -59,8 +59,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -76,8 +76,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -91,13 +91,13 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     def _request_parameters(
         self,
         prompts: list[str],
-        width: int | None = None,
-        height: int | None = None,
-        image: ImageArtifact | None = None,
-        mask: ImageArtifact | None = None,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
-        mask_source: str | None = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        image: Optional[ImageArtifact] = None,
+        mask: Optional[ImageArtifact] = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
+        mask_source: Optional[str] = None,
     ) -> dict:
         if negative_prompts is None:
             negative_prompts = []

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -28,19 +28,19 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     """
 
     cfg_scale: int = field(default=7, kw_only=True)
-    style_preset: str | None = field(default=None, kw_only=True)
-    clip_guidance_preset: str | None = field(default=None, kw_only=True)
-    sampler: str | None = field(default=None, kw_only=True)
-    steps: int | None = field(default=None, kw_only=True)
-    start_schedule: float | None = field(default=None, kw_only=True)
+    style_preset: Optional[str] = field(default=None, kw_only=True)
+    clip_guidance_preset: Optional[str] = field(default=None, kw_only=True)
+    sampler: Optional[str] = field(default=None, kw_only=True)
+    steps: Optional[int] = field(default=None, kw_only=True)
+    start_schedule: Optional[float] = field(default=None, kw_only=True)
 
     def text_to_image_request_parameters(
         self,
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts, width=image_width, height=image_height, negative_prompts=negative_prompts, seed=seed
@@ -50,8 +50,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(prompts, image=image, negative_prompts=negative_prompts, seed=seed)
 
@@ -60,8 +60,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -77,8 +77,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -92,13 +92,13 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     def _request_parameters(
         self,
         prompts: list[str],
-        width: int | None = None,
-        height: int | None = None,
-        image: ImageArtifact | None = None,
-        mask: ImageArtifact | None = None,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
-        mask_source: str | None = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        image: Optional[ImageArtifact] = None,
+        mask: Optional[ImageArtifact] = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
+        mask_source: Optional[str] = None,
     ) -> dict:
         if negative_prompts is None:
             negative_prompts = []

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from typing import Optional
 
 from attr import field, define
 
@@ -27,19 +28,19 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     """
 
     cfg_scale: int = field(default=7, kw_only=True)
-    style_preset: Optional[str] = field(default=None, kw_only=True)
-    clip_guidance_preset: Optional[str] = field(default=None, kw_only=True)
-    sampler: Optional[str] = field(default=None, kw_only=True)
-    steps: Optional[int] = field(default=None, kw_only=True)
-    start_schedule: Optional[float] = field(default=None, kw_only=True)
+    style_preset: str | None = field(default=None, kw_only=True)
+    clip_guidance_preset: str | None = field(default=None, kw_only=True)
+    sampler: str | None = field(default=None, kw_only=True)
+    steps: int | None = field(default=None, kw_only=True)
+    start_schedule: float | None = field(default=None, kw_only=True)
 
     def text_to_image_request_parameters(
         self,
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         return self._request_parameters(
             prompts, width=image_width, height=image_height, negative_prompts=negative_prompts, seed=seed
@@ -49,8 +50,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         return self._request_parameters(prompts, image=image, negative_prompts=negative_prompts, seed=seed)
 
@@ -59,8 +60,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -76,8 +77,8 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         return self._request_parameters(
             prompts,
@@ -91,13 +92,13 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
     def _request_parameters(
         self,
         prompts: list[str],
-        width: Optional[int] = None,
-        height: Optional[int] = None,
-        image: Optional[ImageArtifact] = None,
-        mask: Optional[ImageArtifact] = None,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
-        mask_source: Optional[str] = None,
+        width: int | None = None,
+        height: int | None = None,
+        image: ImageArtifact | None = None,
+        mask: ImageArtifact | None = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
+        mask_source: str | None = None,
     ) -> dict:
         if negative_prompts is None:
             negative_prompts = []

--- a/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
@@ -28,8 +28,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -57,8 +57,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -87,8 +87,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -107,8 +107,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        seed: int | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        seed: Optional[int] = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -132,7 +132,7 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
 
         return base64.decodebytes(bytes(b64_image_data, "utf-8"))
 
-    def _add_common_params(self, request: dict[str, Any], width: int, height: int, seed: int | None = None) -> dict:
+    def _add_common_params(self, request: dict[str, Any], width: int, height: int, seed: Optional[int] = None) -> dict:
         request["imageGenerationConfig"] = {
             "numberOfImages": 1,
             "quality": self.quality,

--- a/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_titan_image_generation_model_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any
+from typing import Any, Optional
 
 from attr import field, define
 
@@ -28,8 +28,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image_width: int,
         image_height: int,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -57,8 +57,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -87,8 +87,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -107,8 +107,8 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        seed: Optional[int] = None,
+        negative_prompts: list[str] | None = None,
+        seed: int | None = None,
     ) -> dict:
         prompt = ", ".join(prompts)
 
@@ -132,7 +132,7 @@ class BedrockTitanImageGenerationModelDriver(BaseImageGenerationModelDriver):
 
         return base64.decodebytes(bytes(b64_image_data, "utf-8"))
 
-    def _add_common_params(self, request: dict[str, Any], width: int, height: int, seed: Optional[int] = None) -> dict:
+    def _add_common_params(self, request: dict[str, Any], width: int, height: int, seed: int | None = None) -> dict:
         request["imageGenerationConfig"] = {
             "numberOfImages": 1,
             "quality": self.quality,

--- a/griptape/drivers/memory/conversation/amazon_dynamodb_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/amazon_dynamodb_conversation_memory_driver.py
@@ -32,7 +32,7 @@ class AmazonDynamoDbConversationMemoryDriver(BaseConversationMemoryDriver):
             ExpressionAttributeValues={":value": memory.to_json()},
         )
 
-    def load(self) -> ConversationMemory | None:
+    def load(self) -> Optional[ConversationMemory]:
         response = self.table.get_item(Key={self.partition_key: self.partition_key_value})
 
         if "Item" in response and self.value_attribute_key in response["Item"]:

--- a/griptape/drivers/memory/conversation/base_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/base_conversation_memory_driver.py
@@ -12,5 +12,5 @@ class BaseConversationMemoryDriver(ABC):
         ...
 
     @abstractmethod
-    def load(self, *args, **kwargs) -> ConversationMemory | None:
+    def load(self, *args, **kwargs) -> Optional[ConversationMemory]:
         ...

--- a/griptape/drivers/prompt/base_multi_model_prompt_driver.py
+++ b/griptape/drivers/prompt/base_multi_model_prompt_driver.py
@@ -22,7 +22,7 @@ class BaseMultiModelPromptDriver(BasePromptDriver, ABC):
         prompt_model_driver: Prompt Model Driver to use.
     """
 
-    tokenizer: BaseTokenizer | None = field(default=None, kw_only=True)
+    tokenizer: Optional[BaseTokenizer] = field(default=None, kw_only=True)
     prompt_model_driver: BasePromptModelDriver = field(kw_only=True)
     stream: bool = field(default=False, kw_only=True)
 

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -28,8 +28,8 @@ class BasePromptDriver(ExponentialBackoffMixin, ABC):
     """
 
     temperature: float = field(default=0.1, kw_only=True)
-    max_tokens: int | None = field(default=None, kw_only=True)
-    structure: Structure | None = field(default=None, kw_only=True)
+    max_tokens: Optional[int] = field(default=None, kw_only=True)
+    structure: Optional[Structure] = field(default=None, kw_only=True)
     prompt_stack_to_string: Callable[[PromptStack], str] = field(
         default=Factory(lambda self: self.default_prompt_stack_to_string_converter, takes_self=True), kw_only=True
     )

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -33,9 +33,9 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         _ratelimit_tokens_reset_at: The time at which the current rate limit window resets.
     """
 
-    base_url: str | None = field(default=None, kw_only=True)
-    api_key: str | None = field(default=None, kw_only=True)
-    organization: str | None = field(default=None, kw_only=True)
+    base_url: Optional[str] = field(default=None, kw_only=True)
+    api_key: Optional[str] = field(default=None, kw_only=True)
+    organization: Optional[str] = field(default=None, kw_only=True)
     client: openai.OpenAI = field(
         default=Factory(
             lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
@@ -47,8 +47,8 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True), kw_only=True
     )
     user: str = field(default="", kw_only=True)
-    response_format: Literal["json_object"] | None = field(default=None, kw_only=True)
-    seed: int | None = field(default=None, kw_only=True)
+    response_format: Optional[Literal["json_object"]] = field(default=None, kw_only=True)
+    seed: Optional[int] = field(default=None, kw_only=True)
     ignored_exception_types: tuple[type[Exception], ...] = field(
         default=Factory(
             lambda: (
@@ -62,12 +62,12 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
-    _ratelimit_request_limit: int | None = field(init=False, default=None)
-    _ratelimit_requests_remaining: int | None = field(init=False, default=None)
-    _ratelimit_requests_reset_at: datetime | None = field(init=False, default=None)
-    _ratelimit_token_limit: int | None = field(init=False, default=None)
-    _ratelimit_tokens_remaining: int | None = field(init=False, default=None)
-    _ratelimit_tokens_reset_at: datetime | None = field(init=False, default=None)
+    _ratelimit_request_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_requests_reset_at: Optional[datetime] = field(init=False, default=None)
+    _ratelimit_token_limit: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_remaining: Optional[int] = field(init=False, default=None)
+    _ratelimit_tokens_reset_at: Optional[datetime] = field(init=False, default=None)
 
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         result = self.client.chat.completions.with_raw_response.create(**self._base_params(prompt_stack))

--- a/griptape/drivers/prompt_model/base_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/base_prompt_model_driver.py
@@ -11,7 +11,7 @@ from griptape.tokenizers import BaseTokenizer
 @define
 class BasePromptModelDriver(ABC):
     max_tokens: int = field(default=600, kw_only=True)
-    prompt_driver: BasePromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
     supports_streaming: bool = field(default=True, kw_only=True)
 
     @property

--- a/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_claude_prompt_model_driver.py
@@ -13,7 +13,7 @@ class BedrockClaudePromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.999, kw_only=True)
     top_k: int = field(default=250, kw_only=True)
     _tokenizer: BedrockClaudeTokenizer = field(default=None, kw_only=True)
-    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockClaudeTokenizer:

--- a/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_jurassic_prompt_model_driver.py
@@ -13,7 +13,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockJurassicPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockJurassicTokenizer = field(default=None, kw_only=True)
-    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
     supports_streaming: bool = field(default=False, kw_only=True)
 
     @property

--- a/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
@@ -13,7 +13,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockLlamaTokenizer = field(default=None, kw_only=True)
-    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockLlamaTokenizer:
@@ -52,7 +52,7 @@ class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
         input_pairs: list[tuple] = list(it.zip_longest(inputs, inputs))
         for input_pair in input_pairs:
             first_input: PromptStack.Input = input_pair[0]
-            second_input: PromptStack.Input | None = input_pair[1]
+            second_input: Optional[PromptStack.Input] = input_pair[1]
 
             if first_input.is_system():
                 prompt_lines.append(f"<s>[INST] <<SYS>>\n{first_input.content}\n<</SYS>>\n\n")

--- a/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
@@ -14,7 +14,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockLlamaTokenizer = field(default=None, kw_only=True)
-    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockLlamaTokenizer:
@@ -53,7 +53,7 @@ class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
         input_pairs: list[tuple] = list(it.zip_longest(inputs, inputs))
         for input_pair in input_pairs:
             first_input: PromptStack.Input = input_pair[0]
-            second_input: PromptStack.Input | None = input_pair[1]
+            second_input: Optional[PromptStack.Input] = input_pair[1]
 
             if first_input.is_system():
                 prompt_lines.append(f"<s>[INST] <<SYS>>\n{first_input.content}\n<</SYS>>\n\n")

--- a/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_llama_prompt_model_driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import json
 import itertools as it
+from typing import Optional
 from attr import define, field
 from griptape.artifacts import TextArtifact
 from griptape.utils import PromptStack
@@ -13,7 +14,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockLlamaTokenizer = field(default=None, kw_only=True)
-    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
+    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockLlamaTokenizer:
@@ -52,7 +53,7 @@ class BedrockLlamaPromptModelDriver(BasePromptModelDriver):
         input_pairs: list[tuple] = list(it.zip_longest(inputs, inputs))
         for input_pair in input_pairs:
             first_input: PromptStack.Input = input_pair[0]
-            second_input: Optional[PromptStack.Input] = input_pair[1]
+            second_input: PromptStack.Input | None = input_pair[1]
 
             if first_input.is_system():
                 prompt_lines.append(f"<s>[INST] <<SYS>>\n{first_input.content}\n<</SYS>>\n\n")

--- a/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
+++ b/griptape/drivers/prompt_model/bedrock_titan_prompt_model_driver.py
@@ -13,7 +13,7 @@ from griptape.drivers import AmazonBedrockPromptDriver
 class BedrockTitanPromptModelDriver(BasePromptModelDriver):
     top_p: float = field(default=0.9, kw_only=True)
     _tokenizer: BedrockTitanTokenizer = field(default=None, kw_only=True)
-    prompt_driver: AmazonBedrockPromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[AmazonBedrockPromptDriver] = field(default=None, kw_only=True)
 
     @property
     def tokenizer(self) -> BedrockTitanTokenizer:

--- a/griptape/drivers/sql/amazon_redshift_sql_driver.py
+++ b/griptape/drivers/sql/amazon_redshift_sql_driver.py
@@ -12,17 +12,17 @@ if TYPE_CHECKING:
 class AmazonRedshiftSqlDriver(BaseSqlDriver):
     database: str = field(kw_only=True)
     session: boto3.Session = field(kw_only=True)
-    cluster_identifier: str | None = field(default=None, kw_only=True)
-    workgroup_name: str | None = field(default=None, kw_only=True)
-    db_user: str | None = field(default=None, kw_only=True)
-    database_credentials_secret_arn: str | None = field(default=None, kw_only=True)
+    cluster_identifier: Optional[str] = field(default=None, kw_only=True)
+    workgroup_name: Optional[str] = field(default=None, kw_only=True)
+    db_user: Optional[str] = field(default=None, kw_only=True)
+    database_credentials_secret_arn: Optional[str] = field(default=None, kw_only=True)
     wait_for_query_completion_sec: float = field(default=0.3, kw_only=True)
     client: Any = field(
         default=Factory(lambda self: self.session.client("redshift-data"), takes_self=True), kw_only=True
     )
 
     @workgroup_name.validator  # pyright: ignore
-    def validate_params(self, _, workgroup_name: str | None) -> None:
+    def validate_params(self, _, workgroup_name: Optional[str]) -> None:
         if not self.cluster_identifier and not self.workgroup_name:
             raise ValueError("Provide a value for one of `cluster_identifier` or `workgroup_name`")
         elif self.cluster_identifier and self.workgroup_name:
@@ -46,14 +46,14 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
         rows = cls._process_rows_from_records(records)
         return cls._process_cells_from_rows_and_columns(columns, rows)
 
-    def execute_query(self, query: str) -> list[BaseSqlDriver.RowResult] | None:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
         if rows:
             return [BaseSqlDriver.RowResult(row) for row in rows]
         else:
             return None
 
-    def execute_query_raw(self, query: str) -> list[dict[str, Any]] | None:
+    def execute_query_raw(self, query: str) -> list[dict[str, Optional[Any]]]:
         function_kwargs = {"Sql": query, "Database": self.database}
         if self.workgroup_name:
             function_kwargs["WorkgroupName"] = self.workgroup_name
@@ -88,7 +88,7 @@ class AmazonRedshiftSqlDriver(BaseSqlDriver):
         elif statement["Status"] in ["FAILED", "ABORTED"]:
             return None
 
-    def get_table_schema(self, table: str, schema: str | None = None) -> str | None:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         function_kwargs = {"Database": self.database, "Table": table}
         if schema:
             function_kwargs["Schema"] = schema

--- a/griptape/drivers/sql/snowflake_sql_driver.py
+++ b/griptape/drivers/sql/snowflake_sql_driver.py
@@ -39,7 +39,7 @@ class SnowflakeSqlDriver(BaseSqlDriver):
         if not engine.url.render_as_string().startswith("snowflake://"):
             raise ValueError("Provide a Snowflake connection")
 
-    def execute_query(self, query: str) -> list[BaseSqlDriver.RowResult] | None:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
 
         if rows:
@@ -47,7 +47,7 @@ class SnowflakeSqlDriver(BaseSqlDriver):
         else:
             return None
 
-    def execute_query_raw(self, query: str) -> list[dict[str, Any]] | None:
+    def execute_query_raw(self, query: str) -> list[dict[str, Optional[Any]]]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         with self.engine.connect() as con:
@@ -58,7 +58,7 @@ class SnowflakeSqlDriver(BaseSqlDriver):
             else:
                 return None
 
-    def get_table_schema(self, table: str, schema: str | None = None) -> str | None:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         try:

--- a/griptape/drivers/sql/sql_driver.py
+++ b/griptape/drivers/sql/sql_driver.py
@@ -20,7 +20,7 @@ class SqlDriver(BaseSqlDriver):
 
         self.engine = sqlalchemy.create_engine(self.engine_url, **self.create_engine_params)
 
-    def execute_query(self, query: str) -> list[BaseSqlDriver.RowResult] | None:
+    def execute_query(self, query: str) -> Optional[list[BaseSqlDriver.RowResult]]:
         rows = self.execute_query_raw(query)
 
         if rows:
@@ -28,7 +28,7 @@ class SqlDriver(BaseSqlDriver):
         else:
             return None
 
-    def execute_query_raw(self, query: str) -> list[dict[str, Any]] | None:
+    def execute_query_raw(self, query: str) -> list[dict[str, Optional[Any]]]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         with self.engine.begin() as con:
@@ -39,7 +39,7 @@ class SqlDriver(BaseSqlDriver):
             else:
                 return None
 
-    def get_table_schema(self, table: str, schema: str | None = None) -> str | None:
+    def get_table_schema(self, table: str, schema: Optional[str] = None) -> Optional[str]:
         sqlalchemy = import_optional_dependency("sqlalchemy")
 
         try:

--- a/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
@@ -21,7 +21,7 @@ class AmazonOpenSearchVectorStoreDriver(OpenSearchVectorStoreDriver):
 
     session: Session = field(kw_only=True)
 
-    http_auth: str | tuple[str, str] | None = field(
+    http_auth: str | tuple[str, Optional[str]] = field(
         default=Factory(
             lambda self: import_optional_dependency("requests_aws4auth").AWS4Auth(
                 self.session.get_credentials().access_key,
@@ -33,7 +33,7 @@ class AmazonOpenSearchVectorStoreDriver(OpenSearchVectorStoreDriver):
         )
     )
 
-    client: OpenSearch | None = field(
+    client: Optional[OpenSearch] = field(
         default=Factory(
             lambda self: import_optional_dependency("opensearchpy").OpenSearch(
                 hosts=[{"host": self.host, "port": self.port}],

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -18,21 +18,21 @@ class BaseVectorStoreDriver(ABC):
         id: str
         vector: list[float]
         score: float
-        meta: dict | None = None
-        namespace: str | None = None
+        meta: Optional[dict] = None
+        namespace: Optional[str] = None
 
     @dataclass
     class Entry:
         id: str
         vector: list[float]
-        meta: dict | None = None
-        namespace: str | None = None
+        meta: Optional[dict] = None
+        namespace: Optional[str] = None
 
     embedding_driver: BaseEmbeddingDriver = field(kw_only=True)
     futures_executor: futures.Executor = field(default=Factory(lambda: futures.ThreadPoolExecutor()), kw_only=True)
 
     def upsert_text_artifacts(
-        self, artifacts: dict[str, list[TextArtifact]], meta: dict | None = None, **kwargs
+        self, artifacts: dict[str, list[TextArtifact]], meta: Optional[dict] = None, **kwargs
     ) -> None:
         utils.execute_futures_dict(
             {
@@ -43,7 +43,7 @@ class BaseVectorStoreDriver(ABC):
         )
 
     def upsert_text_artifact(
-        self, artifact: TextArtifact, namespace: str | None = None, meta: dict | None = None, **kwargs
+        self, artifact: TextArtifact, namespace: Optional[str] = None, meta: Optional[dict] = None, **kwargs
     ) -> str:
         if not meta:
             meta = {}
@@ -60,9 +60,9 @@ class BaseVectorStoreDriver(ABC):
     def upsert_text(
         self,
         string: str,
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         return self.upsert_vector(
@@ -77,27 +77,27 @@ class BaseVectorStoreDriver(ABC):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         ...
 
     @abstractmethod
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[Entry]:
         ...
 
     @abstractmethod
-    def load_entries(self, namespace: str | None = None) -> list[Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[Entry]:
         ...
 
     @abstractmethod
     def query(
         self,
         query: str,
-        count: int | None = None,
-        namespace: str | None = None,
+        count: Optional[int] = None,
+        namespace: Optional[str] = None,
         include_vectors: bool = False,
         **kwargs,
     ) -> list[QueryResult]:

--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -22,7 +22,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
 
     api_key: str = field(kw_only=True)
     url: str = field(kw_only=True)
-    mq: marqo.Client | None = field(
+    mq: Optional[marqo.Client] = field(
         default=Factory(
             lambda self: import_optional_dependency("marqo").Client(self.url, api_key=self.api_key), takes_self=True
         ),
@@ -33,9 +33,9 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_text(
         self,
         string: str,
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         """Upsert a text document into the Marqo index.
@@ -62,7 +62,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         return response["items"][0]["_id"]
 
     def upsert_text_artifact(
-        self, artifact: TextArtifact, namespace: str | None = None, meta: dict | None = None, **kwargs
+        self, artifact: TextArtifact, namespace: Optional[str] = None, meta: Optional[dict] = None, **kwargs
     ) -> str:
         """Upsert a text artifact into the Marqo index.
 
@@ -87,7 +87,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         response = self.mq.index(self.index).add_documents([doc], tensor_fields=["Description", "artifact"])
         return response["items"][0]["_id"]
 
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Load a document entry from the Marqo index.
 
         Args:
@@ -108,7 +108,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         else:
             return None
 
-    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Load all document entries from the Marqo index.
 
         Args:
@@ -145,8 +145,8 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
     def query(
         self,
         query: str,
-        count: int | None = None,
-        namespace: str | None = None,
+        count: Optional[int] = None,
+        namespace: Optional[str] = None,
         include_vectors: bool = False,
         include_metadata: bool = True,
         **kwargs,
@@ -218,9 +218,9 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         """Upsert a vector into the Marqo index.

--- a/griptape/drivers/vector/mongodb_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_vector_store_driver.py
@@ -42,9 +42,9 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         """Inserts or updates a vector in the collection.
@@ -62,7 +62,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
             )
         return vector_id
 
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Loads a document entry from the MongoDB collection based on the vector ID.
 
         Returns:
@@ -81,7 +81,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
                 id=str(doc["_id"]), vector=doc["vector"], namespace=doc["namespace"], meta=doc["meta"]
             )
 
-    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Loads all document entries from the MongoDB collection.
 
         Entries can optionally be filtered by namespace.
@@ -102,10 +102,10 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
     def query(
         self,
         query: str,
-        count: int | None = None,
-        namespace: str | None = None,
+        count: Optional[int] = None,
+        namespace: Optional[str] = None,
         include_vectors: bool = False,
-        offset: int | None = None,
+        offset: Optional[int] = None,
         **kwargs,
     ) -> list[BaseVectorStoreDriver.QueryResult]:
         """Queries the MongoDB collection for documents that match the provided query string.

--- a/griptape/drivers/vector/mongodb_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_vector_store_driver.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from attr import define, field, Factory
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
@@ -42,9 +42,9 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: Optional[str] = None,
-        namespace: Optional[str] = None,
-        meta: Optional[dict] = None,
+        vector_id: str | None = None,
+        namespace: str | None = None,
+        meta: dict | None = None,
         **kwargs,
     ) -> str:
         """Inserts or updates a vector in the collection.
@@ -62,7 +62,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
             )
         return vector_id
 
-    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
+    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
         """Loads a document entry from the MongoDB collection based on the vector ID.
 
         Returns:
@@ -81,7 +81,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
                 id=str(doc["_id"]), vector=doc["vector"], namespace=doc["namespace"], meta=doc["meta"]
             )
 
-    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
         """Loads all document entries from the MongoDB collection.
 
         Entries can optionally be filtered by namespace.
@@ -102,10 +102,10 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
     def query(
         self,
         query: str,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
+        count: int | None = None,
+        namespace: str | None = None,
         include_vectors: bool = False,
-        offset: Optional[int] = None,
+        offset: int | None = None,
         **kwargs,
     ) -> list[BaseVectorStoreDriver.QueryResult]:
         """Queries the MongoDB collection for documents that match the provided query string.

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -25,7 +25,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
 
     host: str = field(kw_only=True)
     port: int = field(default=443, kw_only=True)
-    http_auth: str | tuple[str, str] | None = field(default=None, kw_only=True)
+    http_auth: str | tuple[str, Optional[str]] = field(default=None, kw_only=True)
     use_ssl: bool = field(default=True, kw_only=True)
     verify_certs: bool = field(default=True, kw_only=True)
     index_name: str = field(kw_only=True)
@@ -46,9 +46,9 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         """Inserts or updates a vector in OpenSearch.
@@ -64,7 +64,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
 
         return response["_id"]
 
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Retrieves a specific vector entry from OpenSearch based on its identifier and optional namespace.
 
         Returns:
@@ -93,7 +93,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             logging.error(f"Error while loading entry: {e}")
             return None
 
-    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Retrieves all vector entries from OpenSearch that match the optional namespace.
 
         Returns:
@@ -160,7 +160,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             for hit in response["hits"]["hits"]
         ]
 
-    def create_index(self, vector_dimension: int | None = None, settings_override: dict | None = None) -> None:
+    def create_index(self, vector_dimension: Optional[int] = None, settings_override: Optional[dict] = None) -> None:
         """Creates a new vector index in OpenSearch.
 
         The index is structured to support k-NN (k-nearest neighbors) queries.

--- a/griptape/drivers/vector/pinecone_vector_store_driver.py
+++ b/griptape/drivers/vector/pinecone_vector_store_driver.py
@@ -13,7 +13,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
     api_key: str = field(kw_only=True)
     index_name: str = field(kw_only=True)
     environment: str = field(kw_only=True)
-    project_name: str | None = field(default=None, kw_only=True)
+    project_name: Optional[str] = field(default=None, kw_only=True)
     index: pinecone.Index = field(init=False)
 
     def __attrs_post_init__(self) -> None:
@@ -25,9 +25,9 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         vector_id = vector_id if vector_id else str_to_hash(str(vector))
@@ -38,7 +38,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
 
         return vector_id
 
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         result = self.index.fetch(ids=[vector_id], namespace=namespace).to_dict()
         vectors = list(result["vectors"].values())
 
@@ -51,7 +51,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
         else:
             return None
 
-    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         # This is a hacky way to query up to 10,000 values from Pinecone. Waiting on an official API for fetching
         # all values from a namespace:
         # https://community.pinecone.io/t/is-there-a-way-to-query-all-the-vectors-and-or-metadata-from-a-namespace/797/5
@@ -70,8 +70,8 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
     def query(
         self,
         query: str,
-        count: int | None = None,
-        namespace: str | None = None,
+        count: Optional[int] = None,
+        namespace: Optional[str] = None,
         include_vectors: bool = False,
         # PineconeVectorStorageDriver-specific params:
         include_metadata=True,

--- a/griptape/drivers/vector/redis_vector_store_driver.py
+++ b/griptape/drivers/vector/redis_vector_store_driver.py
@@ -32,7 +32,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     host: str = field(kw_only=True)
     port: int = field(kw_only=True)
     db: int = field(kw_only=True, default=0)
-    password: str | None = field(default=None, kw_only=True)
+    password: Optional[str] = field(default=None, kw_only=True)
     index: str = field(kw_only=True)
 
     client: Redis = field(
@@ -47,9 +47,9 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     def upsert_vector(
         self,
         vector: list[float],
-        vector_id: str | None = None,
-        namespace: str | None = None,
-        meta: dict | None = None,
+        vector_id: Optional[str] = None,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
         **kwargs,
     ) -> str:
         """Inserts or updates a vector in Redis.
@@ -70,7 +70,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
 
         return vector_id
 
-    def load_entry(self, vector_id: str, namespace: str | None = None) -> BaseVectorStoreDriver.Entry | None:
+    def load_entry(self, vector_id: str, namespace: Optional[str] = None) -> Optional[BaseVectorStoreDriver.Entry]:
         """Retrieves a specific vector entry from Redis based on its identifier and optional namespace.
 
         Returns:
@@ -83,7 +83,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
 
         return BaseVectorStoreDriver.Entry(id=vector_id, meta=meta, vector=vector, namespace=namespace)
 
-    def load_entries(self, namespace: str | None = None) -> list[BaseVectorStoreDriver.Entry]:
+    def load_entries(self, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:
         """Retrieves all vector entries from Redis that match the optional namespace.
 
         Returns:
@@ -95,7 +95,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         return [self.load_entry(key.decode("utf-8"), namespace=namespace) for key in keys]
 
     def query(
-        self, query: str, count: int | None = None, namespace: str | None = None, **kwargs
+        self, query: str, count: Optional[int] = None, namespace: Optional[str] = None, **kwargs
     ) -> list[BaseVectorStoreDriver.QueryResult]:
         """Performs a nearest neighbor search on Redis to find vectors similar to the provided input vector.
 
@@ -137,7 +137,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
             )
         return query_results
 
-    def create_index(self, namespace: str | None = None, vector_dimension: int | None = None) -> None:
+    def create_index(self, namespace: Optional[str] = None, vector_dimension: Optional[int] = None) -> None:
         """Creates a new index in Redis with the specified properties.
 
         If an index with the given name already exists, a warning is logged and the method does not proceed.
@@ -165,10 +165,10 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
             definition = IndexDefinition(prefix=[doc_prefix], index_type=IndexType.HASH)
             self.client.ft(self.index).create_index(fields=schema, definition=definition)
 
-    def _generate_key(self, vector_id: str, namespace: str | None = None) -> str:
+    def _generate_key(self, vector_id: str, namespace: Optional[str] = None) -> str:
         """Generates a Redis key using the provided vector ID and optionally a namespace."""
         return f"{namespace}:{vector_id}" if namespace else vector_id
 
-    def _get_doc_prefix(self, namespace: str | None = None) -> str:
+    def _get_doc_prefix(self, namespace: Optional[str] = None) -> str:
         """Get the document prefix based on the provided namespace."""
         return f"{namespace}:" if namespace else ""

--- a/griptape/engines/extraction/base_extraction_engine.py
+++ b/griptape/engines/extraction/base_extraction_engine.py
@@ -44,5 +44,5 @@ class BaseExtractionEngine(ABC):
         )
 
     @abstractmethod
-    def extract(self, text: str | ListArtifact, rulesets: list[Ruleset] | None = None, **kwargs) -> ListArtifact:
+    def extract(self, text: str | ListArtifact, rulesets: Optional[list[Ruleset]] = None, **kwargs) -> ListArtifact:
         ...

--- a/griptape/engines/extraction/csv_extraction_engine.py
+++ b/griptape/engines/extraction/csv_extraction_engine.py
@@ -15,7 +15,7 @@ class CsvExtractionEngine(BaseExtractionEngine):
     template_generator: J2 = field(default=Factory(lambda: J2("engines/extraction/csv_extraction.j2")), kw_only=True)
 
     def extract(
-        self, text: str | ListArtifact, column_names: list[str], rulesets: Ruleset | None = None
+        self, text: str | ListArtifact, column_names: list[str], rulesets: Optional[Ruleset] = None
     ) -> ListArtifact | ErrorArtifact:
         try:
             return ListArtifact(
@@ -44,7 +44,7 @@ class CsvExtractionEngine(BaseExtractionEngine):
         artifacts: list[TextArtifact],
         column_names: list[str],
         rows: list[CsvRowArtifact],
-        rulesets: Ruleset | None = None,
+        rulesets: Optional[Ruleset] = None,
     ) -> list[CsvRowArtifact]:
         artifacts_text = self.chunk_joiner.join([a.value for a in artifacts])
         full_text = self.template_generator.render(

--- a/griptape/engines/extraction/json_extraction_engine.py
+++ b/griptape/engines/extraction/json_extraction_engine.py
@@ -14,7 +14,7 @@ class JsonExtractionEngine(BaseExtractionEngine):
     template_generator: J2 = field(default=Factory(lambda: J2("engines/extraction/json_extraction.j2")), kw_only=True)
 
     def extract(
-        self, text: str | ListArtifact, template_schema: dict, rulesets: Ruleset | None = None
+        self, text: str | ListArtifact, template_schema: dict, rulesets: Optional[Ruleset] = None
     ) -> ListArtifact | ErrorArtifact:
         try:
             json_schema = json.dumps(template_schema)
@@ -39,7 +39,7 @@ class JsonExtractionEngine(BaseExtractionEngine):
         artifacts: list[TextArtifact],
         json_template_schema: str,
         extractions: list[TextArtifact],
-        rulesets: Ruleset | None = None,
+        rulesets: Optional[Ruleset] = None,
     ) -> list[TextArtifact]:
         artifacts_text = self.chunk_joiner.join([a.value for a in artifacts])
         full_text = self.template_generator.render(

--- a/griptape/engines/image/base_image_generation_engine.py
+++ b/griptape/engines/image/base_image_generation_engine.py
@@ -10,7 +10,7 @@ from griptape.rules import Ruleset
 class BaseImageGenerationEngine:
     image_generation_driver: BaseImageGenerationDriver = field(kw_only=True)
 
-    def _ruleset_to_prompts(self, prompts: list[str] | None, rulesets: list[Ruleset] | None) -> list[str]:
+    def _ruleset_to_prompts(self, prompts: Optional[list[str]], rulesets: Optional[list[Ruleset]]) -> list[str]:
         if not prompts:
             prompts = []
 

--- a/griptape/engines/image/base_image_generation_engine.py
+++ b/griptape/engines/image/base_image_generation_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from attr import field, define
+from typing import Optional
 
 from griptape.drivers import BaseImageGenerationDriver
 from griptape.rules import Ruleset
@@ -10,7 +11,7 @@ from griptape.rules import Ruleset
 class BaseImageGenerationEngine:
     image_generation_driver: BaseImageGenerationDriver = field(kw_only=True)
 
-    def _ruleset_to_prompts(self, prompts: Optional[list[str]], rulesets: Optional[list[Ruleset]]) -> list[str]:
+    def _ruleset_to_prompts(self, prompts: list[str] | None, rulesets: list[Ruleset] | None) -> list[str]:
         if not prompts:
             prompts = []
 

--- a/griptape/engines/image/base_image_generation_engine.py
+++ b/griptape/engines/image/base_image_generation_engine.py
@@ -11,7 +11,7 @@ from griptape.rules import Ruleset
 class BaseImageGenerationEngine:
     image_generation_driver: BaseImageGenerationDriver = field(kw_only=True)
 
-    def _ruleset_to_prompts(self, prompts: list[str] | None, rulesets: list[Ruleset] | None) -> list[str]:
+    def _ruleset_to_prompts(self, prompts: Optional[list[str]], rulesets: Optional[list[Ruleset]]) -> list[str]:
         if not prompts:
             prompts = []
 

--- a/griptape/engines/image/inpainting_image_generation_engine.py
+++ b/griptape/engines/image/inpainting_image_generation_engine.py
@@ -14,9 +14,9 @@ class InpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/inpainting_image_generation_engine.py
+++ b/griptape/engines/image/inpainting_image_generation_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from attr import define
+from typing import Optional
 
 from griptape.engines import BaseImageGenerationEngine
 from griptape.artifacts import ImageArtifact
@@ -14,9 +15,9 @@ class InpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        negative_rulesets: Optional[list[Ruleset]] = None,
+        negative_prompts: list[str] | None = None,
+        rulesets: list[Ruleset] | None = None,
+        negative_rulesets: list[Ruleset] | None = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/inpainting_image_generation_engine.py
+++ b/griptape/engines/image/inpainting_image_generation_engine.py
@@ -15,9 +15,9 @@ class InpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/outpainting_image_generation_engine.py
+++ b/griptape/engines/image/outpainting_image_generation_engine.py
@@ -14,9 +14,9 @@ class OutpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/outpainting_image_generation_engine.py
+++ b/griptape/engines/image/outpainting_image_generation_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from attr import define
+from typing import Optional
 
 from griptape.artifacts import ImageArtifact
 from griptape.rules import Ruleset
@@ -14,9 +15,9 @@ class OutpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        negative_rulesets: Optional[list[Ruleset]] = None,
+        negative_prompts: list[str] | None = None,
+        rulesets: list[Ruleset] | None = None,
+        negative_rulesets: list[Ruleset] | None = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/outpainting_image_generation_engine.py
+++ b/griptape/engines/image/outpainting_image_generation_engine.py
@@ -15,9 +15,9 @@ class OutpaintingImageGenerationEngine(BaseImageGenerationEngine):
         prompts: list[str],
         image: ImageArtifact,
         mask: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/prompt_image_generation_engine.py
+++ b/griptape/engines/image/prompt_image_generation_engine.py
@@ -13,9 +13,9 @@ class PromptImageGenerationEngine(BaseImageGenerationEngine):
     def run(
         self,
         prompts: list[str],
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/prompt_image_generation_engine.py
+++ b/griptape/engines/image/prompt_image_generation_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from attr import define
+from typing import Optional
 
 from griptape.rules import Ruleset
 from griptape.artifacts import ImageArtifact
@@ -13,9 +14,9 @@ class PromptImageGenerationEngine(BaseImageGenerationEngine):
     def run(
         self,
         prompts: list[str],
-        negative_prompts: Optional[list[str]] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        negative_rulesets: Optional[list[Ruleset]] = None,
+        negative_prompts: list[str] | None = None,
+        rulesets: list[Ruleset] | None = None,
+        negative_rulesets: list[Ruleset] | None = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/prompt_image_generation_engine.py
+++ b/griptape/engines/image/prompt_image_generation_engine.py
@@ -14,9 +14,9 @@ class PromptImageGenerationEngine(BaseImageGenerationEngine):
     def run(
         self,
         prompts: list[str],
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/variation_image_generation_engine.py
+++ b/griptape/engines/image/variation_image_generation_engine.py
@@ -13,9 +13,9 @@ class VariationImageGenerationEngine(BaseImageGenerationEngine):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/variation_image_generation_engine.py
+++ b/griptape/engines/image/variation_image_generation_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from attr import define
 
+from typing import Optional
 from griptape.engines import BaseImageGenerationEngine
 from griptape.artifacts import ImageArtifact
 from griptape.rules import Ruleset
@@ -13,9 +14,9 @@ class VariationImageGenerationEngine(BaseImageGenerationEngine):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: Optional[list[str]] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        negative_rulesets: Optional[list[Ruleset]] = None,
+        negative_prompts: list[str] | None = None,
+        rulesets: list[Ruleset] | None = None,
+        negative_rulesets: list[Ruleset] | None = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/image/variation_image_generation_engine.py
+++ b/griptape/engines/image/variation_image_generation_engine.py
@@ -14,9 +14,9 @@ class VariationImageGenerationEngine(BaseImageGenerationEngine):
         self,
         prompts: list[str],
         image: ImageArtifact,
-        negative_prompts: list[str] | None = None,
-        rulesets: list[Ruleset] | None = None,
-        negative_rulesets: list[Ruleset] | None = None,
+        negative_prompts: Optional[list[str]] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        negative_rulesets: Optional[list[Ruleset]] = None,
     ) -> ImageArtifact:
         prompts = self._ruleset_to_prompts(prompts, rulesets)
         negative_prompts = self._ruleset_to_prompts(negative_prompts, negative_rulesets)

--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -8,7 +8,9 @@ from griptape.rules import Ruleset
 @define
 class BaseQueryEngine(ABC):
     @abstractmethod
-    def query(self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None) -> TextArtifact:
+    def query(
+        self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None
+    ) -> TextArtifact:
         ...
 
     @abstractmethod

--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -8,7 +8,7 @@ from griptape.rules import Ruleset
 @define
 class BaseQueryEngine(ABC):
     @abstractmethod
-    def query(self, query: str, namespace: str | None = None, rulesets: list[Ruleset] | None = None) -> TextArtifact:
+    def query(self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None) -> TextArtifact:
         ...
 
     @abstractmethod
@@ -16,7 +16,7 @@ class BaseQueryEngine(ABC):
         ...
 
     @abstractmethod
-    def upsert_text_artifact(self, artifact: TextArtifact, namespace: str | None = None) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
         ...
 
     @abstractmethod

--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -9,7 +9,9 @@ from griptape.rules import Ruleset
 @define
 class BaseQueryEngine(ABC):
     @abstractmethod
-    def query(self, query: str, namespace: str | None = None, rulesets: list[Ruleset] | None = None) -> TextArtifact:
+    def query(
+        self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None
+    ) -> TextArtifact:
         ...
 
     @abstractmethod
@@ -17,7 +19,7 @@ class BaseQueryEngine(ABC):
         ...
 
     @abstractmethod
-    def upsert_text_artifact(self, artifact: TextArtifact, namespace: str | None = None) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
         ...
 
     @abstractmethod

--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from attr import define
+from typing import Optional
 from griptape.artifacts import TextArtifact, ListArtifact
 from griptape.rules import Ruleset
 
@@ -8,9 +9,7 @@ from griptape.rules import Ruleset
 @define
 class BaseQueryEngine(ABC):
     @abstractmethod
-    def query(
-        self, query: str, namespace: Optional[str] = None, rulesets: Optional[list[Ruleset]] = None
-    ) -> TextArtifact:
+    def query(self, query: str, namespace: str | None = None, rulesets: list[Ruleset] | None = None) -> TextArtifact:
         ...
 
     @abstractmethod
@@ -18,7 +17,7 @@ class BaseQueryEngine(ABC):
         ...
 
     @abstractmethod
-    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: str | None = None) -> str:
         ...
 
     @abstractmethod

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -26,10 +26,10 @@ class VectorQueryEngine(BaseQueryEngine):
     def query(
         self,
         query: str,
-        namespace: str | None = None,
-        rulesets: list[Ruleset] | None = None,
-        metadata: str | None = None,
-        top_n: int | None = None,
+        namespace: Optional[str] = None,
+        rulesets: Optional[list[Ruleset]] = None,
+        metadata: Optional[str] = None,
+        top_n: Optional[int] = None,
     ) -> TextArtifact:
         tokenizer = self.prompt_driver.tokenizer
         result = self.vector_store_driver.query(query, top_n, namespace)
@@ -68,7 +68,7 @@ class VectorQueryEngine(BaseQueryEngine):
 
         return self.prompt_driver.run(PromptStack(inputs=[PromptStack.Input(message, role=PromptStack.USER_ROLE)]))
 
-    def upsert_text_artifact(self, artifact: TextArtifact, namespace: str | None = None) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
         result = self.vector_store_driver.upsert_text_artifact(artifact, namespace=namespace)
 
         return result

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact, BaseArtifact, ListArtifact
 from griptape.utils import PromptStack
@@ -26,10 +26,10 @@ class VectorQueryEngine(BaseQueryEngine):
     def query(
         self,
         query: str,
-        namespace: Optional[str] = None,
-        rulesets: Optional[list[Ruleset]] = None,
-        metadata: Optional[str] = None,
-        top_n: Optional[int] = None,
+        namespace: str | None = None,
+        rulesets: list[Ruleset] | None = None,
+        metadata: str | None = None,
+        top_n: int | None = None,
     ) -> TextArtifact:
         tokenizer = self.prompt_driver.tokenizer
         result = self.vector_store_driver.query(query, top_n, namespace)
@@ -68,7 +68,7 @@ class VectorQueryEngine(BaseQueryEngine):
 
         return self.prompt_driver.run(PromptStack(inputs=[PromptStack.Input(message, role=PromptStack.USER_ROLE)]))
 
-    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: str | None = None) -> str:
         result = self.vector_store_driver.upsert_text_artifact(artifact, namespace=namespace)
 
         return result

--- a/griptape/events/base_action_subtask_event.py
+++ b/griptape/events/base_action_subtask_event.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
 
 @define
 class BaseActionSubtaskEvent(BaseTaskEvent, ABC):
-    subtask_parent_task_id: str | None = field(kw_only=True)
-    subtask_thought: str | None = field(kw_only=True)
-    subtask_action_name: str | None = field(kw_only=True)
-    subtask_action_path: str | None = field(kw_only=True)
-    subtask_action_input: dict | None = field(kw_only=True)
+    subtask_parent_task_id: Optional[str] = field(kw_only=True)
+    subtask_thought: Optional[str] = field(kw_only=True)
+    subtask_action_name: Optional[str] = field(kw_only=True)
+    subtask_action_path: Optional[str] = field(kw_only=True)
+    subtask_action_input: Optional[dict] = field(kw_only=True)
 
     @classmethod
     def from_task(cls, task: ActionSubtask) -> BaseActionSubtaskEvent:

--- a/griptape/events/base_task_event.py
+++ b/griptape/events/base_task_event.py
@@ -16,7 +16,7 @@ class BaseTaskEvent(BaseEvent, ABC):
     task_child_ids: list[str] = field(kw_only=True)
 
     task_input: BaseArtifact = field(kw_only=True)
-    task_output: BaseArtifact | None = field(kw_only=True)
+    task_output: Optional[BaseArtifact] = field(kw_only=True)
 
     @classmethod
     def from_task(cls, task: BaseTask) -> BaseTaskEvent:

--- a/griptape/events/start_image_generation_event.py
+++ b/griptape/events/start_image_generation_event.py
@@ -8,7 +8,7 @@ from .base_image_generation_event import BaseImageGenerationEvent
 @define
 class StartImageGenerationEvent(BaseImageGenerationEvent):
     prompts: list[str] = field(kw_only=True)
-    negative_prompts: list[str] | None = field(default=None, kw_only=True)
+    negative_prompts: Optional[list[str]] = field(default=None, kw_only=True)
 
     def to_dict(self) -> dict:
         from griptape.schemas import StartImageGenerationEventSchema

--- a/griptape/events/start_image_generation_event.py
+++ b/griptape/events/start_image_generation_event.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Optional
 from attr import define, field
 
 from .base_image_generation_event import BaseImageGenerationEvent
@@ -8,7 +9,7 @@ from .base_image_generation_event import BaseImageGenerationEvent
 @define
 class StartImageGenerationEvent(BaseImageGenerationEvent):
     prompts: list[str] = field(kw_only=True)
-    negative_prompts: Optional[list[str]] = field(default=None, kw_only=True)
+    negative_prompts: list[str] | None = field(default=None, kw_only=True)
 
     def to_dict(self) -> dict:
         from griptape.schemas import StartImageGenerationEventSchema

--- a/griptape/events/start_image_generation_event.py
+++ b/griptape/events/start_image_generation_event.py
@@ -9,7 +9,7 @@ from .base_image_generation_event import BaseImageGenerationEvent
 @define
 class StartImageGenerationEvent(BaseImageGenerationEvent):
     prompts: list[str] = field(kw_only=True)
-    negative_prompts: list[str] | None = field(default=None, kw_only=True)
+    negative_prompts: Optional[list[str]] = field(default=None, kw_only=True)
 
     def to_dict(self) -> dict:
         from griptape.schemas import StartImageGenerationEventSchema

--- a/griptape/events/start_prompt_event.py
+++ b/griptape/events/start_prompt_event.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attrs import define
 from attrs import field
 from griptape.events.base_prompt_event import BasePromptEvent

--- a/griptape/events/start_prompt_event.py
+++ b/griptape/events/start_prompt_event.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attrs import define
 from attrs import field
 from griptape.events.base_prompt_event import BasePromptEvent

--- a/griptape/loaders/dataframe_loader.py
+++ b/griptape/loaders/dataframe_loader.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @define
 class DataFrameLoader(BaseLoader):
-    embedding_driver: BaseEmbeddingDriver | None = field(default=None, kw_only=True)
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
 
     def load(self, dataframe: DataFrame) -> list[CsvRowArtifact]:
         return self._load_file(dataframe)

--- a/griptape/loaders/email_loader.py
+++ b/griptape/loaders/email_loader.py
@@ -23,9 +23,9 @@ class EmailLoader(BaseLoader):
         """
 
         label: str = field(kw_only=True)
-        key: str | None = field(default=None, kw_only=True)
-        search_criteria: str | None = field(default=None, kw_only=True)
-        max_count: int | None = field(default=None, kw_only=True)
+        key: Optional[str] = field(default=None, kw_only=True)
+        search_criteria: Optional[str] = field(default=None, kw_only=True)
+        max_count: Optional[int] = field(default=None, kw_only=True)
 
     imap_url: str = field(kw_only=True)
     username: str = field(kw_only=True)

--- a/griptape/loaders/file_loader.py
+++ b/griptape/loaders/file_loader.py
@@ -10,7 +10,7 @@ from griptape.loaders import BaseLoader
 
 @define
 class FileLoader(BaseLoader):
-    encoding: str | None = field(default=None, kw_only=True)
+    encoding: Optional[str] = field(default=None, kw_only=True)
 
     def load(self, path: str | Path) -> TextArtifact | BlobArtifact | ErrorArtifact:
         return self.file_to_artifact(path)

--- a/griptape/loaders/pdf_loader.py
+++ b/griptape/loaders/pdf_loader.py
@@ -16,11 +16,11 @@ class PdfLoader(TextLoader):
         kw_only=True,
     )
 
-    def load(self, stream: str | IO | Path, password: str | None = None) -> list[TextArtifact]:
+    def load(self, stream: str | IO | Path, password: Optional[str] = None) -> list[TextArtifact]:
         return self._load_pdf(stream, password)
 
     def load_collection(
-        self, streams: list[str | IO | Path], password: str | None = None
+        self, streams: list[str | IO | Path], password: Optional[str] = None
     ) -> dict[str, list[TextArtifact]]:
         return execute_futures_dict(
             {
@@ -31,7 +31,7 @@ class PdfLoader(TextLoader):
             }
         )
 
-    def _load_pdf(self, stream: str | IO | Path, password: str | None) -> list[TextArtifact]:
+    def _load_pdf(self, stream: str | IO | Path, password: Optional[str]) -> list[TextArtifact]:
         reader = PdfReader(stream, strict=True, password=password)
 
         return self.text_to_artifacts("\n".join([p.extract_text() for p in reader.pages]))

--- a/griptape/loaders/text_loader.py
+++ b/griptape/loaders/text_loader.py
@@ -27,7 +27,7 @@ class TextLoader(BaseLoader):
         ),
         kw_only=True,
     )
-    embedding_driver: BaseEmbeddingDriver | None = field(default=None, kw_only=True)
+    embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
     encoding: str = field(default="utf-8", kw_only=True)
 
     def load(self, text: str | Path) -> list[TextArtifact]:

--- a/griptape/memory/structure/conversation_memory.py
+++ b/griptape/memory/structure/conversation_memory.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:
 @define
 class ConversationMemory:
     type: str = field(default=Factory(lambda self: self.__class__.__name__, takes_self=True), kw_only=True)
-    driver: BaseConversationMemoryDriver | None = field(default=None, kw_only=True)
+    driver: Optional[BaseConversationMemoryDriver] = field(default=None, kw_only=True)
     runs: list[Run] = field(factory=list, kw_only=True)
     structure: Structure = field(init=False)
     autoload: bool = field(default=True, kw_only=True)
     autoprune: bool = field(default=True, kw_only=True)
-    max_runs: int | None = field(default=None, kw_only=True)
+    max_runs: Optional[int] = field(default=None, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         if self.driver and self.autoload:
@@ -57,7 +57,7 @@ class ConversationMemory:
 
         return dict(ConversationMemorySchema().dump(self))
 
-    def to_prompt_stack(self, last_n: int | None = None) -> PromptStack:
+    def to_prompt_stack(self, last_n: Optional[int] = None) -> PromptStack:
         prompt_stack = PromptStack()
         runs = self.runs[-last_n:] if last_n else self.runs
         for run in runs:

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from typing import Optional
 from attr import define, field, Factory
 from griptape.drivers import OpenAiChatPromptDriver

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import json
 import logging
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from typing import Optional
 from attr import define, field, Factory
 from griptape.drivers import OpenAiChatPromptDriver

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -22,7 +22,7 @@ class SummaryConversationMemory(ConversationMemory):
         default=Factory(lambda: OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)),
         kw_only=True,
     )
-    summary: str | None = field(default=None, kw_only=True)
+    summary: Optional[str] = field(default=None, kw_only=True)
     summary_index: int = field(default=0, kw_only=True)
     summary_template_generator: J2 = field(default=Factory(lambda: J2("memory/conversation/summary.j2")), kw_only=True)
     summarize_conversation_template_generator: J2 = field(
@@ -37,7 +37,7 @@ class SummaryConversationMemory(ConversationMemory):
     def from_json(cls, memory_json: str) -> SummaryConversationMemory:
         return SummaryConversationMemory.from_dict(json.loads(memory_json))
 
-    def to_prompt_stack(self, last_n: int | None = None) -> PromptStack:
+    def to_prompt_stack(self, last_n: Optional[int] = None) -> PromptStack:
         stack = PromptStack()
         if self.summary:
             stack.add_user_input(self.summary_template_generator.render(summary=self.summary))
@@ -51,7 +51,7 @@ class SummaryConversationMemory(ConversationMemory):
     def to_dict(self) -> dict:
         return dict(SummaryConversationMemorySchema().dump(self))
 
-    def unsummarized_runs(self, last_n: int | None = None) -> list[Run]:
+    def unsummarized_runs(self, last_n: Optional[int] = None) -> list[Run]:
         summary_index_runs = self.runs[self.summary_index :]
 
         if last_n:

--- a/griptape/memory/task/storage/text_artifact_storage.py
+++ b/griptape/memory/task/storage/text_artifact_storage.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attr import define, field
 from griptape.artifacts import TextArtifact, BaseArtifact, ListArtifact
 from griptape.memory.task.storage import BaseArtifactStorage

--- a/griptape/memory/task/storage/text_artifact_storage.py
+++ b/griptape/memory/task/storage/text_artifact_storage.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attr import define, field
 from griptape.artifacts import TextArtifact, BaseArtifact, ListArtifact
 from griptape.memory.task.storage import BaseArtifactStorage

--- a/griptape/memory/task/task_memory.py
+++ b/griptape/memory/task/task_memory.py
@@ -27,7 +27,7 @@ class TaskMemory(ActivityMixin):
 
             seen_types.append(type(storage))
 
-    def get_storage_for(self, artifact: BaseArtifact) -> BaseArtifactStorage | None:
+    def get_storage_for(self, artifact: BaseArtifact) -> Optional[BaseArtifactStorage]:
         find_storage = lambda a: next((v for k, v in self.artifact_storages.items() if isinstance(a, k)), None)
 
         if isinstance(artifact, ListArtifact):
@@ -71,7 +71,7 @@ class TaskMemory(ActivityMixin):
         else:
             return InfoArtifact("tool output is empty")
 
-    def store_artifact(self, namespace: str, artifact: BaseArtifact) -> BaseArtifact | None:
+    def store_artifact(self, namespace: str, artifact: BaseArtifact) -> Optional[BaseArtifact]:
         namespace_storage = self.namespace_storage.get(namespace)
         storage = self.get_storage_for(artifact)
 
@@ -107,7 +107,7 @@ class TaskMemory(ActivityMixin):
         else:
             return ListArtifact()
 
-    def find_input_memory(self, memory_name: str) -> TaskMemory | None:
+    def find_input_memory(self, memory_name: str) -> Optional[TaskMemory]:
         if memory_name == self.name:
             return self
         else:

--- a/griptape/mixins/action_subtask_origin_mixin.py
+++ b/griptape/mixins/action_subtask_origin_mixin.py
@@ -12,15 +12,15 @@ if TYPE_CHECKING:
 @define(slots=False)
 class ActionSubtaskOriginMixin:
     @abstractmethod
-    def find_tool(self, tool_name: str) -> BaseTool | None:
+    def find_tool(self, tool_name: str) -> Optional[BaseTool]:
         ...
 
     @abstractmethod
-    def find_memory(self, memory_name: str) -> TaskMemory | None:
+    def find_memory(self, memory_name: str) -> Optional[TaskMemory]:
         ...
 
     @abstractmethod
-    def find_subtask(self, subtask_id: str) -> ActionSubtask | None:
+    def find_subtask(self, subtask_id: str) -> Optional[ActionSubtask]:
         ...
 
     @abstractmethod

--- a/griptape/mixins/image_artifact_file_output_mixin.py
+++ b/griptape/mixins/image_artifact_file_output_mixin.py
@@ -10,8 +10,8 @@ from griptape.artifacts import ImageArtifact
 
 @define(slots=False)
 class ImageArtifactFileOutputMixin:
-    output_dir: str | None = field(default=None, kw_only=True)
-    output_file: str | None = field(default=None, kw_only=True)
+    output_dir: Optional[str] = field(default=None, kw_only=True)
+    output_file: Optional[str] = field(default=None, kw_only=True)
 
     @output_dir.validator  # pyright: ignore
     def validate_output_dir(self, _, output_dir: str) -> None:

--- a/griptape/mixins/image_artifact_file_output_mixin.py
+++ b/griptape/mixins/image_artifact_file_output_mixin.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import os
 
 from attr import define, field
+from typing import Optional
 
 from griptape.artifacts import ImageArtifact
 
 
 @define(slots=False)
 class ImageArtifactFileOutputMixin:
-    output_dir: Optional[str] = field(default=None, kw_only=True)
-    output_file: Optional[str] = field(default=None, kw_only=True)
+    output_dir: str | None = field(default=None, kw_only=True)
+    output_file: str | None = field(default=None, kw_only=True)
 
     @output_dir.validator  # pyright: ignore
     def validate_output_dir(self, _, output_dir: str) -> None:

--- a/griptape/mixins/image_artifact_file_output_mixin.py
+++ b/griptape/mixins/image_artifact_file_output_mixin.py
@@ -9,8 +9,8 @@ from griptape.artifacts import ImageArtifact
 
 @define(slots=False)
 class ImageArtifactFileOutputMixin:
-    output_dir: str | None = field(default=None, kw_only=True)
-    output_file: str | None = field(default=None, kw_only=True)
+    output_dir: Optional[str] = field(default=None, kw_only=True)
+    output_file: Optional[str] = field(default=None, kw_only=True)
 
     @output_dir.validator  # pyright: ignore
     def validate_output_dir(self, _, output_dir: str) -> None:

--- a/griptape/mixins/rule_mixin.py
+++ b/griptape/mixins/rule_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 
 from attr import define, field
 

--- a/griptape/mixins/rule_mixin.py
+++ b/griptape/mixins/rule_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 
 from attr import define, field
 

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class Agent(Structure):
     input_template: str = field(default=PromptTask.DEFAULT_INPUT_TEMPLATE)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
-    max_meta_memory_entries: int | None = field(default=20, kw_only=True)
+    max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         if len(self.tasks) == 0:

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -74,7 +74,7 @@ class Pipeline(Structure):
 
         return context
 
-    def __run_from_task(self, task: BaseTask | None) -> None:
+    def __run_from_task(self, task: Optional[BaseTask]) -> None:
         if task is None:
             return
         else:

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -46,7 +46,9 @@ class Structure(ABC):
     custom_logger: Optional[Logger] = field(default=None, kw_only=True)
     logger_level: int = field(default=logging.INFO, kw_only=True)
     event_listeners: list[EventListener] = field(factory=list, kw_only=True)
-    conversation_memory: Optional[ConversationMemory] = field(default=Factory(lambda: ConversationMemory()), kw_only=True)
+    conversation_memory: Optional[ConversationMemory] = field(
+        default=Factory(lambda: ConversationMemory()), kw_only=True
+    )
     task_memory: Optional[TaskMemory] = field(
         default=Factory(lambda self: self.default_task_memory, takes_self=True), kw_only=True
     )

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -43,16 +43,16 @@ class Structure(ABC):
     rulesets: list[Ruleset] = field(factory=list, kw_only=True)
     rules: list[Rule] = field(factory=list, kw_only=True)
     tasks: list[BaseTask] = field(factory=list, kw_only=True)
-    custom_logger: Logger | None = field(default=None, kw_only=True)
+    custom_logger: Optional[Logger] = field(default=None, kw_only=True)
     logger_level: int = field(default=logging.INFO, kw_only=True)
     event_listeners: list[EventListener] = field(factory=list, kw_only=True)
-    conversation_memory: ConversationMemory | None = field(default=Factory(lambda: ConversationMemory()), kw_only=True)
-    task_memory: TaskMemory | None = field(
+    conversation_memory: Optional[ConversationMemory] = field(default=Factory(lambda: ConversationMemory()), kw_only=True)
+    task_memory: Optional[TaskMemory] = field(
         default=Factory(lambda self: self.default_task_memory, takes_self=True), kw_only=True
     )
-    meta_memory: MetaMemory | None = field(default=Factory(lambda: MetaMemory()), kw_only=True)
+    meta_memory: Optional[MetaMemory] = field(default=Factory(lambda: MetaMemory()), kw_only=True)
     _execution_args: tuple = ()
-    _logger: Logger | None = None
+    _logger: Optional[Logger] = None
 
     @rulesets.validator  # pyright: ignore
     def validate_rulesets(self, _, rulesets: list[Ruleset]) -> None:
@@ -101,11 +101,11 @@ class Structure(ABC):
             return self._logger
 
     @property
-    def input_task(self) -> BaseTask | None:
+    def input_task(self) -> Optional[BaseTask]:
         return self.tasks[0] if self.tasks else None
 
     @property
-    def output_task(self) -> BaseTask | None:
+    def output_task(self) -> Optional[BaseTask]:
         return self.tasks[-1] if self.tasks else None
 
     @property

--- a/griptape/tasks/action_subtask.py
+++ b/griptape/tasks/action_subtask.py
@@ -33,22 +33,22 @@ class ActionSubtask(PromptTask):
         },
     )
 
-    _input: str | None = field(default=None)
-    parent_task_id: str | None = field(default=None, kw_only=True)
-    thought: str | None = field(default=None, kw_only=True)
-    action_name: str | None = field(default=None, kw_only=True)
-    action_path: str | None = field(default=None, kw_only=True)
-    action_input: dict | None = field(default=None, kw_only=True)
+    _input: Optional[str] = field(default=None)
+    parent_task_id: Optional[str] = field(default=None, kw_only=True)
+    thought: Optional[str] = field(default=None, kw_only=True)
+    action_name: Optional[str] = field(default=None, kw_only=True)
+    action_path: Optional[str] = field(default=None, kw_only=True)
+    action_input: Optional[dict] = field(default=None, kw_only=True)
 
-    _tool: BaseTool | None = None
-    _memory: TaskMemory | None = None
+    _tool: Optional[BaseTool] = None
+    _memory: Optional[TaskMemory] = None
 
     @property
     def input(self) -> TextArtifact:
         return TextArtifact(self._input)
 
     @property
-    def origin_task(self) -> ActionSubtaskOriginMixin | None:
+    def origin_task(self) -> Optional[ActionSubtaskOriginMixin]:
         return self.structure.find_task(self.parent_task_id)
 
     @property

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -27,10 +27,10 @@ class BaseTask(ABC):
     state: State = field(default=State.PENDING, kw_only=True)
     parent_ids: list[str] = field(factory=list, kw_only=True)
     child_ids: list[str] = field(factory=list, kw_only=True)
-    max_meta_memory_entries: int | None = field(default=20, kw_only=True)
+    max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
 
-    output: BaseArtifact | None = field(default=None, init=False)
-    structure: Structure | None = field(default=None, init=False)
+    output: Optional[BaseArtifact] = field(default=None, init=False)
+    structure: Optional[Structure] = field(default=None, init=False)
     context: dict[str, Any] = field(factory=dict, kw_only=True)
 
     @property
@@ -81,7 +81,7 @@ class BaseTask(ABC):
         if self.structure:
             self.structure.publish_event(FinishTaskEvent.from_task(self))
 
-    def execute(self) -> BaseArtifact | None:
+    def execute(self) -> Optional[BaseArtifact]:
         try:
             self.state = BaseTask.State.EXECUTING
 

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from attr import define, field, Factory
 
@@ -27,10 +27,10 @@ class BaseTask(ABC):
     state: State = field(default=State.PENDING, kw_only=True)
     parent_ids: list[str] = field(factory=list, kw_only=True)
     child_ids: list[str] = field(factory=list, kw_only=True)
-    max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
+    max_meta_memory_entries: int | None = field(default=20, kw_only=True)
 
-    output: Optional[BaseArtifact] = field(default=None, init=False)
-    structure: Optional[Structure] = field(default=None, init=False)
+    output: BaseArtifact | None = field(default=None, init=False)
+    structure: Structure | None = field(default=None, init=False)
     context: dict[str, Any] = field(factory=dict, kw_only=True)
 
     @property
@@ -81,7 +81,7 @@ class BaseTask(ABC):
         if self.structure:
             self.structure.publish_event(FinishTaskEvent.from_task(self))
 
-    def execute(self) -> Optional[BaseArtifact]:
+    def execute(self) -> BaseArtifact | None:
         try:
             self.state = BaseTask.State.EXECUTING
 

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -12,12 +12,12 @@ if TYPE_CHECKING:
 
 @define
 class PromptTask(BaseTextInputTask):
-    prompt_driver: BasePromptDriver | None = field(default=None, kw_only=True)
+    prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
     generate_system_template: Callable[[PromptTask], str] = field(
         default=Factory(lambda self: self.default_system_template_generator, takes_self=True), kw_only=True
     )
 
-    output: TextArtifact | ErrorArtifact | InfoArtifact | None = field(default=None, init=False)
+    output: TextArtifact | ErrorArtifact | Optional[InfoArtifact] = field(default=None, init=False)
 
     @property
     def prompt_stack(self) -> PromptStack:

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact
 from griptape.engines import PromptSummaryEngine

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact
 from griptape.engines import PromptSummaryEngine

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 @define
 class ToolTask(PromptTask, ActionSubtaskOriginMixin):
     tool: BaseTool = field(kw_only=True)
-    subtask: ActionSubtask | None = field(default=None, kw_only=True)
-    task_memory: TaskMemory | None = field(default=None, kw_only=True)
+    subtask: Optional[ActionSubtask] = field(default=None, kw_only=True)
+    task_memory: Optional[TaskMemory] = field(default=None, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         self.set_default_tools_memory(self.task_memory)
@@ -54,16 +54,16 @@ class ToolTask(PromptTask, ActionSubtaskOriginMixin):
 
         return self.output
 
-    def find_tool(self, tool_name: str) -> BaseTool | None:
+    def find_tool(self, tool_name: str) -> Optional[BaseTool]:
         if self.tool.name == tool_name:
             return self.tool
         else:
             return None
 
-    def find_memory(self, memory_name: str) -> TaskMemory | None:
+    def find_memory(self, memory_name: str) -> Optional[TaskMemory]:
         return None
 
-    def find_subtask(self, subtask_id: str) -> ActionSubtask | None:
+    def find_subtask(self, subtask_id: str) -> Optional[ActionSubtask]:
         return self.subtask if self.subtask.id == subtask_id else None
 
     def add_subtask(self, subtask: ActionSubtask) -> ActionSubtask:

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -23,7 +23,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_subtasks: int = field(default=DEFAULT_MAX_STEPS, kw_only=True)
-    task_memory: TaskMemory | None = field(default=None, kw_only=True)
+    task_memory: Optional[TaskMemory] = field(default=None, kw_only=True)
     subtasks: list[ActionSubtask] = field(factory=list)
     generate_assistant_subtask_template: Callable[[ActionSubtask], str] = field(
         default=Factory(lambda self: self.default_assistant_subtask_template_generator, takes_self=True), kw_only=True
@@ -143,7 +143,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
         return self.output
 
-    def find_subtask(self, subtask_id: str) -> ActionSubtask | None:
+    def find_subtask(self, subtask_id: str) -> Optional[ActionSubtask]:
         return next((subtask for subtask in self.subtasks if subtask.id == subtask_id), None)
 
     def add_subtask(self, subtask: ActionSubtask) -> ActionSubtask:
@@ -156,8 +156,8 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
         return subtask
 
-    def find_tool(self, tool_name: str) -> BaseTool | None:
+    def find_tool(self, tool_name: str) -> Optional[BaseTool]:
         return next((t for t in self.tools if t.name == tool_name), None)
 
-    def find_memory(self, memory_name: str) -> TaskMemory | None:
+    def find_memory(self, memory_name: str) -> Optional[TaskMemory]:
         return next((m for m in self.tool_output_memory if m.name == memory_name), None)

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 from attr import define, field, Factory
 from griptape import utils
 from griptape.artifacts import TextArtifact, ErrorArtifact
@@ -23,7 +23,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_subtasks: int = field(default=DEFAULT_MAX_STEPS, kw_only=True)
-    task_memory: Optional[TaskMemory] = field(default=None, kw_only=True)
+    task_memory: TaskMemory | None = field(default=None, kw_only=True)
     subtasks: list[ActionSubtask] = field(factory=list)
     generate_assistant_subtask_template: Callable[[ActionSubtask], str] = field(
         default=Factory(lambda self: self.default_assistant_subtask_template_generator, takes_self=True), kw_only=True
@@ -143,7 +143,7 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
         return self.output
 
-    def find_subtask(self, subtask_id: str) -> Optional[ActionSubtask]:
+    def find_subtask(self, subtask_id: str) -> ActionSubtask | None:
         return next((subtask for subtask in self.subtasks if subtask.id == subtask_id), None)
 
     def add_subtask(self, subtask: ActionSubtask) -> ActionSubtask:
@@ -156,8 +156,8 @@ class ToolkitTask(PromptTask, ActionSubtaskOriginMixin):
 
         return subtask
 
-    def find_tool(self, tool_name: str) -> Optional[BaseTool]:
+    def find_tool(self, tool_name: str) -> BaseTool | None:
         return next((t for t in self.tools if t.name == tool_name), None)
 
-    def find_memory(self, memory_name: str) -> Optional[TaskMemory]:
+    def find_memory(self, memory_name: str) -> TaskMemory | None:
         return next((m for m in self.tool_output_memory if m.name == memory_name), None)

--- a/griptape/tokenizers/anthropic_tokenizer.py
+++ b/griptape/tokenizers/anthropic_tokenizer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from attr import define, field, Factory
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from griptape.utils import import_optional_dependency
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/anthropic_tokenizer.py
+++ b/griptape/tokenizers/anthropic_tokenizer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from attr import define, field, Factory
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from griptape.utils import import_optional_dependency
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/cohere_tokenizer.py
+++ b/griptape/tokenizers/cohere_tokenizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attr import define, field
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/cohere_tokenizer.py
+++ b/griptape/tokenizers/cohere_tokenizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attr import define, field
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/huggingface_tokenizer.py
+++ b/griptape/tokenizers/huggingface_tokenizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attr import define, field, Factory
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/huggingface_tokenizer.py
+++ b/griptape/tokenizers/huggingface_tokenizer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attr import define, field, Factory
 from griptape.tokenizers import BaseTokenizer
 

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -48,7 +48,7 @@ class OpenAiTokenizer(BaseTokenizer):
 
         return (tokens if tokens else self.DEFAULT_MAX_TOKENS) - offset
 
-    def count_tokens(self, text: str | list[dict], model: str | None = None) -> int:
+    def count_tokens(self, text: str | list[dict], model: Optional[str] = None) -> int:
         """
         Handles the special case of ChatML. Implementation adopted from the official OpenAI notebook:
         https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -49,7 +49,7 @@ class OpenAiTokenizer(BaseTokenizer):
 
         return (tokens if tokens else self.DEFAULT_MAX_TOKENS) - offset
 
-    def count_tokens(self, text: str | list[dict], model: str | None = None) -> int:
+    def count_tokens(self, text: str | list[dict], model: Optional[str] = None) -> int:
         """
         Handles the special case of ChatML. Implementation adopted from the official OpenAI notebook:
         https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -3,6 +3,7 @@ import logging
 from attr import define, field, Factory
 import tiktoken
 from griptape.tokenizers import BaseTokenizer
+from typing import Optional
 
 
 @define(frozen=True)
@@ -48,7 +49,7 @@ class OpenAiTokenizer(BaseTokenizer):
 
         return (tokens if tokens else self.DEFAULT_MAX_TOKENS) - offset
 
-    def count_tokens(self, text: str | list[dict], model: Optional[str] = None) -> int:
+    def count_tokens(self, text: str | list[dict], model: str | None = None) -> int:
         """
         Handles the special case of ChatML. Implementation adopted from the official OpenAI notebook:
         https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb

--- a/griptape/tools/aws_iam_client/tool.py
+++ b/griptape/tools/aws_iam_client/tool.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from schema import Schema, Literal
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact, ErrorArtifact, ListArtifact

--- a/griptape/tools/aws_iam_client/tool.py
+++ b/griptape/tools/aws_iam_client/tool.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from schema import Schema, Literal
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact, ErrorArtifact, ListArtifact

--- a/griptape/tools/aws_s3_client/tool.py
+++ b/griptape/tools/aws_s3_client/tool.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import io
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from schema import Schema, Literal
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact, BlobArtifact

--- a/griptape/tools/aws_s3_client/tool.py
+++ b/griptape/tools/aws_s3_client/tool.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from schema import Schema, Literal
 from attr import define, field, Factory
 from griptape.artifacts import TextArtifact, ErrorArtifact, InfoArtifact, ListArtifact, BlobArtifact

--- a/griptape/tools/base_aws_client.py
+++ b/griptape/tools/base_aws_client.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from abc import ABC
 from attr import define, field
 from griptape.artifacts import TextArtifact, ErrorArtifact, BaseArtifact

--- a/griptape/tools/base_aws_client.py
+++ b/griptape/tools/base_aws_client.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from abc import ABC
 from attr import define, field
 from griptape.artifacts import TextArtifact, ErrorArtifact, BaseArtifact

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -36,10 +36,10 @@ class BaseTool(ActivityMixin, ABC):
     REQUIREMENTS_FILE = "requirements.txt"
 
     name: str = field(default=Factory(lambda self: self.class_name, takes_self=True), kw_only=True)
-    input_memory: list[TaskMemory] | None = field(default=None, kw_only=True)
-    output_memory: dict[str, list[TaskMemory]] | None = field(default=None, kw_only=True)
+    input_memory: Optional[list[TaskMemory]] = field(default=None, kw_only=True)
+    output_memory: dict[str, Optional[list[TaskMemory]]] = field(default=None, kw_only=True)
     install_dependencies_on_init: bool = field(default=True, kw_only=True)
-    dependencies_install_directory: str | None = field(default=None, kw_only=True)
+    dependencies_install_directory: Optional[str] = field(default=None, kw_only=True)
     verbose: bool = field(default=False, kw_only=True)
     off_prompt: bool = field(default=True, kw_only=True)
 
@@ -48,7 +48,7 @@ class BaseTool(ActivityMixin, ABC):
             self.install_dependencies(os.environ.copy())
 
     @output_memory.validator  # pyright: ignore
-    def validate_output_memory(self, _, output_memory: dict[str, list[TaskMemory]] | None) -> None:
+    def validate_output_memory(self, _, output_memory: dict[str, Optional[list[TaskMemory]]]) -> None:
         if output_memory:
             for activity_name, memory_list in output_memory.items():
                 if not self.find_activity(activity_name):
@@ -108,10 +108,10 @@ class BaseTool(ActivityMixin, ABC):
 
         return postprocessed_output
 
-    def before_run(self, activity: Callable, value: dict | None) -> dict | None:
+    def before_run(self, activity: Callable, value: Optional[dict]) -> Optional[dict]:
         return value
 
-    def run(self, activity: Callable, subtask: ActionSubtask, value: dict | None) -> BaseArtifact:
+    def run(self, activity: Callable, subtask: ActionSubtask, value: Optional[dict]) -> BaseArtifact:
         activity_result = activity(value)
 
         if isinstance(activity_result, BaseArtifact):
@@ -156,7 +156,7 @@ class BaseTool(ActivityMixin, ABC):
 
         return os.path.dirname(os.path.abspath(class_file))
 
-    def install_dependencies(self, env: dict[str, str] | None = None) -> None:
+    def install_dependencies(self, env: dict[str, Optional[str]] = None) -> None:
         env = env if env else {}
 
         command = [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
@@ -174,7 +174,7 @@ class BaseTool(ActivityMixin, ABC):
             stderr=None if self.verbose else subprocess.DEVNULL,
         )
 
-    def find_input_memory(self, memory_name: str) -> TaskMemory | None:
+    def find_input_memory(self, memory_name: str) -> Optional[TaskMemory]:
         if self.input_memory:
             return next((m for m in self.input_memory if m.name == memory_name), None)
         else:

--- a/griptape/tools/computer/tool.py
+++ b/griptape/tools/computer/tool.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 @define
 class Computer(BaseTool):
-    local_workdir: str | None = field(default=None, kw_only=True)
+    local_workdir: Optional[str] = field(default=None, kw_only=True)
     container_workdir: str = field(default="/griptape", kw_only=True)
     env_vars: dict = field(factory=dict, kw_only=True)
     dockerfile_path: str = field(
@@ -36,7 +36,7 @@ class Computer(BaseTool):
         default=Factory(lambda self: self.default_docker_client(), takes_self=True), kw_only=True
     )
 
-    __tempdir: tempfile.TemporaryDirectory | None = field(default=None, kw_only=True)
+    __tempdir: Optional[tempfile.TemporaryDirectory] = field(default=None, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
@@ -52,7 +52,7 @@ class Computer(BaseTool):
         if not docker_client:
             raise ValueError("Docker client can't be initialized: make sure the Docker daemon is running")
 
-    def install_dependencies(self, env: dict[str, str] | None = None) -> None:
+    def install_dependencies(self, env: dict[str, Optional[str]] = None) -> None:
         super().install_dependencies(env)
 
         self.remove_existing_container(self.container_name(self))
@@ -144,7 +144,7 @@ class Computer(BaseTool):
             if tempdir:
                 tempdir.cleanup()
 
-    def default_docker_client(self) -> DockerClient | None:
+    def default_docker_client(self) -> Optional[DockerClient]:
         try:
             return docker.from_env()
         except Exception as e:

--- a/griptape/tools/email_client/tool.py
+++ b/griptape/tools/email_client/tool.py
@@ -35,18 +35,18 @@ class EmailClient(BaseTool):
         email_loader: Used to retrieve email.
     """
 
-    username: str | None = field(default=None, kw_only=True)
-    password: str | None = field(default=None, kw_only=True)
-    email_max_retrieve_count: int | None = field(default=None, kw_only=True)
-    smtp_host: str | None = field(default=None, kw_only=True)
-    smtp_port: int | None = field(default=None, kw_only=True)
+    username: Optional[str] = field(default=None, kw_only=True)
+    password: Optional[str] = field(default=None, kw_only=True)
+    email_max_retrieve_count: Optional[int] = field(default=None, kw_only=True)
+    smtp_host: Optional[str] = field(default=None, kw_only=True)
+    smtp_port: Optional[int] = field(default=None, kw_only=True)
     smtp_use_ssl: bool = field(default=True, kw_only=True)
-    smtp_user: str | None = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
-    smtp_password: str | None = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
-    imap_url: str | None = field(default=None, kw_only=True)
-    imap_user: str | None = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
-    imap_password: str | None = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
-    mailboxes: dict[str, str] | None = field(default=None, kw_only=True)
+    smtp_user: Optional[str] = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
+    smtp_password: Optional[str] = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
+    imap_url: Optional[str] = field(default=None, kw_only=True)
+    imap_user: Optional[str] = field(default=Factory(lambda self: self.username, takes_self=True), kw_only=True)
+    imap_password: Optional[str] = field(default=Factory(lambda self: self.password, takes_self=True), kw_only=True)
+    mailboxes: dict[str, Optional[str]] = field(default=None, kw_only=True)
     email_loader: EmailLoader = field(
         default=Factory(
             lambda self: EmailLoader(imap_url=self.imap_url, username=self.imap_user, password=self.imap_password),

--- a/griptape/tools/file_manager/tool.py
+++ b/griptape/tools/file_manager/tool.py
@@ -40,7 +40,7 @@ class FileManager(BaseTool):
         ),
         kw_only=True,
     )
-    save_file_encoding: str | None = field(default=None, kw_only=True)
+    save_file_encoding: Optional[str] = field(default=None, kw_only=True)
 
     @workdir.validator  # pyright: ignore
     def validate_workdir(self, _, workdir: str) -> None:

--- a/griptape/tools/openweather_client/tool.py
+++ b/griptape/tools/openweather_client/tool.py
@@ -92,7 +92,7 @@ class OpenWeatherClient(BaseTool):
         else:
             return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
-    def _fetch_coordinates(self, location: str) -> tuple[float, float] | None:
+    def _fetch_coordinates(self, location: str) -> tuple[float, Optional[float]]:
         parts = location.split(",")
         if len(parts) == 2 and parts[1].strip() in self.US_STATE_CODES:
             location += ", US"

--- a/griptape/tools/openweather_client/tool.py
+++ b/griptape/tools/openweather_client/tool.py
@@ -93,7 +93,7 @@ class OpenWeatherClient(BaseTool):
         else:
             return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
-    def _fetch_coordinates(self, location: str) -> tuple[float, float | None]:
+    def _fetch_coordinates(self, location: str) -> tuple[float, Optional[float]]:
         parts = location.split(",")
         if len(parts) == 2 and parts[1].strip() in self.US_STATE_CODES:
             location += ", US"

--- a/griptape/tools/openweather_client/tool.py
+++ b/griptape/tools/openweather_client/tool.py
@@ -3,6 +3,7 @@ from griptape.artifacts import ListArtifact, TextArtifact, ErrorArtifact, InfoAr
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 from schema import Schema, Literal
+from typing import Optional
 from attr import define, field
 import requests
 import logging
@@ -92,7 +93,7 @@ class OpenWeatherClient(BaseTool):
         else:
             return ErrorArtifact(f"Error fetching coordinates for location: {location}")
 
-    def _fetch_coordinates(self, location: str) -> tuple[float, Optional[float]]:
+    def _fetch_coordinates(self, location: str) -> tuple[float, float | None]:
         parts = location.split(",")
         if len(parts) == 2 and parts[1].strip() in self.US_STATE_CODES:
             location += ", US"

--- a/griptape/tools/sql_client/tool.py
+++ b/griptape/tools/sql_client/tool.py
@@ -11,10 +11,10 @@ from schema import Schema
 @define
 class SqlClient(BaseTool):
     sql_loader: SqlLoader = field(kw_only=True)
-    schema_name: str | None = field(default=None, kw_only=True)
+    schema_name: Optional[str] = field(default=None, kw_only=True)
     table_name: str = field(kw_only=True)
-    table_description: str | None = field(default=None, kw_only=True)
-    engine_name: str | None = field(default=None, kw_only=True)
+    table_description: Optional[str] = field(default=None, kw_only=True)
+    engine_name: Optional[str] = field(default=None, kw_only=True)
 
     @property
     def full_table_name(self) -> str:

--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -13,7 +13,7 @@ class Chat:
     exit_keywords: list[str] = field(default=["exit"], kw_only=True)
     exiting_text: str = field(default="Exiting...", kw_only=True)
     processing_text: str = field(default="Thinking...", kw_only=True)
-    intro_text: str | None = field(default=None, kw_only=True)
+    intro_text: Optional[str] = field(default=None, kw_only=True)
     prompt_prefix: str = field(default="User: ", kw_only=True)
     response_prefix: str = field(default="Assistant: ", kw_only=True)
     output_fn: Callable[[str], None] = field(

--- a/griptape/utils/conversation.py
+++ b/griptape/utils/conversation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional$
+from typing import TYPE_CHECKING, Optional
 from attr import define, field
 
 if TYPE_CHECKING:

--- a/griptape/utils/conversation.py
+++ b/griptape/utils/conversation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional$
 from attr import define, field
 
 if TYPE_CHECKING:

--- a/griptape/utils/prompt_stack.py
+++ b/griptape/utils/prompt_stack.py
@@ -50,7 +50,7 @@ class PromptStack:
     def add_assistant_input(self, content: str) -> Input:
         return self.add_input(content, self.ASSISTANT_ROLE)
 
-    def add_conversation_memory(self, memory: ConversationMemory, index: int | None = None) -> list[Input]:
+    def add_conversation_memory(self, memory: ConversationMemory, index: Optional[int] = None) -> list[Input]:
         """Add the Conversation Memory runs to the Prompt Stack.
 
         If autoprune is enabled, this will fit as many Conversation Memory runs into the Prompt Stack

--- a/tests/unit/loaders/test_email_loader.py
+++ b/tests/unit/loaders/test_email_loader.py
@@ -125,7 +125,7 @@ def to_select_response(status: str, message_count: int):
     return (status, (str(message_count),))
 
 
-def to_fetch_message(body: str, content_type: str | None):
+def to_fetch_message(body: str, content_type: Optional[str]):
     return to_fetch_response(to_message(body, content_type))
 
 
@@ -133,7 +133,7 @@ def to_fetch_response(message: message):
     return (None, ((None, message.as_bytes()),))
 
 
-def to_message(body: str, content_type: str | None) -> message:
+def to_message(body: str, content_type: Optional[str]) -> message:
     message = email.message_from_string(body)
     if content_type:
         message.set_type(content_type)

--- a/tests/unit/mixins/test_seriliazable_mixin.py
+++ b/tests/unit/mixins/test_seriliazable_mixin.py
@@ -1,0 +1,3 @@
+import pytest
+import json
+from griptape.artifacts import TextArtifact

--- a/tests/unit/mixins/test_seriliazable_mixin.py
+++ b/tests/unit/mixins/test_seriliazable_mixin.py
@@ -1,3 +1,0 @@
-import pytest
-import json
-from griptape.artifacts import TextArtifact


### PR DESCRIPTION
Reverts pyupgrade's [pep 604 typing rewrites](https://github.com/asottile/pyupgrade?tab=readme-ov-file#pep-604-typing-rewrites) which causes issues with https://github.com/griptape-ai/griptape/pull/561 on versions greater than python 3.9.

Thank goodness for regexes.