### PR TITLE
Run pyright on all framework files

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/init-environment
       - name: Run formatter
         run: poetry run black --check .
-  type-check:
+  type-check-diff:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,3 +40,16 @@ jobs:
       - name: Run type checker
         if: steps.changed-files.outputs.any_changed == 'true'
         run: poetry run pyright ${{ steps.changed-files.outputs.all_changed_files }}
+  type-check-all:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.9" ]
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v3
+      - name: Init environment
+        uses: ./.github/actions/init-environment
+      - name: Run type checker
+        run: poetry run pyright griptape/

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,27 +20,7 @@ jobs:
         uses: ./.github/actions/init-environment
       - name: Run formatter
         run: poetry run black --check .
-  type-check-diff:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
-    steps:
-      - name: Checkout actions
-        uses: actions/checkout@v3
-      - name: Init environment
-        uses: ./.github/actions/init-environment
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v41
-        with:
-          files: |
-            **/*.py
-      - name: Run type checker
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: poetry run pyright ${{ steps.changed-files.outputs.all_changed_files }}
-  type-check-all:
+  type-check:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
A change in one file can cause Pyright errors in other files.

Previously, we only checked files touched in the diff because there were hundreds of unrelated errors that would be hard to ignore. Now that we have a baseline of zero Pyright errors, we should check the entire project to ensure new changes don't break any associated code.