### PR TITLE
Revert calculating max output tokens for openai

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -123,10 +123,9 @@ class OpenAiChatPromptDriver(BasePromptDriver):
 
         messages = self._prompt_stack_to_messages(prompt_stack)
 
-        if isinstance(self.tokenizer, OpenAiTokenizer):
-            params["max_tokens"] = self.max_output_tokens(messages)
-        else:
-            params["max_tokens"] = self.max_output_tokens(self.prompt_stack_to_string(prompt_stack))
+        if self.max_tokens is not None:
+            params["max_tokens"] = self.max_tokens
+
         params["messages"] = messages
 
         return params

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -41,7 +41,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
         )
         assert text_artifact.value == "model-output"
 
@@ -62,6 +61,5 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             stream=True,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
         )
         assert text_artifact.value == "model-output"

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -100,7 +100,6 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             seed=driver.seed,
         )
         assert text_artifact.value == "model-output"
@@ -122,7 +121,6 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             messages=[*messages, {"role": "system", "content": "Provide your response as a valid JSON object."}],
             seed=driver.seed,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             response_format={"type": "json_object"},
         )
         assert text_artifact.value == "model-output"
@@ -142,7 +140,6 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             stream=True,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
             seed=driver.seed,
         )
         assert text_artifact.value == "model-output"
@@ -184,7 +181,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stop=driver.tokenizer.stop_sequences,
             user=driver.user,
             messages=messages,
-            max_tokens=driver.max_output_tokens(driver._prompt_stack_to_messages(prompt_stack)),
+            max_tokens=max_tokens_request,
             seed=driver.seed,
         )
         assert max_tokens_request > tokens_left


### PR DESCRIPTION
Need a better long term solution, but reverting to avoid a regression with the upcoming release.