### PR TITLE
Update default API version for `AzureOpenAiImageGenerationDriver`

### DIFF
--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -24,7 +24,7 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
     azure_endpoint: str = field(kw_only=True, metadata={"serializable": True})
     azure_ad_token: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
     azure_ad_token_provider: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
-    api_version: str = field(default="2023-12-01-preview", kw_only=True, metadata={"serializable": True})
+    api_version: str = field(default="2024-02-01", kw_only=True, metadata={"serializable": True})
     client: openai.AzureOpenAI = field(
         default=Factory(
             lambda self: openai.AzureOpenAI(


### PR DESCRIPTION
closes #730 

Taking the latest GA api version from [here](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#image-generation)