### PR TITLE
Fix vector query engine exceeding token limits

### DIFF
--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -61,7 +61,11 @@ class VectorQueryEngine(BaseQueryEngine):
             if message_token_count + self.answer_token_offset >= tokenizer.max_input_tokens:
                 text_segments.pop()
 
-                user_message = self.user_template_generator.render(query=query, text_segments=text_segments)
+                system_message = self.system_template_generator.render(
+                    rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
+                    metadata=metadata,
+                    text_segments=text_segments,
+                )
 
                 break
 


### PR DESCRIPTION
We moved `text_segments` from the user message to the system message, and did not update the message regeneration logic for when the message exceeds the token input limits.