### PR TITLE
Fix image loader

### DIFF
--- a/griptape/loaders/image_loader.py
+++ b/griptape/loaders/image_loader.py
@@ -48,9 +48,10 @@ class ImageLoader(BaseLoader):
             byte_stream = BytesIO()
             image.save(byte_stream, format=self.format)
             image = Image.open(byte_stream)
+            source = byte_stream.getvalue()
 
         image_artifact = ImageArtifact(
-            image.tobytes(), mime_type=self._get_mime_type(image.format), width=image.width, height=image.height
+            source, mime_type=self._get_mime_type(image.format), width=image.width, height=image.height
         )
 
         return image_artifact

--- a/tests/unit/loaders/test_image_loader.py
+++ b/tests/unit/loaders/test_image_loader.py
@@ -1,6 +1,8 @@
 import os
+from io import BytesIO
 
 import pytest
+from PIL import Image
 
 from griptape.artifacts import ImageArtifact
 from griptape.loaders import ImageLoader
@@ -99,9 +101,12 @@ class TestImageLoader:
         with open(path, "rb") as file:
             artifact = loader.load(file.read())
 
+        image = Image.open(BytesIO(artifact.value))
+
         assert isinstance(artifact, ImageArtifact)
         assert artifact.name.endswith(".png")
         assert artifact.height == 32
         assert artifact.width == 32
         assert artifact.mime_type == "image/png"
         assert len(artifact.value) > 0
+        assert image.format == "PNG"


### PR DESCRIPTION
This PR fixes a bug in the image loader that would corrupt image artifacts when a format is specified.