### PR TITLE
Fix incorrect tool schema

### DIFF
--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Optional, Callable
 from attr import define, field
 from jinja2 import Template
-from schema import Schema
+from schema import Schema, Literal
 
 
 @define(slots=False)
@@ -84,6 +84,13 @@ class ActivityMixin:
             return Schema(full_schema).json_schema("InputSchema")
         else:
             return None
+
+    def activity_to_input(self, activity: Callable) -> dict:
+        return (
+            {Literal("input"): {"values": getattr(activity, "config")["schema"]}}
+            if self.activity_schema(activity)
+            else {}
+        )
 
     def _validate_tool_activity(self, activity_name):
         tool = self.__class__

--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -86,11 +86,10 @@ class ActivityMixin:
             return None
 
     def activity_to_input(self, activity: Callable) -> dict:
-        return (
-            {Literal("input"): {"values": getattr(activity, "config")["schema"]}}
-            if self.activity_schema(activity)
-            else {}
-        )
+        if self.activity_schema(activity):
+            return {Literal("input"): {"values": getattr(activity, "config")["schema"]}}
+        else:
+            return {}
 
     def _validate_tool_activity(self, activity_name):
         tool = self.__class__

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -94,9 +94,11 @@ class BaseTool(ActivityMixin, ABC):
                 {
                     Literal("name"): self.name,
                     Literal("path", description=self.activity_description(activity)): self.activity_name(activity),
-                    Literal("input"): {"values": getattr(activity, "config")["schema"]}
-                    if self.activity_schema(activity)
-                    else {},
+                    **(
+                        {Literal("input"): {"values": getattr(activity, "config")["schema"]}}
+                        if self.activity_schema(activity)
+                        else {}
+                    ),
                 }
             )
             for activity in self.activities()

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -94,11 +94,9 @@ class BaseTool(ActivityMixin, ABC):
                 {
                     Literal("name"): self.name,
                     Literal("path", description=self.activity_description(activity)): self.activity_name(activity),
-                    **(
-                        {Literal("input"): {"values": getattr(activity, "config")["schema"]}}
-                        if self.activity_schema(activity)
-                        else {}
-                    ),
+                    **self.activity_to_input(
+                        activity
+                    ),  # Unpack the dictionary in order to only add the key-values if there are any
                 }
             )
             for activity in self.activities()

--- a/tests/unit/mixins/test_activity_mixin.py
+++ b/tests/unit/mixins/test_activity_mixin.py
@@ -1,5 +1,5 @@
 import pytest
-from schema import Schema
+from schema import Schema, Literal
 from tests.mocks.mock_tool.tool import MockTool
 
 
@@ -71,3 +71,12 @@ class TestActivityMixin:
         tool.enable_activities()
 
         assert len(tool.activities()) > 0
+
+    def test_activity_to_input(self, tool):
+        input = tool.activity_to_input(tool.test)
+        assert str(input) == str(
+            {Literal("input", description=""): {"values": Schema({Literal("test"): str}, description="Test input")}}
+        )
+
+        input = tool.activity_to_input(tool.test_no_schema)
+        assert input == {}

--- a/tests/unit/tools/test_base_tool.py
+++ b/tests/unit/tools/test_base_tool.py
@@ -64,6 +64,7 @@ class TestBaseTool:
             output_memory={"test": [defaults.text_task_memory("Memory1"), defaults.text_task_memory("Memory2")]}
         )
 
+        assert tool.output_memory is not None
         assert len(tool.output_memory["test"]) == 2
 
     def test_memory_validation(self):
@@ -146,9 +147,8 @@ class TestBaseTool:
                     "properties": {
                         "name": {"const": "MockTool"},
                         "path": {"description": "test description", "const": "test_list_output"},
-                        "input": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
                     },
-                    "required": ["name", "path", "input"],
+                    "required": ["name", "path"],
                     "additionalProperties": False,
                 },
                 {
@@ -156,9 +156,8 @@ class TestBaseTool:
                     "properties": {
                         "name": {"const": "MockTool"},
                         "path": {"description": "test description", "const": "test_no_schema"},
-                        "input": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
                     },
-                    "required": ["name", "path", "input"],
+                    "required": ["name", "path"],
                     "additionalProperties": False,
                 },
                 {


### PR DESCRIPTION
`input` is an optional field as according to `ACTION_SCHEMA`. But if it is present, it must contain a key `values`.

This PR fixes logic where Tool schemas were being incorrectly generated with `values` as the optional field rather than `input`.

Some relevant output:
```
Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and try again.
Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}[02/16/24 15:51:08] ERROR    Subtask 7372d6bf7b9942919676f04661786d3d                                                                                        
                             Error parsing tool action: Key 'input' error:                                                                                   
                             Missing key: 'values'                                                                                                           
                    INFO     Subtask 99e9fefe432a4655b37d5d2a550891fa                                                                                        
                             Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and 
                             try again.                                                                                                                      
                             Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}          
                    INFO     Subtask 99e9fefe432a4655b37d5d2a550891fa                                                                                        
                             Response: {'error': "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}                                    

Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and try again.
Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}[02/16/24 15:51:13] ERROR    Subtask 7372d6bf7b9942919676f04661786d3d                                                                                        
                             Error parsing tool action: Key 'input' error:                                                                                   
                             Missing key: 'values'                                                                                                           

                    INFO     Subtask 5d4ccecd15f04e1ba10ea7755886ca9d                                                                                        
                             Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and 
                             try again.                                                                                                                      
                             Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}          
                    INFO     Subtask 5d4ccecd15f04e1ba10ea7755886ca9d                                                                                        
                             Response: {'error': "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}                                    
Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and try again.
Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}[02/16/24 15:51:20] ERROR    Subtask 7372d6bf7b9942919676f04661786d3d                                                                                        
                             Error parsing tool action: Key 'input' error:                                                                                   
                             Missing key: 'values'                                                                                                           

                    INFO     Subtask b1e1f6b186bb434c962fad2e50e1eb86                                                                                        
                             Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and 
                             try again.                                                                                                                      
                             Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}          
                    INFO     Subtask b1e1f6b186bb434c962fad2e50e1eb86                                                                                        
                             Response: {'error': "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}                                    
Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and try again.
Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}[02/16/24 15:51:25] ERROR    Subtask 7372d6bf7b9942919676f04661786d3d                                                                                        
                             Error parsing tool action: Key 'input' error:                                                                                   
                             Missing key: 'values'                                                                                                           

                    INFO     Subtask 136ff61c62324f2c8188fe94368f866f                                                                                        
                             Thought: I made a mistake in the previous action. I forgot to include the "values" key in the input. I need to correct this and 
                             try again.                                                                                                                      
                             Action: {"name": "error", "input": {"error": "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}}          
                    INFO     Subtask 136ff61c62324f2c8188fe94368f866f                                                                                        
                             Response: {'error': "Action input parsing error: Key 'input' error:\nMissing key: 'values'"}  
```