### PR TITLE
Add support for VoyageAi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseWebScraperDriver` allowing multiple web scraping implementations.
 - `TrafilaturaWebScraperDriver` for scraping text from web pages using trafilatura.
 - `MarkdownifyWebScraperDriver` for scraping text from web pages using playwright and converting to markdown using markdownify.
+- `VoyageAiEmbeddingDriver` for use with VoyageAi's embedding models. 
 
 ### Fixed
 - Improved system prompt in `ToolTask` to support more use cases.

--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -23,6 +23,7 @@ from .embedding.base_multi_model_embedding_driver import BaseMultiModelEmbedding
 from .embedding.amazon_sagemaker_embedding_driver import AmazonSageMakerEmbeddingDriver
 from .embedding.amazon_bedrock_titan_embedding_driver import AmazonBedrockTitanEmbeddingDriver
 from .embedding.amazon_bedrock_cohere_embedding_driver import AmazonBedrockCohereEmbeddingDriver
+from .embedding.voyageai_embedding_driver import VoyageAiEmbeddingDriver
 from .embedding.huggingface_hub_embedding_driver import HuggingFaceHubEmbeddingDriver
 from .embedding.dummy_embedding_driver import DummyEmbeddingDriver
 
@@ -101,6 +102,7 @@ __all__ = [
     "AmazonSageMakerEmbeddingDriver",
     "AmazonBedrockTitanEmbeddingDriver",
     "AmazonBedrockCohereEmbeddingDriver",
+    "VoyageAiEmbeddingDriver",
     "HuggingFaceHubEmbeddingDriver",
     "DummyEmbeddingDriver",
     "BaseEmbeddingModelDriver",

--- a/griptape/drivers/embedding/voyageai_embedding_driver.py
+++ b/griptape/drivers/embedding/voyageai_embedding_driver.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+from attr import define, field, Factory
+from griptape.utils import import_optional_dependency
+from griptape.drivers import BaseEmbeddingDriver
+from griptape.tokenizers import VoyageAiTokenizer
+
+if TYPE_CHECKING:
+    from voyageai import Client
+
+
+@define
+class VoyageAiEmbeddingDriver(BaseEmbeddingDriver):
+    """
+    Attributes:
+        model: VoyageAI embedding model name. Defaults to `voyage-large-2`.
+        api_key: API key to pass directly. Defaults to `VOYAGE_API_KEY` environment variable.
+        tokenizer: Optionally provide custom `VoyageAiTokenizer`.
+        client: Optionally provide custom VoyageAI `Client`.
+        input_type: VoyageAI input type. Defaults to `document`.
+    """
+
+    DEFAULT_MODEL = "voyage-large-2"
+
+    model: str = field(default=DEFAULT_MODEL, kw_only=True, metadata={"serializable": True})
+    api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+    client: Client = field(
+        default=Factory(
+            lambda self: import_optional_dependency("voyageai").Client(api_key=self.api_key), takes_self=True
+        )
+    )
+    tokenizer: VoyageAiTokenizer = field(
+        default=Factory(lambda self: VoyageAiTokenizer(model=self.model, api_key=self.api_key), takes_self=True),
+        kw_only=True,
+    )
+    input_type: str = field(default="document", kw_only=True, metadata={"serializable": True})
+
+    def try_embed_chunk(self, chunk: str) -> list[float]:
+        return self.client.embed([chunk], model=self.model, input_type=self.input_type).embeddings[0]

--- a/griptape/tokenizers/__init__.py
+++ b/griptape/tokenizers/__init__.py
@@ -8,6 +8,7 @@ from griptape.tokenizers.bedrock_cohere_tokenizer import BedrockCohereTokenizer
 from griptape.tokenizers.bedrock_jurassic_tokenizer import BedrockJurassicTokenizer
 from griptape.tokenizers.bedrock_claude_tokenizer import BedrockClaudeTokenizer
 from griptape.tokenizers.bedrock_llama_tokenizer import BedrockLlamaTokenizer
+from griptape.tokenizers.voyageai_tokenizer import VoyageAiTokenizer
 from griptape.tokenizers.simple_tokenizer import SimpleTokenizer
 from griptape.tokenizers.dummy_tokenizer import DummyTokenizer
 
@@ -23,6 +24,7 @@ __all__ = [
     "BedrockJurassicTokenizer",
     "BedrockClaudeTokenizer",
     "BedrockLlamaTokenizer",
+    "VoyageAiTokenizer",
     "SimpleTokenizer",
     "DummyTokenizer",
 ]

--- a/griptape/tokenizers/voyageai_tokenizer.py
+++ b/griptape/tokenizers/voyageai_tokenizer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from attr import define, field, Factory
+from typing import TYPE_CHECKING, Optional
+from griptape.utils import import_optional_dependency
+from griptape.tokenizers import BaseTokenizer
+
+if TYPE_CHECKING:
+    from voyageai import Client
+
+
+@define()
+class VoyageAiTokenizer(BaseTokenizer):
+    MODEL_PREFIXES_TO_MAX_INPUT_TOKENS = {
+        "voyage-large-2": 16000,
+        "voyage-code-2": 16000,
+        "voyage-2": 4000,
+        "voyage-lite-02-instruct": 4000,
+    }
+    MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS = {"voyage": 0}
+
+    api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+    client: Client = field(
+        default=Factory(
+            lambda self: import_optional_dependency("voyageai").Client(api_key=self.api_key), takes_self=True
+        ),
+        kw_only=True,
+    )
+
+    def count_tokens(self, text: str | list) -> int:
+        if isinstance(text, str):
+            return self.client.count_tokens([text])
+        else:
+            raise ValueError("Text must be a str.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -4951,4 +4951,4 @@ loaders-pdf = ["pypdf"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6a9485690f4d95b3c6b05146ecba7f747ebce7f6f5223bed79389b2e69d162e4"
+content-hash = "6937f4061beccc91cb1f8aa6aa395a3c05f2fb6a0619060380c31007b65df38c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,6 +97,17 @@ yarl = ">=1.0,<2.0"
 speedups = ["Brotli", "aiodns", "brotlicffi"]
 
 [[package]]
+name = "aiolimiter"
+version = "1.1.0"
+description = "asyncio rate limiter, a leaky bucket implementation"
+optional = true
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "aiolimiter-1.1.0-py3-none-any.whl", hash = "sha256:0b4997961fc58b8df40279e739f9cf0d3e255e63e9a44f64df567a8c17241e24"},
+    {file = "aiolimiter-1.1.0.tar.gz", hash = "sha256:461cf02f82a29347340d031626c92853645c099cb5ff85577b831a7bd21132b5"},
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -4715,6 +4726,24 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
+name = "voyageai"
+version = "0.2.1"
+description = ""
+optional = true
+python-versions = ">=3.7.1,<4.0.0"
+files = [
+    {file = "voyageai-0.2.1-py3-none-any.whl", hash = "sha256:a00978f880adb689718940f8a5c5e4b80f76053e51d1e7e2dd35a9f2025b5506"},
+    {file = "voyageai-0.2.1.tar.gz", hash = "sha256:209ddf06343a271538a1f48340bcc4ddf93f346797462d4cf58d32a891d56093"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.5,<4.0"
+aiolimiter = ">=1.1.0,<2.0.0"
+numpy = ">=1.11"
+requests = ">=2.20,<3.0"
+tenacity = ">=8.0.1"
+
+[[package]]
 name = "websocket-client"
 version = "1.7.0"
 description = "WebSocket client for Python with low level API options"
@@ -4891,10 +4920,11 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
-all = ["anthropic", "beautifulsoup4", "boto3", "cohere", "mail-parser", "markdownify", "marqo", "opensearch-py", "pandas", "pgvector", "pillow", "pinecone-client", "playwright", "psycopg2-binary", "pymongo", "pypdf", "redis", "snowflake-sqlalchemy", "sqlalchemy-redshift", "trafilatura", "transformers"]
+all = ["anthropic", "beautifulsoup4", "boto3", "cohere", "mail-parser", "markdownify", "marqo", "opensearch-py", "pandas", "pgvector", "pillow", "pinecone-client", "playwright", "psycopg2-binary", "pymongo", "pypdf", "redis", "snowflake-sqlalchemy", "sqlalchemy-redshift", "trafilatura", "transformers", "voyageai"]
 drivers-embedding-amazon-bedrock = ["boto3"]
 drivers-embedding-amazon-sagemaker = ["boto3"]
 drivers-embedding-huggingface = ["huggingface-hub", "transformers"]
+drivers-embedding-voyageai = ["voyageai"]
 drivers-memory-conversation-amazon-dynamodb = ["boto3"]
 drivers-prompt-amazon-bedrock = ["anthropic", "boto3"]
 drivers-prompt-amazon-sagemaker = ["boto3", "transformers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ trafilatura = {version = "^1.6", optional = true}
 playwright = {version = "^1.42", optional = true}
 beautifulsoup4 = {version = "^4.12.3", optional = true}
 markdownify = {version = "^0.11.6", optional = true}
+voyageai = {version = "^0.2.1", optional = true}
 
 # loaders
 pandas = {version = "^1.3", optional = true}
@@ -82,6 +83,7 @@ drivers-vector-postgresql = ["pgvector", "psycopg2-binary"]
 drivers-embedding-amazon-bedrock = ["boto3"]
 drivers-embedding-amazon-sagemaker = ["boto3"]
 drivers-embedding-huggingface = ["huggingface-hub", "transformers"]
+drivers-embedding-voyageai = ["voyageai"]
 
 drivers-web-scraper-trafilatura = ["trafilatura"]
 drivers-web-scraper-markdownify = ["playwright", "beautifulsoup4", "markdownify"]
@@ -112,6 +114,7 @@ all = [
     "playwright",
     "beautifulsoup4",
     "markdownify",
+    "voyageai",
 
     # loaders
     "pandas",

--- a/tests/unit/drivers/embedding/test_voyageai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_voyageai_embedding_driver.py
@@ -1,0 +1,18 @@
+import pytest
+from unittest.mock import Mock
+from griptape.drivers import VoyageAiEmbeddingDriver
+
+
+class TestVoyageAiEmbeddingDriver:
+    @pytest.fixture(autouse=True)
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("voyageai.Client")
+        mock_client.return_value.embed.return_value = Mock(embeddings=[[0, 1, 0]])
+
+        return mock_client
+
+    def test_init(self):
+        assert VoyageAiEmbeddingDriver()
+
+    def test_try_embed_chunk(self):
+        assert VoyageAiEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]

--- a/tests/unit/tokenizers/test_voyageai_tokenizer.py
+++ b/tests/unit/tokenizers/test_voyageai_tokenizer.py
@@ -1,0 +1,39 @@
+import pytest
+from griptape.tokenizers import VoyageAiTokenizer
+
+
+class TestVoyageAiTokenizer:
+    @pytest.fixture(autouse=True)
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("voyageai.Client")
+        mock_client.return_value.count_tokens.return_value = 5
+
+        return mock_client
+
+    @pytest.fixture
+    def tokenizer(self, request):
+        return VoyageAiTokenizer(model=request.param)
+
+    @pytest.mark.parametrize(
+        "tokenizer,expected",
+        [("voyage-large-2", 5), ("voyage-code-2", 5), ("voyage-2", 5), ("voyage-lite-02-instruct", 5)],
+        indirect=["tokenizer"],
+    )
+    def test_token_count(self, tokenizer, expected):
+        assert tokenizer.count_tokens("foo bar huzzah") == expected
+
+    @pytest.mark.parametrize(
+        "tokenizer,expected",
+        [("voyage-large-2", 15995), ("voyage-code-2", 15995), ("voyage-2", 3995), ("voyage-lite-02-instruct", 3995)],
+        indirect=["tokenizer"],
+    )
+    def test_input_tokens_left(self, tokenizer, expected):
+        assert tokenizer.count_input_tokens_left("foo bar huzzah") == expected
+
+    @pytest.mark.parametrize(
+        "tokenizer,expected",
+        [("voyage-large-2", 0), ("voyage-code-2", 0), ("voyage-2", 0), ("voyage-lite-02-instruct", 0)],
+        indirect=["tokenizer"],
+    )
+    def test_output_tokens_left(self, tokenizer, expected):
+        assert tokenizer.count_output_tokens_left("foo bar huzzah") == expected


### PR DESCRIPTION
Adds VoyageAi as an Embedding Driver since they are [recommended by Anthropic](https://docs.anthropic.com/claude/docs/embeddings#can-i-count-the-number-of-tokens-in-a-string-before-embedding-it)