### PR TITLE
Exclude fields that are not present in schema loading

### DIFF
--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -5,12 +5,15 @@ from typing import Union, Literal, get_args, get_origin
 from collections.abc import Sequence
 
 import attrs
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, EXCLUDE
 
 from griptape.schemas.bytes_field import Bytes
 
 
 class BaseSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
     DATACLASS_TYPE_MAPPING = {**Schema.TYPE_MAPPING, dict: fields.Dict, bytes: Bytes}
 
     @classmethod

--- a/tests/unit/schemas/test_base_schema.py
+++ b/tests/unit/schemas/test_base_schema.py
@@ -71,3 +71,15 @@ class TestBaseSchema:
         assert not BaseSchema.is_list_sequence(bytes)
         assert not BaseSchema.is_list_sequence(str)
         assert not BaseSchema.is_list_sequence(int)
+
+    def test_load(self):
+        schema = BaseSchema.from_attrs_cls(MockSerializable)()
+        mock_serializable = schema.load({"foo": "baz", "bar": "qux", "baz": [1, 2, 3]})
+        assert mock_serializable.foo == "baz"
+        assert mock_serializable.bar == "qux"
+        assert mock_serializable.baz == [1, 2, 3]
+
+    def test_load_with_unknown_attribute(self):
+        schema = BaseSchema.from_attrs_cls(MockSerializable)()
+        mock_serializable = schema.load({"foo": "baz", "bar": "qux", "baz": [1, 2, 3], "zoop": "bop"})
+        assert hasattr(mock_serializable, "zoop") is False


### PR DESCRIPTION
Fixes example from docs where two Structure Configs are merged:

```python
from griptape.structures import Agent
from griptape.config import AmazonBedrockStructureConfig
from griptape.drivers import AmazonBedrockCohereEmbeddingDriver

custom_config = AmazonBedrockStructureConfig()
custom_config.global_drivers.embedding_driver = AmazonBedrockCohereEmbeddingDriver()
custom_config.merge_config(
    {
        "task_memory": {
            "summary_engine": {
                "prompt_driver": {
                    "model": "amazon.titan-text-express-v1",
                    "prompt_model_driver": {
                        "type": "BedrockTitanPromptModelDriver",
                    },
                }
            }
        }
    }
)
serialized_config = custom_config.to_json()
deserialized_config = AmazonBedrockStructureConfig.from_json(serialized_config)

agent = Agent(
    config=deserialized_config,
)
```

```
Traceback (most recent call last):
  File "/Users/collindutter/Documents/griptape/griptape-playground/src/docs/config-5.py", line 7, in <module>
    custom_config.merge_config(
  File "/Users/collindutter/Documents/griptape/griptape/griptape/config/base_structure_config.py", line 21, in merge_config
    return BaseStructureConfig.from_dict(merged_config)
  File "/Users/collindutter/Documents/griptape/griptape/griptape/mixins/serializable_mixin.py", line 45, in from_dict
    return cast(T, cls.get_schema(subclass_name=data["type"] if "type" in data else None).load(data))
  File "/Users/collindutter/Documents/griptape/griptape-playground/.venv/lib/python3.9/site-packages/marshmallow/schema.py", line 722, in load
    return self._do_load(
  File "/Users/collindutter/Documents/griptape/griptape-playground/.venv/lib/python3.9/site-packages/marshmallow/schema.py", line 909, in _do_load
    raise exc
marshmallow.exceptions.ValidationError: {'task_memory': {'summary_engine': {'prompt_driver': {'prompt_model_driver': {'top_k': ['Unknown field.']}}}}}
```

This occurs because `top_k` does not exist in `BedrockTitanPromptModelDriver` and Marshmallow raises this by default. Setting `unknown=EXCLUDE` makes Mashmallow exclude the unknown fields during loading.