### PR TITLE
Remove boto3 from types

### DIFF
--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -100,13 +100,15 @@ class BaseSchema(Schema):
         Args:
             attrs_cls: An attrs class.
         """
+        from griptape.utils.import_utils import import_optional_dependency, is_dependency_installed
 
         # These modules are required to avoid `NameError`s when resolving types.
         from griptape.drivers import BaseConversationMemoryDriver, BasePromptDriver, BasePromptModelDriver
         from griptape.structures import Structure
         from griptape.utils import PromptStack
         from griptape.tokenizers.base_tokenizer import BaseTokenizer
-        import boto3
+
+        boto3 = import_optional_dependency("boto3") if is_dependency_installed("boto3") else {}
 
         attrs.resolve_types(
             attrs_cls,

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -107,8 +107,9 @@ class BaseSchema(Schema):
         from griptape.structures import Structure
         from griptape.utils import PromptStack
         from griptape.tokenizers.base_tokenizer import BaseTokenizer
+        from typing import Any
 
-        boto3 = import_optional_dependency("boto3") if is_dependency_installed("boto3") else {}
+        boto3 = import_optional_dependency("boto3") if is_dependency_installed("boto3") else Any
 
         attrs.resolve_types(
             attrs_cls,

--- a/griptape/utils/__init__.py
+++ b/griptape/utils/__init__.py
@@ -12,6 +12,7 @@ from .dict_utils import remove_null_values_in_dict_recursively
 from .dict_utils import dict_merge
 from .hash import str_to_hash
 from .import_utils import import_optional_dependency
+from .import_utils import is_dependency_installed
 from .stream import Stream
 from .constants import Constants as constants
 from .load_artifact_from_memory import load_artifact_from_memory
@@ -32,6 +33,7 @@ __all__ = [
     "Chat",
     "str_to_hash",
     "import_optional_dependency",
+    "is_dependency_installed",
     "execute_futures_dict",
     "TokenCounter",
     "PromptStack",

--- a/griptape/utils/import_utils.py
+++ b/griptape/utils/import_utils.py
@@ -33,3 +33,20 @@ def import_optional_dependency(name: str) -> Optional[ModuleType]:
         raise ImportError(msg)
 
     return module
+
+
+def is_dependency_installed(name: str) -> bool:
+    """Check if an optional dependency is available.
+
+    Args:
+        name: The module name.
+    Returns:
+        True if the dependency is available.
+        False if the dependency is not available.
+    """
+    try:
+        import_optional_dependency(name)
+    except ImportError:
+        return False
+
+    return True

--- a/tests/unit/utils/test_import_utils.py
+++ b/tests/unit/utils/test_import_utils.py
@@ -1,0 +1,17 @@
+import pytest
+from griptape.utils import import_optional_dependency, is_dependency_installed
+
+
+class TestImportUtils:
+    def test_import_optional_dependency(self):
+        assert import_optional_dependency("os")
+        assert import_optional_dependency("boto3")
+
+        with pytest.raises(ImportError):
+            assert import_optional_dependency("foobar")
+
+    def test_is_dependency_installed(self):
+        assert is_dependency_installed("os") is True
+        assert is_dependency_installed("boto3") is True
+
+        assert is_dependency_installed("foobar") is False


### PR DESCRIPTION
Fixes serialization crash when `boto3` is not installed via extras. ~Side effect of this is that we cannot use `boto3` type hints (boto.Session) in any serializable fields.~