### PR TITLE
Add AmazonS3FileManagerDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `model` field to `StartPromptEvent` and `FinishPromptEvent`.
 - `input_task_input` and `input_task_output` fields to `StartStructureRunEvent`.
 - `output_task_input` and `output_task_output` fields to `FinishStructureRunEvent`.
+- `AmazonS3FileManagerDriver` for managing files on Amazon S3.
 
 ### Changed
 - **BREAKING**: Secret fields (ex: api_key) removed from serialized Drivers.

--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -95,6 +95,7 @@ from .event_listener.local_event_listener_driver import LocalEventListenerDriver
 
 from .file_manager.base_file_manager_driver import BaseFileManagerDriver
 from .file_manager.local_file_manager_driver import LocalFileManagerDriver
+from .file_manager.amazon_s3_file_manager_driver import AmazonS3FileManagerDriver
 
 __all__ = [
     "BasePromptDriver",
@@ -179,4 +180,5 @@ __all__ = [
     "LocalEventListenerDriver",
     "BaseFileManagerDriver",
     "LocalFileManagerDriver",
+    "AmazonS3FileManagerDriver",
 ]

--- a/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
+++ b/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from attr import define, field, Factory
+from griptape.utils.import_utils import import_optional_dependency
+from .base_file_manager_driver import BaseFileManagerDriver
+
+if TYPE_CHECKING:
+    import boto3
+
+
+@define
+class AmazonS3FileManagerDriver(BaseFileManagerDriver):
+    """
+    AmazonS3FileManagerDriver can be used to list, load, and save files in an Amazon S3 bucket.
+
+    Attributes:
+        session: The boto3 session to use for S3 operations.
+        bucket: The name of the S3 bucket.
+        workdir: The absolute working directory (must start with "/"). List, load, and save
+            operations will be performed relative to this directory.
+        s3_client: The S3 client to use for S3 operations.
+    """
+
+    session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
+    bucket: str = field(kw_only=True)
+    workdir: str = field(default="/", kw_only=True)
+    s3_client: Any = field(default=Factory(lambda self: self.session.client("s3"), takes_self=True), kw_only=True)
+
+    @workdir.validator  # pyright: ignore
+    def validate_workdir(self, _, workdir: str) -> None:
+        if not Path(workdir).is_absolute():
+            raise ValueError("Workdir must be an absolute path")
+
+    def try_list_files(self, path: str) -> list[str]:
+        full_key = self._to_dir_full_key(path)
+        files_and_dirs = self._list_files_and_dirs(full_key)
+        if len(files_and_dirs) == 0:
+            if len(self._list_files_and_dirs(full_key.rstrip("/"), max_items=1)) > 0:
+                raise NotADirectoryError
+            else:
+                raise FileNotFoundError
+        return files_and_dirs
+
+    def _to_full_key(self, path: str) -> str:
+        path = path.lstrip("/")
+        full_key = os.path.join(self.workdir, path)
+        # Need to keep the trailing slash if it was there,
+        # because it means the path is a directory.
+        ended_with_slash = path.endswith("/")
+        full_key = os.path.normpath(full_key)
+        if ended_with_slash:
+            full_key += "/"
+        return full_key.lstrip("/")
+
+    def _to_dir_full_key(self, path: str) -> str:
+        full_key = self._to_full_key(path)
+        # S3 "directories" always end with a slash, except for the root.
+        if full_key != "" and not full_key.endswith("/"):
+            full_key += "/"
+        return full_key
+
+    def _list_files_and_dirs(self, full_key: str, **kwargs) -> list[str]:
+        max_items = kwargs.get("max_items")
+        pagination_config = {}
+        if max_items is not None:
+            pagination_config["MaxItems"] = max_items
+
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        pages = paginator.paginate(
+            Bucket=self.bucket, Prefix=full_key, Delimiter="/", PaginationConfig=pagination_config
+        )
+        files_and_dirs = []
+        for page in pages:
+            for obj in page.get("CommonPrefixes", []):
+                prefix = obj.get("Prefix")
+                dir = prefix[len(full_key) :].rstrip("/")
+                files_and_dirs.append(dir)
+
+            for obj in page.get("Contents", []):
+                key = obj.get("Key")
+                file = key[len(full_key) :]
+                files_and_dirs.append(file)
+        return files_and_dirs
+
+    def try_load_file(self, path: str) -> bytes:
+        botocore = import_optional_dependency("botocore")
+        full_key = self._to_full_key(path)
+
+        if self._is_a_directory(full_key):
+            raise IsADirectoryError
+
+        try:
+            response = self.s3_client.get_object(Bucket=self.bucket, Key=full_key)
+            return response["Body"].read()
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in {"NoSuchKey", "404"}:
+                raise FileNotFoundError
+            else:
+                raise e
+        except Exception as e:
+            raise e
+
+    def try_save_file(self, path: str, value: bytes):
+        full_key = self._to_full_key(path)
+        if self._is_a_directory(full_key):
+            raise IsADirectoryError
+        self.s3_client.put_object(Bucket=self.bucket, Key=full_key, Body=value)
+
+    def _is_a_directory(self, full_key: str) -> bool:
+        botocore = import_optional_dependency("botocore")
+        if full_key == "" or full_key.endswith("/"):
+            return True
+
+        try:
+            self.s3_client.head_object(Bucket=self.bucket, Key=full_key)
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in {"NoSuchKey", "404"}:
+                return len(self._list_files_and_dirs(full_key, max_items=1)) > 0
+            else:
+                raise e
+        return False

--- a/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
+++ b/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
@@ -58,8 +58,6 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
                 raise FileNotFoundError
             else:
                 raise e
-        except Exception as e:
-            raise e
 
     def try_save_file(self, path: str, value: bytes):
         full_key = self._to_full_key(path)
@@ -120,4 +118,5 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
                 return len(self._list_files_and_dirs(full_key, max_items=1)) > 0
             else:
                 raise e
+
         return False

--- a/griptape/drivers/file_manager/base_file_manager_driver.py
+++ b/griptape/drivers/file_manager/base_file_manager_driver.py
@@ -49,10 +49,6 @@ class BaseFileManagerDriver(ABC):
         except Exception as e:
             return ErrorArtifact(f"Failed to list files: {str(e)}")
 
-    @abstractmethod
-    def try_list_files(self, path: str) -> list[str]:
-        ...
-
     def load_file(self, path: str) -> BaseArtifact:
         try:
             extension = path.split(".")[-1]
@@ -72,10 +68,6 @@ class BaseFileManagerDriver(ABC):
             return ErrorArtifact("Not a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to load file: {str(e)}")
-
-    @abstractmethod
-    def try_load_file(self, path: str) -> bytes:
-        ...
 
     def save_file(self, path: str, value: bytes | str) -> InfoArtifact | ErrorArtifact:
         try:
@@ -98,6 +90,14 @@ class BaseFileManagerDriver(ABC):
             return ErrorArtifact("Path is a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to save file: {str(e)}")
+
+    @abstractmethod
+    def try_list_files(self, path: str) -> list[str]:
+        ...
+
+    @abstractmethod
+    def try_load_file(self, path: str) -> bytes:
+        ...
 
     @abstractmethod
     def try_save_file(self, path: str, value: bytes):

--- a/griptape/drivers/file_manager/base_file_manager_driver.py
+++ b/griptape/drivers/file_manager/base_file_manager_driver.py
@@ -49,6 +49,10 @@ class BaseFileManagerDriver(ABC):
         except Exception as e:
             return ErrorArtifact(f"Failed to list files: {str(e)}")
 
+    @abstractmethod
+    def try_list_files(self, path: str) -> list[str]:
+        ...
+
     def load_file(self, path: str) -> BaseArtifact:
         try:
             extension = path.split(".")[-1]
@@ -68,6 +72,10 @@ class BaseFileManagerDriver(ABC):
             return ErrorArtifact("Not a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to load file: {str(e)}")
+
+    @abstractmethod
+    def try_load_file(self, path: str) -> bytes:
+        ...
 
     def save_file(self, path: str, value: bytes | str) -> InfoArtifact | ErrorArtifact:
         try:
@@ -90,14 +98,6 @@ class BaseFileManagerDriver(ABC):
             return ErrorArtifact("Path is a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to save file: {str(e)}")
-
-    @abstractmethod
-    def try_list_files(self, path: str) -> list[str]:
-        ...
-
-    @abstractmethod
-    def try_load_file(self, path: str) -> bytes:
-        ...
 
     @abstractmethod
     def try_save_file(self, path: str, value: bytes):

--- a/griptape/drivers/file_manager/base_file_manager_driver.py
+++ b/griptape/drivers/file_manager/base_file_manager_driver.py
@@ -68,6 +68,8 @@ class BaseFileManagerDriver(ABC):
             return ErrorArtifact("Path not found")
         except IsADirectoryError:
             return ErrorArtifact("Path is a directory")
+        except NotADirectoryError:
+            return ErrorArtifact("Not a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to load file: {str(e)}")
 
@@ -92,6 +94,8 @@ class BaseFileManagerDriver(ABC):
             self.try_save_file(path, value)
 
             return InfoArtifact("Successfully saved file")
+        except IsADirectoryError:
+            return ErrorArtifact("Path is a directory")
         except Exception as e:
             return ErrorArtifact(f"Failed to save file: {str(e)}")
 

--- a/griptape/drivers/file_manager/local_file_manager_driver.py
+++ b/griptape/drivers/file_manager/local_file_manager_driver.py
@@ -27,15 +27,29 @@ class LocalFileManagerDriver(BaseFileManagerDriver):
 
     def try_load_file(self, path: str) -> bytes:
         full_path = self._full_path(path)
+        if self._is_dir(full_path):
+            raise IsADirectoryError
         with open(full_path, "rb") as file:
             return file.read()
 
     def try_save_file(self, path: str, value: bytes):
         full_path = self._full_path(path)
+        if self._is_dir(full_path):
+            raise IsADirectoryError
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
         with open(full_path, "wb") as file:
             file.write(value)
 
-    def _full_path(self, path: str) -> Path:
+    def _full_path(self, path: str) -> str:
         path = path.lstrip("/")
-        return Path(os.path.normpath(os.path.join(self.workdir, path)))
+        full_path = os.path.join(self.workdir, path)
+        # Need to keep the trailing slash if it was there,
+        # because it means the path is a directory.
+        ended_with_slash = path.endswith("/")
+        full_path = os.path.normpath(full_path)
+        if ended_with_slash:
+            full_path = full_path.rstrip("/") + "/"
+        return full_path
+
+    def _is_dir(self, full_path: str) -> bool:
+        return full_path.endswith("/") or Path(full_path).is_dir()

--- a/tests/unit/drivers/event_listener/test_aws_iot_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_aws_iot_event_listener_driver.py
@@ -8,7 +8,7 @@ from tests.utils.aws import mock_aws_credentials
 
 @mock_iotdata
 class TestAwsIotCoreEventListenerDriver:
-    @fixture()
+    @fixture(autouse=True)
     def run_before_and_after_tests(self):
         mock_aws_credentials()
 


### PR DESCRIPTION
Changes:
- Add AmazonS3FileManagerDriver
- Edit LocalFileManagerDriver to have consistent error artifact output
- Edit BaseFileManagerDriver with more exception to error artifact translations for common scenarios
- Improve test coverage of LocalFileManagerDriver

Also manually tested using the driver against a real s3 bucket, in a similar style to those added in the unit tests.