### PR TITLE
Edit MarkdownifyWebScraperDriver

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4908,15 +4908,14 @@ drivers-vector-opensearch = ["opensearch-py"]
 drivers-vector-pinecone = ["pinecone-client"]
 drivers-vector-postgresql = ["pgvector", "psycopg2-binary"]
 drivers-vector-redis = ["redis"]
-drivers-web-scraper-markdown = ["beautifulsoup4", "markdownify", "playwright"]
+drivers-web-scraper-markdownify = ["beautifulsoup4", "markdownify", "playwright"]
 drivers-web-scraper-trafilatura = ["trafilatura"]
 loaders-dataframe = ["pandas"]
 loaders-email = ["mail-parser"]
 loaders-image = ["pillow"]
 loaders-pdf = ["pypdf"]
-loaders-web = []
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f6d1e0a73c3d68d3bd7bc2f6d2e7ff20c781aabe113f6f84f7e7d1adfe2bbdb5"
+content-hash = "7d8645e478a43b6051ab8dac055c3f883cf882fd76a0d3625fd44a7d716713d2"

--- a/tests/unit/drivers/web_scraper/test_markdownify_web_scraper_driver.py
+++ b/tests/unit/drivers/web_scraper/test_markdownify_web_scraper_driver.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 import pytest
 
 from griptape.drivers.web_scraper.markdownify_web_scraper_driver import MarkdownifyWebScraperDriver
@@ -24,6 +25,31 @@ class TestMarkdownifyWebScraperDriver:
     def test_scrape_url(self, web_scraper):
         artifact = web_scraper.scrape_url("https://example.com/")
         assert "[foobar](foobar.com)" == artifact.value
+
+    def test_scrape_url_whitespace(self, web_scraper, mock_content):
+        mock_content.return_value = dedent(
+            """\
+            <html>
+                \t<br><br>
+                <br>
+                <h2>foo</h2>
+                <br>
+                <br>
+                <ul>
+                    <li>
+                        bar:
+                        <ul>
+                            <li>baz</li>
+                            <li>baz</li><br>\t<br>
+                            <li>baz</li>
+                        </ul>
+                    </li>
+                </ul><br>\t
+            </html>
+            """
+        )
+        artifact = web_scraper.scrape_url("https://example.com/")
+        assert "foo\n---\n\n* bar:\n  + baz\n  + baz\n\n  + baz" == artifact.value
 
     def test_scrape_url_no_excludes(self):
         web_scraper = MarkdownifyWebScraperDriver(exclude_tags=[], exclude_classes=[], exclude_ids=[])


### PR DESCRIPTION
After reviewing the output from the example usage I was adding to the docs, I wanted to remove unsightly triple+ newlines from the output markdown. While I made I was making the change, I thought it would be a good idea to also decrease the assumptions made in the default `exclude_tags` list. Then, while submitting the PR, then I realize that I had needed to update `poetry.lock` one more time for [Add web scraper drivers #691](https://github.com/griptape-ai/griptape/pull/691/files). (Surprised this wasn't caught by the PR checks...)

Changes:
- Edit `poetry.lock` via `poetry lock --no-update`. This was missed after renaming the `drivers-web-scraper-markdown` extra to `drivers-web-scraper-markdownify` in `pyproject.toml`.
- Remove `header`, `footer`, and `svg` from default `exclude_tags`, since it is reasonable to assume that it may contain meaningful content. (`svg`s sometimes contain text too)
- Add a constant to hold the default `exclude_tags` value. This makes it easier for client code to add exclude tags without duplicating the defaults. (e.g. they can now do  `exclude_tags = DEFAULT_EXCLUDE_TAGS + ["foo"]`)
- Remove trailing whitespace from lines.
- Indent using 2 spaces instead of tabs for more human readable output. (Like tabs are human readable too, but they depend on you tab size, so it can be ugly if you don't normally use tabs, and indenting with spaces is more of the convention we are following with our own use of markdown).
- Limit occurrences contiguous newline to 2. By default markdownify does not do this and it can lead to unsightly whitespace in the output. We need to allow 2 contiguous newlines to separate paragraphs.


Testing:
- Compared [output before change](https://gist.github.com/dylanholmes/b81dbee4b0632ccebd698db1592f10c2) and [output after change](https://gist.github.com/dylanholmes/7b1712ed95e1b8fa822b81f66ca4ce9c) for url: https://docs.griptape.ai/latest/griptape-framework/drivers/sql-drivers/
