### PR TITLE
Add filter to pgvector query

### DIFF
--- a/griptape/engines/query/base_query_engine.py
+++ b/griptape/engines/query/base_query_engine.py
@@ -16,6 +16,7 @@ class BaseQueryEngine(ABC):
         *,
         rulesets: Optional[list[Ruleset]] = None,
         top_n: Optional[int] = None,
+        filter: Optional[dict] = None,
     ) -> TextArtifact:
         ...
 

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -26,9 +26,10 @@ class VectorQueryEngine(BaseQueryEngine):
         rulesets: Optional[list[Ruleset]] = None,
         metadata: Optional[str] = None,
         top_n: Optional[int] = None,
+        filter: Optional[dict] = None,
     ) -> TextArtifact:
         tokenizer = self.prompt_driver.tokenizer
-        result = self.vector_store_driver.query(query, top_n, namespace)
+        result = self.vector_store_driver.query(query, top_n, namespace, filter=filter)
         artifacts = [
             artifact
             for artifact in [BaseArtifact.from_json(r.meta["artifact"]) for r in result if r.meta]


### PR DESCRIPTION
Adding the capability to pass in an arbitrary `filter` dict to the query engine. 

* Changes
  * BaseQueryEngine and VectorQueryEngine accept an optional `filter` dict parameter in the `query` method
  * The PgVectorVectorStoreDriver utilizes kwargs in the instantiation of its model, and checks for a `filter` kwarg to use in the `filter_by` method