### PR TITLE
Add CitationVectorQueryEngine

### DIFF
--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -6,6 +6,9 @@ from .blob_artifact import BlobArtifact
 from .csv_row_artifact import CsvRowArtifact
 from .list_artifact import ListArtifact
 from .image_artifact import ImageArtifact
+from .meta.base_meta import BaseMeta
+from .meta.derived_artifact_meta import DerivedArtifactMeta
+from .meta.web_artifact_meta import WebArtifactMeta
 
 
 __all__ = [
@@ -17,4 +20,7 @@ __all__ = [
     "CsvRowArtifact",
     "ListArtifact",
     "ImageArtifact",
+    "BaseMeta",
+    "DerivedArtifactMeta",
+    "WebArtifactMeta",
 ]

--- a/griptape/artifacts/base_artifact.py
+++ b/griptape/artifacts/base_artifact.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
+from .meta.base_meta import BaseMeta
 from griptape.mixins import SerializableMixin
-from typing import Any
+from typing import Any, Optional
 import json
 import uuid
 from abc import ABC, abstractmethod
@@ -13,6 +15,7 @@ class BaseArtifact(SerializableMixin, ABC):
     name: str = field(
         default=Factory(lambda self: self.id, takes_self=True), kw_only=True, metadata={"serializable": True}
     )
+    meta: Optional[BaseMeta] = field(default=None, kw_only=True, metadata={"serializable": True})
     value: Any = field()
 
     @classmethod

--- a/griptape/artifacts/meta/base_meta.py
+++ b/griptape/artifacts/meta/base_meta.py
@@ -1,0 +1,8 @@
+from abc import ABC
+from attr import define
+from griptape.mixins.serializable_mixin import SerializableMixin
+
+
+@define
+class BaseMeta(SerializableMixin, ABC):
+    pass

--- a/griptape/artifacts/meta/derived_artifact_meta.py
+++ b/griptape/artifacts/meta/derived_artifact_meta.py
@@ -1,0 +1,9 @@
+from attr import Factory, define, field
+
+from griptape.artifacts.list_artifact import ListArtifact
+from .base_meta import BaseMeta
+
+
+@define
+class DerivedArtifactMeta(BaseMeta):
+    sources: ListArtifact = field(default=Factory(ListArtifact), kw_only=True, metadata={"serializable": True})

--- a/griptape/artifacts/meta/web_artifact_meta.py
+++ b/griptape/artifacts/meta/web_artifact_meta.py
@@ -1,0 +1,7 @@
+from attr import define, field
+from .base_meta import BaseMeta
+
+
+@define
+class WebArtifactMeta(BaseMeta):
+    url: str = field(kw_only=True, metadata={"serializable": True})

--- a/griptape/engines/__init__.py
+++ b/griptape/engines/__init__.py
@@ -3,6 +3,7 @@ from .extraction.csv_extraction_engine import CsvExtractionEngine
 from .extraction.json_extraction_engine import JsonExtractionEngine
 from .query.base_query_engine import BaseQueryEngine
 from .query.vector_query_engine import VectorQueryEngine
+from .query.citation_vector_query_engine import CitationVectorQueryEngine
 from .summary.base_summary_engine import BaseSummaryEngine
 from .summary.prompt_summary_engine import PromptSummaryEngine
 from .image.base_image_generation_engine import BaseImageGenerationEngine
@@ -15,6 +16,7 @@ from .image_query.image_query_engine import ImageQueryEngine
 __all__ = [
     "BaseQueryEngine",
     "VectorQueryEngine",
+    "CitationVectorQueryEngine",
     "BaseSummaryEngine",
     "PromptSummaryEngine",
     "BaseExtractionEngine",

--- a/griptape/engines/query/citation_vector_query_engine.py
+++ b/griptape/engines/query/citation_vector_query_engine.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+import json
+from typing import TYPE_CHECKING, Optional
+from attr import define, field, Factory
+from griptape.artifacts import TextArtifact, BaseArtifact, ListArtifact, DerivedArtifactMeta
+from griptape.utils import PromptStack
+from griptape.engines import BaseQueryEngine
+from griptape.utils.j2 import J2
+from griptape.rules import Ruleset
+from schema import Schema, And, Use
+
+
+if TYPE_CHECKING:
+    from griptape.drivers import BaseVectorStoreDriver, BasePromptDriver
+
+
+@define
+class CitationVectorQueryEngine(BaseQueryEngine):
+    answer_token_offset: int = field(default=400, kw_only=True)
+    vector_store_driver: BaseVectorStoreDriver = field(kw_only=True)
+    prompt_driver: BasePromptDriver = field(kw_only=True)
+    user_template_generator: J2 = field(default=Factory(lambda: J2("engines/query/user.j2")), kw_only=True)
+    system_template_generator: J2 = field(default=Factory(lambda: J2("engines/query/citation_system.j2")), kw_only=True)
+
+    def query(
+        self,
+        query: str,
+        namespace: Optional[str] = None,
+        *,
+        rulesets: Optional[list[Ruleset]] = None,
+        metadata: Optional[str] = None,
+        top_n: Optional[int] = None,
+        filter: Optional[dict] = None,
+    ) -> TextArtifact:
+        tokenizer = self.prompt_driver.tokenizer
+        result = self.vector_store_driver.query(query, top_n, namespace, filter=filter)
+        text_artifacts = ListArtifact(
+            [
+                artifact
+                for artifact in [BaseArtifact.from_json(r.meta["artifact"]) for r in result if r.meta]
+                if isinstance(artifact, TextArtifact)
+            ]
+        )
+        source_artifacts = self._flatten_derived_artifacts(text_artifacts)
+        sources = []
+        user_message = ""
+        system_message = ""
+
+        for source_artifact in source_artifacts:
+            sources.append(source_artifact)
+            system_message = self.system_template_generator.render(
+                rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets), metadata=metadata, sources=sources
+            )
+            user_message = self.user_template_generator.render(query=query)
+
+            message_token_count = self.prompt_driver.token_count(
+                PromptStack(
+                    inputs=[
+                        PromptStack.Input(system_message, role=PromptStack.SYSTEM_ROLE),
+                        PromptStack.Input(user_message, role=PromptStack.USER_ROLE),
+                    ]
+                )
+            )
+
+            if message_token_count + self.answer_token_offset >= tokenizer.max_input_tokens:
+                sources.pop()
+
+                user_message = self.user_template_generator.render(query=query)
+
+                break
+
+        text_artifact = self.prompt_driver.run(
+            PromptStack(
+                inputs=[
+                    PromptStack.Input(system_message, role=PromptStack.SYSTEM_ROLE),
+                    PromptStack.Input(user_message, role=PromptStack.USER_ROLE),
+                ]
+            )
+        )
+        value_and_sources = Schema(
+            And(Use(json.loads), {"value": str, "sources": [And(int, lambda n: 1 <= n <= len(sources))]})
+        ).validate(text_artifact.value)
+        value = value_and_sources["value"]
+        source_indices = value_and_sources["sources"]
+        sources = ListArtifact([sources[i - 1] for i in source_indices])
+        return TextArtifact(value=value, meta=DerivedArtifactMeta(sources=sources))
+
+    def _flatten_derived_artifacts(self, sources: ListArtifact) -> ListArtifact:
+        source_artifacts = []
+        for source in sources:
+            if isinstance(source.meta, DerivedArtifactMeta):
+                # We want to sort the original sources as much as possible. If this is a derived artifact,
+                # then we should recursively get the source artifacts which it was derived from. This is
+                # important when for example, a derived artifact cites multiple other artifacts, since the
+                # the newest artifact we are returning as a result of `query` may only reference one of them.
+                source_artifacts.extend(self._flatten_derived_artifacts(source.meta.sources).value)
+            else:
+                # The original source may or may not have the `SourceMeta` metadata. If it doesn't, then the
+                # resulting TextArtifact will cite the original text artifact, it just won't have any kind of
+                # reference to where it came from (e.g. url, etc).
+                source_artifacts.append(source)
+        return ListArtifact(source_artifacts)
+
+    def upsert_text_artifact(self, artifact: TextArtifact, namespace: Optional[str] = None) -> str:
+        result = self.vector_store_driver.upsert_text_artifact(artifact, namespace=namespace)
+
+        return result
+
+    def upsert_text_artifacts(self, artifacts: list[TextArtifact], namespace: str) -> None:
+        self.vector_store_driver.upsert_text_artifacts({namespace: artifacts})
+
+    def load_artifacts(self, namespace: str) -> ListArtifact:
+        result = self.vector_store_driver.load_entries(namespace)
+        artifacts = [BaseArtifact.from_json(r.meta["artifact"]) for r in result if r.meta and r.meta.get("artifact")]
+
+        return ListArtifact([a for a in artifacts if isinstance(a, TextArtifact)])

--- a/griptape/engines/query/citation_vector_query_engine.py
+++ b/griptape/engines/query/citation_vector_query_engine.py
@@ -89,15 +89,12 @@ class CitationVectorQueryEngine(BaseQueryEngine):
         source_artifacts = []
         for source in sources:
             if isinstance(source.meta, DerivedArtifactMeta):
-                # We want to sort the original sources as much as possible. If this is a derived artifact,
-                # then we should recursively get the source artifacts which it was derived from. This is
-                # important when for example, a derived artifact cites multiple other artifacts, since the
-                # the newest artifact we are returning as a result of `query` may only reference one of them.
+                # We want to cite the original sources. If this is a derived artifact, then we should
+                # recursively get the source artifacts which it was derived from. This is important when
+                # for example, a derived artifact cites multiple other artifacts, since the newest
+                # artifact we are returning as a result of `query` may only reference one of them.
                 source_artifacts.extend(self._flatten_derived_artifacts(source.meta.sources).value)
             else:
-                # The original source may or may not have the `SourceMeta` metadata. If it doesn't, then the
-                # resulting TextArtifact will cite the original text artifact, it just won't have any kind of
-                # reference to where it came from (e.g. url, etc).
                 source_artifacts.append(source)
         return ListArtifact(source_artifacts)
 

--- a/griptape/templates/engines/query/citation_system.j2
+++ b/griptape/templates/engines/query/citation_system.j2
@@ -1,0 +1,40 @@
+You are an expert Q&A system that is trusted around the world.
+Always answer the query using the provided sources, and not prior knowledge.
+Never directly reference the given source in your answer.
+Avoid statements like 'Based on the source, ...' or 'The sources...' or anything along those lines.
+{% if rulesets %}
+
+{{ rulesets }}
+{% endif %}
+
+When referencing information from a source, cite the appropriate source(s) using their corresponding numbers. 
+Every answer should include at least one source citation. 
+Only cite a source when you are explicitly referencing it. 
+If none of the sources are helpful, you should indicate that. 
+For example:
+Source 1:
+The sky is red in the evening and blue in the morning.
+Source 2:
+Water is wet when the sky is red.
+Query: When is water wet?
+Answer: { "value": "Water will be wet when the sky is red, which occurs in the evening.", "sources": [1, 2] }
+
+{% if metadata %}
+
+Metadata: """
+{{ metadata }}
+"""
+{% endif %}
+
+The sources are listed below.
+---------------------
+{% for source in sources %}
+
+Source {{loop.index}}:
+"""{{ source }}"""
+{% endfor %}
+---------------------
+
+Response must be a valid JSON object.
+The JSON object must have a key named "value" and a string as its value.
+The JSON object must have a key named "sources" and an array of the source numbers as its value.


### PR DESCRIPTION
Would like some early feedback on the general approach.

Note: This change does not support inline citations. For that I was planning on creating PR that adds InlineCitationVectorQueryEngine (or something like that) that returns a ListArtifact of TextArtifacts that make up the full answer when the values are concatenated together. This will allow segments of the entirety to have separate lists of sources.

Example usage:
```python
from dotenv import load_dotenv
from griptape.artifacts import WebArtifactMeta, DerivedArtifactMeta
from griptape.drivers import OpenAiChatPromptDriver, LocalVectorStoreDriver, OpenAiEmbeddingDriver
from griptape.engines import CitationVectorQueryEngine
from griptape.artifacts import TextArtifact, ListArtifact

load_dotenv()

query_engine = CitationVectorQueryEngine(
    prompt_driver=OpenAiChatPromptDriver(model="gpt-3.5-turbo"),
    vector_store_driver=LocalVectorStoreDriver(embedding_driver=OpenAiEmbeddingDriver()),
)

source_artifacts = [
    TextArtifact("Jim is one.", meta=WebArtifactMeta(url="www.jimisone.com")),
    TextArtifact("Harold is three and guther is two.", meta=DerivedArtifactMeta(sources=ListArtifact([
        TextArtifact("Harold is three.", meta=WebArtifactMeta(url="www.haroldisthree.com")),
        TextArtifact("Gunther is two.", meta=WebArtifactMeta(url="www.guntheristwo.com")),
    ]))),
    TextArtifact("Lester is two."),

]
for source_artifact in source_artifacts:
    query_engine.vector_store_driver.upsert_text_artifact(source_artifact)

queries = [
    "Who is one?",
    "Who is two?",
    "Who is three?",
    "Who is four?",
    "How old is everyone?",
    "How old is Jim?",
    "How old is Sally?",
]
for query in queries:
    text_artifact = query_engine.query(query, top_n=5)
    value = text_artifact.value
    meta = text_artifact.meta
    sources = []
    if isinstance(meta, DerivedArtifactMeta):
        sources = meta.sources

    print(f"Query: {query}")
    print(f"Result: {value}")
    print(f"Sources(count={len(sources)}):")
    for index, source in enumerate(sources):
        print(f"- Source {index + 1}:")
        print(f"    - Value: \"{source.value}\"")
        if isinstance(source.meta, WebArtifactMeta):
            print(f"    - url: {source.meta.url}")
        else:
            print(f"    - url: (None)")
    print('\n')
````

Output:
```txt
Query: Who is one?
Result: Jim is one.
Sources(count=1):
- Source 1:
    - Value: "Jim is one."
    - url: www.jimisone.com


Query: Who is two?
Result: Lester is two.
Sources(count=1):
- Source 1:
    - Value: "Lester is two."
    - url: (None)


Query: Who is three?
Result: Harold is three.
Sources(count=1):
- Source 1:
    - Value: "Harold is three."
    - url: www.haroldisthree.com


Query: Who is four?
Result: There is no information provided about anyone being four.
Sources(count=0):


Query: How old is everyone?
Result: Lester is two, Harold is three, Gunther is two, and Jim is one.
Sources(count=4):
- Source 1:
    - Value: "Lester is two."
    - url: (None)
- Source 2:
    - Value: "Harold is three."
    - url: www.haroldisthree.com
- Source 3:
    - Value: "Gunther is two."
    - url: www.guntheristwo.com
- Source 4:
    - Value: "Jim is one."
    - url: www.jimisone.com


Query: How old is Jim?
Result: Jim's age is not provided in the context information.
Sources(count=1):
- Source 1:
    - Value: "Jim is one."
    - url: www.jimisone.com


Query: How old is Sally?
Result: Sally's age is not provided in the given context information.
Sources(count=4):
- Source 1:
    - Value: "Lester is two."
    - url: (None)
- Source 2:
    - Value: "Harold is three."
    - url: www.haroldisthree.com
- Source 3:
    - Value: "Gunther is two."
    - url: www.guntheristwo.com
- Source 4:
    - Value: "Jim is one."
    - url: www.jimisone.com
```