### PR TITLE
Add gpt-4o and update OpenAiStructureConfig default prompt_driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Default behavior of OpenAiStructureConfig to utilize `gpt-4o` for prompt_driver.
+
 ## [0.25.1] - 2024-05-09
 ### Added
 - Optional event batching on Event Listener Drivers.

--- a/griptape/config/openai_structure_config.py
+++ b/griptape/config/openai_structure_config.py
@@ -24,7 +24,7 @@ class OpenAiStructureConfig(BaseStructureConfig):
     global_drivers: StructureGlobalDriversConfig = field(
         default=Factory(
             lambda: StructureGlobalDriversConfig(
-                prompt_driver=OpenAiChatPromptDriver(model="gpt-4"),
+                prompt_driver=OpenAiChatPromptDriver(model="gpt-4o"),
                 image_generation_driver=OpenAiImageGenerationDriver(model="dall-e-2", image_size="512x512"),
                 image_query_driver=OpenAiVisionImageQueryDriver(model="gpt-4-vision-preview"),
                 embedding_driver=OpenAiEmbeddingDriver(model="text-embedding-3-small"),

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -10,7 +10,7 @@ from typing import Optional
 class OpenAiTokenizer(BaseTokenizer):
     DEFAULT_OPENAI_GPT_3_COMPLETION_MODEL = "gpt-3.5-turbo-instruct"
     DEFAULT_OPENAI_GPT_3_CHAT_MODEL = "gpt-3.5-turbo"
-    DEFAULT_OPENAI_GPT_4_MODEL = "gpt-4"
+    DEFAULT_OPENAI_GPT_4_MODEL = "gpt-4o"
     DEFAULT_ENCODING = "cl100k_base"
     DEFAULT_MAX_TOKENS = 2049
     DEFAULT_MAX_OUTPUT_TOKENS = 4096
@@ -18,6 +18,7 @@ class OpenAiTokenizer(BaseTokenizer):
 
     # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
     MODEL_PREFIXES_TO_MAX_INPUT_TOKENS = {
+        "gpt-4o": 128000,
         "gpt-4-1106": 128000,
         "gpt-4-32k": 32768,
         "gpt-4": 8192,

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -86,6 +86,7 @@ class OpenAiTokenizer(BaseTokenizer):
                 "gpt-4-32k-0314",
                 "gpt-4-0613",
                 "gpt-4-32k-0613",
+                "gpt-4o-2024-05-13",
             }:
                 tokens_per_message = 3
                 tokens_per_name = 1
@@ -97,6 +98,9 @@ class OpenAiTokenizer(BaseTokenizer):
             elif "gpt-3.5-turbo" in model or "gpt-35-turbo" in model:
                 logging.info("gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.")
                 return self.count_tokens(text, model="gpt-3.5-turbo-0613")
+            elif "gpt-4o" in model:
+                logging.info("gpt-4o may update over time. Returning num tokens assuming gpt-4o-2024-05-13.")
+                return self.count_tokens(text, model="gpt-4o-2024-05-13")
             elif "gpt-4" in model:
                 logging.info("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
                 return self.count_tokens(text, model="gpt-4-0613")

--- a/tests/unit/config/test_openai_structure_config.py
+++ b/tests/unit/config/test_openai_structure_config.py
@@ -19,7 +19,7 @@ class TestOpenAiStructureConfig:
                 "prompt_driver": {
                     "type": "OpenAiChatPromptDriver",
                     "base_url": None,
-                    "model": "gpt-4",
+                    "model": "gpt-4o",
                     "organization": None,
                     "response_format": None,
                     "seed": None,
@@ -72,7 +72,7 @@ class TestOpenAiStructureConfig:
                     "prompt_driver": {
                         "base_url": None,
                         "type": "OpenAiChatPromptDriver",
-                        "model": "gpt-4",
+                        "model": "gpt-4o",
                         "organization": None,
                         "response_format": None,
                         "seed": None,
@@ -98,7 +98,7 @@ class TestOpenAiStructureConfig:
                         "prompt_driver": {
                             "type": "OpenAiChatPromptDriver",
                             "base_url": None,
-                            "model": "gpt-4",
+                            "model": "gpt-4o",
                             "organization": None,
                             "response_format": None,
                             "seed": None,
@@ -113,7 +113,7 @@ class TestOpenAiStructureConfig:
                         "prompt_driver": {
                             "type": "OpenAiChatPromptDriver",
                             "base_url": None,
-                            "model": "gpt-4",
+                            "model": "gpt-4o",
                             "organization": None,
                             "response_format": None,
                             "seed": None,
@@ -129,7 +129,7 @@ class TestOpenAiStructureConfig:
                     "prompt_driver": {
                         "type": "OpenAiChatPromptDriver",
                         "base_url": None,
-                        "model": "gpt-4",
+                        "model": "gpt-4o",
                         "organization": None,
                         "response_format": None,
                         "seed": None,


### PR DESCRIPTION
- Add `gpt-4o` in `OpenAiTokenizer`
- Update `OpenAiStructureConfig` default prompt_driver to `gpt-4o`
- Update openai structure config test

https://platform.openai.com/docs/models/gpt-4o