### PR TITLE
Output single artifact, move value to name

### DIFF
--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -93,8 +93,6 @@ class ActionsSubtask(BaseTextInputTask):
         self.structure.logger.info(f"Subtask {self.id}\n{self.input.to_text()}")
 
     def run(self) -> BaseArtifact:
-        format_output: Callable[[tuple[str, BaseArtifact]], str] = lambda o: f"{o[0]} output: {o[1].to_text()}"
-
         try:
             if any(a.name == "error" for a in self.actions):
                 errors = [a.input["error"] for a in self.actions if a.name == "error"]
@@ -103,7 +101,9 @@ class ActionsSubtask(BaseTextInputTask):
             else:
                 results = self.execute_actions(self.actions)
 
-                self.output = ListArtifact([TextArtifact(format_output(r)) for r in results])
+                self.output = ListArtifact(
+                    [TextArtifact(name=f"{r[0]} output: {r[1].to_text()}", value=r[1].to_text()) for r in results]
+                )
         except Exception as e:
             self.structure.logger.error(f"Subtask {self.id}\n{e}", exc_info=True)
 

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -101,9 +101,7 @@ class ActionsSubtask(BaseTextInputTask):
             else:
                 results = self.execute_actions(self.actions)
 
-                self.output = ListArtifact(
-                    [TextArtifact(name=f"{r[0]} output: {r[1].to_text()}", value=r[1].to_text()) for r in results]
-                )
+                self.output = ListArtifact([TextArtifact(name=f"{r[0]} output", value=r[1].to_text()) for r in results])
         except Exception as e:
             self.structure.logger.error(f"Subtask {self.id}\n{e}", exc_info=True)
 

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -6,7 +6,7 @@ from attr import define, field
 from schema import Schema
 
 from griptape import utils
-from griptape.artifacts import InfoArtifact, BaseArtifact, ErrorArtifact
+from griptape.artifacts import InfoArtifact, BaseArtifact, ErrorArtifact, ListArtifact
 from griptape.tasks import PromptTask, ActionsSubtask
 from griptape.tools import BaseTool
 from griptape.utils import J2
@@ -63,8 +63,8 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
                 subtask.run()
                 subtask.after_run()
 
-                if subtask.output:
-                    self.output = subtask.output
+                if subtask.output and isinstance(subtask.output, ListArtifact):
+                    self.output = subtask.output[0]
                 else:
                     self.output = InfoArtifact("No tool output")
             except Exception as e:

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -63,7 +63,7 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
                 subtask.run()
                 subtask.after_run()
 
-                if subtask.output and isinstance(subtask.output, ListArtifact):
+                if isinstance(subtask.output, ListArtifact):
                     self.output = subtask.output[0]
                 else:
                     self.output = InfoArtifact("No tool output")

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -24,7 +24,7 @@ class TestToolTask:
 
         agent.add_task(task)
 
-        assert task.run().name == "MockTool output: ack foobar"
+        assert task.run().name == "MockTool output"
         assert task.run().value == "ack foobar"
 
     def test_run_with_memory(self, agent):

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -24,14 +24,15 @@ class TestToolTask:
 
         agent.add_task(task)
 
-        assert task.run().to_text() == "MockTool output: ack foobar"
+        assert task.run().name == "MockTool output: ack foobar"
+        assert task.run().value == "ack foobar"
 
     def test_run_with_memory(self, agent):
         task = ToolTask(tool=MockTool())
 
         agent.add_task(task)
 
-        assert task.run().to_text().startswith('MockTool output: Output of "MockTool.test" was stored in memory')
+        assert task.run().to_text().startswith('Output of "MockTool.test" was stored in memory')
 
     def test_meta_memory(self):
         memory = defaults.text_task_memory("TestMemory")


### PR DESCRIPTION
This PR makes the following changes:
- Don't return a `ListArtifact` from `ToolTask`. Consistent with old behavior.
- Move the formatted output of `ActionsSubtask` to `TextArtifact.name` instead of `TextArtifact.value`. This allows developers to have a formatted output in additional to the raw output (for parsing).