### PR TITLE
Update Bedrock Stable Diffusion request parameters to support SDXLv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AzureMongoDbVectorStoreDriver` for using CosmosDB with MongoDB vCore API.
 - `vector_path` field on `MongoDbAtlasVectorStoreDriver`
 
+### Fixed 
+- `BedrockStableDiffusionImageGenerationModelDriver` request parameters for SDXLv1.
+
 ### Changed
 - **BREAKING**: Make `index_name` on `MongoDbAtlasVectorStoreDriver` a required field
 

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -106,13 +106,16 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         text_prompts = [{"text": prompt, "weight": 1.0} for prompt in prompts]
         text_prompts += [{"text": negative_prompt, "weight": -1.0} for negative_prompt in negative_prompts]
 
-        request = {
-            "text_prompts": text_prompts,
-            "cfg_scale": self.cfg_scale,
-            "style_preset": self.style_preset,
-            "clip_guidance_preset": self.clip_guidance_preset,
-            "sampler": self.sampler,
-        }
+        request = {"text_prompts": text_prompts, "cfg_scale": self.cfg_scale}
+
+        if self.style_preset:
+            request["style_preset"] = self.style_preset
+
+        if self.clip_guidance_preset:
+            request["clip_guidance_preset"] = self.clip_guidance_preset
+
+        if self.sampler:
+            request["sampler"] = self.sampler
 
         if image:
             request["init_image"] = image.base64

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -108,16 +108,16 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
 
         request = {"text_prompts": text_prompts, "cfg_scale": self.cfg_scale}
 
-        if self.style_preset:
+        if self.style_preset is not None:
             request["style_preset"] = self.style_preset
 
-        if self.clip_guidance_preset:
+        if self.clip_guidance_preset is not None:
             request["clip_guidance_preset"] = self.clip_guidance_preset
 
-        if self.sampler:
+        if self.sampler is not None:
             request["sampler"] = self.sampler
 
-        if image:
+        if image is not None:
             request["init_image"] = image.base64
             request["width"] = image.width
             request["height"] = image.height
@@ -125,20 +125,20 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
             request["width"] = width
             request["height"] = height
 
-        if self.steps:
+        if self.steps is not None:
             request["steps"] = self.steps
 
-        if seed:
+        if seed is not None:
             request["seed"] = seed
 
-        if mask:
+        if mask is not None:
             if not mask_source:
                 raise ValueError("mask_source must be provided when mask is provided")
 
             request["mask_source"] = mask_source
             request["mask_image"] = mask.base64
 
-        if self.start_schedule:
+        if self.start_schedule is not None:
             request["start_schedule"] = self.start_schedule
 
         return request


### PR DESCRIPTION
The Stable Diffusion Model Driver for Bedrock previously supported SDXLv0, but failed when pointed at SDXLv1. This PR updates the request body to conform with SDXLv1 validation.

Tested on generation, variation, inpainting, and outpainting for SDXLv0 and SDXLv1.