### PR TITLE
Fix initialization when overriding drivers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4818,4 +4818,4 @@ loaders-web = ["trafilatura"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4ba528fecb3053537506559a73a8e44d7809d6005f636ded3b3f034b8f1d7acf"
+content-hash = "69813a3cca88dbe5681a8ce68a41d159c262013466ff0bd62d4abb4a93fc9f97"


### PR DESCRIPTION
Fixes logic so that if a user is providing a `prompt_driver` or `embedding_driver`, it will stick those into a generic `StructureConfig`, not an `OpenAiStructureConfig`. Additionally, if a user provides only one of `prompt_driver` or `embedding_driver`, it will default the null one to the defaults we provide in `<0.23`.

All of this can be removed after we remove the `prompt_driver` and `embedding_driver` fields for good.