### PR TITLE
Generalize ImageLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: Make `index_name` on `MongoDbAtlasVectorStoreDriver` a required field.
 - **BREAKING**: Remove `create_index()` from `MarqoVectorStoreDriver`, `OpenSearchVectorStoreDriver`, `PineconeVectorStoreDriver`, `RedisVectorStoreDriver`.
+- **BREAKING**: `ImageLoader().load()` now accepts image bytes instead of a file path.
 
 ## [0.22.3] - 2024-01-22
 

--- a/griptape/tasks/base_image_generation_task.py
+++ b/griptape/tasks/base_image_generation_task.py
@@ -57,4 +57,5 @@ class BaseImageGenerationTask(ImageArtifactFileOutputMixin, RuleMixin, BaseTask,
 
     def _read_from_file(self, path: str) -> ImageArtifact:
         self.structure.logger.info(f"Reading image from {os.path.abspath(path)}")
-        return ImageLoader().load(path)
+        with open(path, "rb") as file:
+            return ImageLoader().load(file.read())

--- a/tests/unit/loaders/test_image_loader.py
+++ b/tests/unit/loaders/test_image_loader.py
@@ -14,14 +14,14 @@ class TestImageLoader:
     def test_init(self, loader):
         assert loader
 
-    def test_load_with_path(self, loader):
+    def test_load_png(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.png")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.png"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".png")
         assert artifact.height == 32
         assert artifact.width == 32
         assert artifact.mime_type == "image/png"
@@ -30,63 +30,77 @@ class TestImageLoader:
     def test_load_jpg(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.jpg")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.jpg"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".jpeg")
         assert artifact.height == 32
         assert artifact.width == 32
-        assert artifact.mime_type == "image/png"
+        assert artifact.mime_type == "image/jpeg"
         assert len(artifact.value) > 0
 
     def test_load_webp(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.webp")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.webp"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".webp")
         assert artifact.height == 32
         assert artifact.width == 32
-        assert artifact.mime_type == "image/png"
+        assert artifact.mime_type == "image/webp"
         assert len(artifact.value) > 0
 
     def test_load_bmp(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.bmp")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.bmp"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".bmp")
         assert artifact.height == 32
         assert artifact.width == 32
-        assert artifact.mime_type == "image/png"
+        assert artifact.mime_type == "image/bmp"
         assert len(artifact.value) > 0
 
     def test_load_gif(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.gif")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.gif"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".gif")
         assert artifact.height == 32
         assert artifact.width == 32
-        assert artifact.mime_type == "image/png"
+        assert artifact.mime_type == "image/gif"
         assert len(artifact.value) > 0
 
     def test_load_tiff(self, loader):
         path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.tiff")
 
-        artifact = loader.load(path)
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
 
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.name == "small.tiff"
-        assert artifact.dir_name.endswith("/resources")
+        assert artifact.name.endswith(".tiff")
+        assert artifact.height == 32
+        assert artifact.width == 32
+        assert artifact.mime_type == "image/tiff"
+        assert len(artifact.value) > 0
+
+    def test_normalize_format(self):
+        loader = ImageLoader(format="png")
+        path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources/small.jpg")
+
+        with open(path, "rb") as file:
+            artifact = loader.load(file.read())
+
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.name.endswith(".png")
         assert artifact.height == 32
         assert artifact.width == 32
         assert artifact.mime_type == "image/png"


### PR DESCRIPTION
This PR generalizes the `ImageLoader` to operate on bytes rather than file paths. This change places a bit more responsibility on the developer but allows the `ImageLoader` to implicitly handle images not just in files on disk, but from arbitrary sources (including request parameters or web downloads).

Loading from a file now looks like this:

```python
from griptape.loaders import ImageLoader

with open("image.png", "rb") as file:
  image_artifact = ImageLoader().load(file.read())
```

From a base64-encoded image (e.g. request param):

```python
import base64
from griptape.loaders import ImageLoader

...

artifact = loader.load(base64.b64decode(req["b64_image"]))
```

From an image download:
```python
import requests
from griptape.loaders import ImageLoader 

response = requests.get("https://example.com/image.png")
artifact = ImageLoader().load(response.content)
```

Documentation and trade school updates required, see griptape-ai/griptape-docs#208

Resolves #559
Resolves #560