### PR TITLE
Don't raise exception when action input not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.23.1] - 2024-03-07
+### Fixed
+- Action Subtask incorrectly raising an exception for actions without an input. 
+
 ## [0.23.0] - 2024-02-26
 
 ### Added 

--- a/griptape/tasks/action_subtask.py
+++ b/griptape/tasks/action_subtask.py
@@ -214,11 +214,8 @@ class ActionSubtask(BaseTextInputTask):
                             "ActionSubtask must be attached to a Task that implements ActionSubtaskOriginMixin."
                         )
 
-                if self._tool:
-                    if self.action_input:
-                        self.__validate_action_input(self.action_input, self._tool)
-                    else:
-                        raise Exception("Action input not found.")
+                if self._tool and self.action_input:
+                    self.__validate_action_input(self.action_input, self._tool)
             except SyntaxError as e:
                 self.structure.logger.error(f"Subtask {self.origin_task.id}\nSyntax error: {e}")
 


### PR DESCRIPTION
Reproduce:
```python
from griptape.tools import DateTime
from griptape.structures import Agent

agent = Agent(
    tools=[DateTime(off_prompt=False)],
)

agent.run("Whats the time?")
```

Output:
```
                           Thought: The user wants to know the current time. I can use the "get_current_datetime" action to get this information.

                             Action:
                             {
                               "name": "DateTime",
                               "path": "get_current_datetime"
                             }
                    INFO     Subtask 00da8251ac4e4bc19155786c505eabc7
                             Response: {'error': 'Action input parsing error: Action input not found.'}
```