### PR TITLE
Make MarkdownChunker inherit from TextChunker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Default embedding model of `OpenAiEmbeddingDriver` to `text-embedding-3-small`.
 - Default embedding model of `OpenAiStructureConfig` to `text-embedding-3-small`.
+- `BaseTextLoader` to accept a `BaseChunker`.
 
 ## [0.23.1] - 2024-03-07
 

--- a/griptape/loaders/base_text_loader.py
+++ b/griptape/loaders/base_text_loader.py
@@ -7,7 +7,7 @@ from attrs import define, field, Factory
 from pathlib import Path
 
 from griptape.artifacts import TextArtifact
-from griptape.chunkers import TextChunker
+from griptape.chunkers import TextChunker, BaseChunker
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.loaders import BaseLoader
 from griptape.tokenizers import OpenAiTokenizer
@@ -24,7 +24,7 @@ class BaseTextLoader(BaseLoader, ABC):
         default=Factory(lambda self: round(self.tokenizer.max_tokens * self.MAX_TOKEN_RATIO), takes_self=True),
         kw_only=True,
     )
-    chunker: TextChunker = field(
+    chunker: BaseChunker = field(
         default=Factory(
             lambda self: TextChunker(tokenizer=self.tokenizer, max_tokens=self.max_tokens), takes_self=True
         ),


### PR DESCRIPTION
Fixes type error of not being able to pass a `MarkdownChunker` into a `TextLoader`