### PR TITLE
Edit workflow tasks to accept lists of tasks defining execution order

### DIFF
--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -30,7 +30,7 @@ class Agent(Structure):
 
     @property
     def task(self) -> BaseTask:
-        return self.tasks[0]
+        return self.task_list[0]
 
     def add_task(self, task: BaseTask) -> BaseTask:
         self.tasks.clear()

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -45,7 +45,7 @@ class Pipeline(Structure):
     def try_run(self, *args) -> Pipeline:
         self._execution_args = args
 
-        [task.reset() for task in self.tasks]
+        [task.reset() for task in self.task_list]
 
         self.__run_from_task(self.input_task)
 


### PR DESCRIPTION
We would like to make creating Workflows more intuitive.

This PR accomplishes this by modifying the type of `Structure.tasks` to `list[BaseTask | list[BaseTask]]` in order to allow initializing `Workflow` with "task batches" which determine execution order. See unit tests for example usages.

This PR strongly favors "don't make breaking changes" over "rethink past decisions" and avoids adding new attributes to `Structure`. The result of this preference is some additional complexity.

The only "breaking" change is that customer code that references `Structure.tasks` directly may begin to see static typing errors if their usage is incompatible with the `list[BaseTask | list[BaseTask]]` type. The mitigation is to ask them to use the `task_list` property instead of `tasks` directly. That said, the actual value of `tasks` post-initialization will always be a `list[BaseTask]`, so their code will still run fine even without this mitigation.



