### PR TITLE
Remove references to old docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We welcome and encourage pull requests. To streamline the process, please follow
 
 3. **Unit Tests:** Ensure that your pull request passes all existing unit tests. Additionally, if you are introducing new code, please include new unit tests to validate its functionality.
 
-4. **Documentation:** Every pull request must include a corresponding pull request in the [docs repository](https://github.com/griptape-ai/griptape-docs) or explicitly explain why a documentation update is not required. Documentation is crucial for maintaining a comprehensive and user-friendly project.
+4. **Documentation:** Every pull request must include updates to documentation or explicitly explain why a documentation update is not required. Documentation is crucial for maintaining a comprehensive and user-friendly project.
 
 5. **Code Style:** Griptape uses [Black](https://github.com/ambv/black) to enforce style guidelines. You can ensure that your code is formatted accordingly and will pass formatting checks using `pre-commit`. See [Tools](#tools) for information on how to configure this and other dev tools.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to Griptape documentation! Before you sta
 
 ## Submitting Issues
 
-If you have identified a documentation issue, want to propose new documentation, or have a question, please submit an issue through our public [issue tracker](https://github.com/griptape-ai/griptape-docs/issues). Before submitting a new issue, please check the existing issues to ensure it hasn't been reported or discussed before.
+If you have identified a documentation issue, want to propose new documentation, or have a question, please submit an issue through our public [issue tracker](https://github.com/griptape-ai/griptape/issues). Before submitting a new issue, please check the existing issues to ensure it hasn't been reported or discussed before.
 
 ## Submitting Pull Requests
 
@@ -17,13 +17,11 @@ We welcome and encourage pull requests. To streamline the process, please follow
 ## Getting Started
 Griptape docs are built using [MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/). Dependencies are managed using [Poetry](https://python-poetry.org/).
 
-To directly contribute to Griptape documentation, first fork the [griptape-docs](https://github.com/griptape-ai/griptape-docs) repository to your GitHub account. Then clone your repository to your local machine.
-
-From inside the directory run: 
+To contribute to Griptape docs, install the `docs` extra with:
 
 ```poetry install --with docs```
 
-To run `griptape-docs` locally run: 
+Then serve the documentation locally with:
 
 ```poetry run mkdocs serve```
 
@@ -37,18 +35,3 @@ INFO     -  [09:28:33] Watching paths for changes: 'docs', 'mkdocs.yml'
 INFO     -  [09:28:33] Serving on http://127.0.0.1:8000/
 INFO     -  [09:28:37] Browser connected: http://127.0.0.1:8000/
 ```
-
-### Reference Docs
-
-You may see many `WARNING` messages in the console output. This is because the [reference docs](./reference/griptape/index.md) are not built.
-Fixing this is not necessary to contribute to the documentation, but it helps to reduce noise in the console output.
-
-First, clone the Griptape repository to a separate directory:
-
-`git clone git@github.com:griptape-ai/griptape.git ~/some/other/directory/`
-
-Then, create a symlink called `griptape` in the `griptape-docs` repository:
-
-`ln -s ~/some/other/directory/griptape griptape`
-
-The `WARNING` messages should now be resolved. 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,3 +1,3 @@
 This section of the documentation is dedicated to examples highlighting Griptape functionality.
 
-We try to keep all examples up to date, but if you think there is a bug please [submit a pull request](https://github.com/griptape-ai/griptape-docs/tree/main/docs/examples). We are also more than happy to include new examples :)
+We try to keep all examples up to date, but if you think there is a bug please [submit a pull request](https://github.com/griptape-ai/griptape/tree/dev/docs/examples). We are also more than happy to include new examples :)


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--749.org.readthedocs.build//749/

<!-- readthedocs-preview griptape end -->