### PR TITLE
Add cloud docs API Reference

### DIFF
--- a/docs/griptape-cloud/api/api-reference.md
+++ b/docs/griptape-cloud/api/api-reference.md
@@ -1,0 +1,1 @@
+# Content overriden by Swagger Plugin

--- a/docs/griptape-cloud/index.md
+++ b/docs/griptape-cloud/index.md
@@ -1,0 +1,3 @@
+# Griptape Cloud
+
+Griptape Cloud is a managed platform for running AI-powered agents, pipelines, and workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ Welcome to Griptape Docs! This documentation is organized into the following sec
 
 Griptape Topic Guides discuss key topics at a high level and provide useful background information and explanation.
 
+### Griptape Cloud
+
+[Griptape Cloud](griptape-cloud/api/api-reference.md) provides an overview of the APIs available in the managed cloud service. 
+
 ### Griptape Framework
 
 [Griptape Framework](griptape-framework/index.md) provides an overview of the key topics within Griptape, and how you can get started building agents.

--- a/docs/plugins/swagger_ui_plugin.py
+++ b/docs/plugins/swagger_ui_plugin.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
 
 config_scheme = {
-    "spec_url": "https://cloud-preview.griptape.ai/public/openapi.yaml",
+    "spec_url": "https://griptape-cloud-assets.s3.amazonaws.com/Griptape.openapi.yaml",
     "template": "swagger.md.tmpl",
     "outfile": "griptape-cloud/api/api-reference.md",
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,9 @@ nav:
   - Home:
       - Overview: "index.md"
       - Contributing: "contributing.md"
+  - Cloud:
+      - Cloud API:
+          - API Reference: "griptape-cloud/api/api-reference.md"
   - Framework:
       - Overview: "griptape-framework/index.md"
       - Structures:


### PR DESCRIPTION
* Adding cloud docs to link to the API Reference

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--760.org.readthedocs.build//760/

<!-- readthedocs-preview griptape end -->