### PR TITLE
Fix index name retrieval on Marqo Index object

### DIFF
--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -213,7 +213,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
             The list of all indexes.
         """
 
-        return [index["index"] for index in self.mq.get_indexes()["results"]]
+        return [index.index_name for index in self.mq.get_indexes()["results"]]
 
     def upsert_vector(
         self,


### PR DESCRIPTION
This PR fixes our final Pyright error by correcting how we grab Marqo index names from Index objects.