### PR TITLE
Fix calculation of max tokens

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -123,7 +123,10 @@ class OpenAiChatPromptDriver(BasePromptDriver):
 
         messages = self._prompt_stack_to_messages(prompt_stack)
 
-        params["max_tokens"] = self.max_output_tokens(self.prompt_stack_to_string(prompt_stack))
+        if isinstance(self.tokenizer, OpenAiTokenizer):
+            params["max_tokens"] = self.max_output_tokens(messages)
+        else:
+            params["max_tokens"] = self.max_output_tokens(self.prompt_stack_to_string(prompt_stack))
         params["messages"] = messages
 
         return params

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -41,7 +41,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
         )
         assert text_artifact.value == "model-output"
 
@@ -62,6 +62,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             stream=True,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
         )
         assert text_artifact.value == "model-output"

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -100,7 +100,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             seed=driver.seed,
         )
         assert text_artifact.value == "model-output"
@@ -122,7 +122,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             messages=[*messages, {"role": "system", "content": "Provide your response as a valid JSON object."}],
             seed=driver.seed,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             response_format={"type": "json_object"},
         )
         assert text_artifact.value == "model-output"
@@ -142,7 +142,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             stream=True,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             seed=driver.seed,
         )
         assert text_artifact.value == "model-output"
@@ -184,7 +184,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver.prompt_stack_to_string(prompt_stack)),
+            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             seed=driver.seed,
         )
         assert max_tokens_request > tokens_left


### PR DESCRIPTION
Fixes calculation of `max_tokens` to use Prompt Stack as ChatML messages instead of Prompt Stack as string. Other tokenizers besides `OpenAiTokenizer` will still convert Prompt Stack to string for token calculation.