### PR TITLE
Update dummy tokenizers default max tokens

### DIFF
--- a/griptape/tokenizers/dummy_tokenizer.py
+++ b/griptape/tokenizers/dummy_tokenizer.py
@@ -6,7 +6,7 @@ from griptape.tokenizers import BaseTokenizer
 
 @define(frozen=True)
 class DummyTokenizer(BaseTokenizer):
-    max_tokens: int = field(default=float("inf"), kw_only=True)
+    max_tokens: int = field(default=0, kw_only=True)
 
     def count_tokens(self, text: str | list) -> int:
         raise DummyException(__class__.__name__, "count_tokens")


### PR DESCRIPTION
`inf` was causing crashes in other places in the framework.