### PR TITLE
Refactor/artifact chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `AzureOpenAiStructureConfig` for providing Structures with all Azure OpenAI Driver configuration.
 - `AzureOpenAiVisionImageQueryDriver` to support queries on images using Azure's OpenAI Vision models.
+- `ActionArtifact` for storing Action calls.
+- `ActionChunkArtifact` for storing partial Action calls when streaming.
+- `TextChunkArtifact` for storing partial text when streaming.
 
 ### Changed
 - **BREAKING**: Updated OpenAI-based image query drivers to remove Vision from the name.
+- **BREAKING**: Replaced `ActionsSubtask.Action` with `ActionArtifact.Action`.
+- **BREAKING**: Yield `TextChunkArtifact`s instead of `TextArtifact`s in the `Stream` util.
 - Default the value of `azure_deployment` on all Azure Drivers to the model the Driver is using.
 - Field `azure_ad_token` on all Azure Drivers is no longer serializable.
 - Default standard OpenAI and Azure OpenAI image query model to `gpt-4o`.

--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -1,6 +1,8 @@
 from .base_artifact import BaseArtifact
+from .base_chunk_artifact import BaseChunkArtifact
 from .error_artifact import ErrorArtifact
 from .info_artifact import InfoArtifact
+from .text_chunk_artifact import TextChunkArtifact
 from .text_artifact import TextArtifact
 from .blob_artifact import BlobArtifact
 from .csv_row_artifact import CsvRowArtifact
@@ -8,12 +10,16 @@ from .list_artifact import ListArtifact
 from .media_artifact import MediaArtifact
 from .image_artifact import ImageArtifact
 from .audio_artifact import AudioArtifact
+from .action_chunk_artifact import ActionChunkArtifact
+from .action_artifact import ActionArtifact
 
 
 __all__ = [
     "BaseArtifact",
+    "BaseChunkArtifact",
     "ErrorArtifact",
     "InfoArtifact",
+    "TextChunkArtifact",
     "TextArtifact",
     "BlobArtifact",
     "CsvRowArtifact",
@@ -21,4 +27,6 @@ __all__ = [
     "MediaArtifact",
     "ImageArtifact",
     "AudioArtifact",
+    "ActionChunkArtifact",
+    "ActionArtifact",
 ]

--- a/griptape/artifacts/action_artifact.py
+++ b/griptape/artifacts/action_artifact.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Optional
+from collections.abc import Sequence
+
+from attrs import define, field
+
+from griptape.artifacts import BaseArtifact, ActionChunkArtifact
+from griptape.mixins import SerializableMixin
+
+if TYPE_CHECKING:
+    from griptape.artifacts import BaseChunkArtifact
+    from griptape.tools import BaseTool
+
+
+@define()
+class ActionArtifact(BaseArtifact, SerializableMixin):
+    """Represents an instance of an LLM taking an action to use a Tool.
+    Attributes:
+        tag: The tag (unique identifier) of the action.
+        name: The name (Tool name) of the action.
+        path: The path (Tool activity name) of the action.
+        input: The input (Tool params) of the action.
+        tool: The tool used in the action.
+        output: The output of the action execution.
+    """
+
+    @define(kw_only=True)
+    class Action(SerializableMixin):
+        tag: str = field(metadata={"serializable": True})
+        name: str = field(metadata={"serializable": True})
+        path: Optional[str] = field(default=None, metadata={"serializable": True})
+        input: dict = field(default={}, metadata={"serializable": True})
+        tool: Optional[BaseTool] = field(default=None, metadata={"serializable": False})
+
+        def __str__(self) -> str:
+            return f"{self.name} {self.path} {self.input}"
+
+    value: Action = field(metadata={"serializable": True})
+
+    def __add__(self, other: BaseArtifact) -> ActionArtifact:
+        raise NotImplementedError
+
+    @classmethod
+    def from_chunks(cls, chunks: Sequence[BaseChunkArtifact]) -> ActionArtifact:
+        tag = ""
+        name = ""
+        path = ""
+        partial_input = ""
+
+        for chunk in chunks:
+            if isinstance(chunk, ActionChunkArtifact):
+                tag += chunk.value.tag or ""
+                name += chunk.value.name or ""
+                path += chunk.value.path or ""
+                partial_input += chunk.value.input or ""
+
+        try:
+            input = json.loads(partial_input)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to decode JSON input: {partial_input}, {e}")
+
+        result = ActionArtifact.Action(tag=tag, name=name, path=path, input=input)
+
+        return cls(result)

--- a/griptape/artifacts/action_artifact.py
+++ b/griptape/artifacts/action_artifact.py
@@ -17,13 +17,13 @@ if TYPE_CHECKING:
 @define()
 class ActionArtifact(BaseArtifact, SerializableMixin):
     """Represents an instance of an LLM taking an action to use a Tool.
+
     Attributes:
         tag: The tag (unique identifier) of the action.
         name: The name (Tool name) of the action.
         path: The path (Tool activity name) of the action.
         input: The input (Tool params) of the action.
         tool: The tool used in the action.
-        output: The output of the action execution.
     """
 
     @define(kw_only=True)

--- a/griptape/artifacts/action_chunk_artifact.py
+++ b/griptape/artifacts/action_chunk_artifact.py
@@ -12,11 +12,12 @@ from griptape.mixins import SerializableMixin
 class ActionChunkArtifact(BaseChunkArtifact, SerializableMixin):
     """An Artifact that represents a chunk of an Action.
     Can be used when streaming with Prompt Drivers that support native function calling.
+
     Attributes:
         tag: The tag of the action.
         name: The name of the action.
         path: The path of the action.
-        partial_input: The partial input of the action.
+        input: The partial input of the action.
         index: The index of the action.
     """
 

--- a/griptape/artifacts/action_chunk_artifact.py
+++ b/griptape/artifacts/action_chunk_artifact.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from attr import define, field
+
+from griptape.artifacts import BaseArtifact, BaseChunkArtifact
+from griptape.mixins import SerializableMixin
+
+
+@define
+class ActionChunkArtifact(BaseChunkArtifact, SerializableMixin):
+    """An Artifact that represents a chunk of an Action.
+    Can be used when streaming with Prompt Drivers that support native function calling.
+    Attributes:
+        tag: The tag of the action.
+        name: The name of the action.
+        path: The path of the action.
+        partial_input: The partial input of the action.
+        index: The index of the action.
+    """
+
+    @define()
+    class ActionChunk(SerializableMixin):
+        tag: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+        name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+        path: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+        input: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+        index: Optional[int] = field(default=None, kw_only=True, metadata={"serializable": True})
+
+        def __add__(self, other: ActionChunkArtifact.ActionChunk) -> ActionChunkArtifact.ActionChunk:
+            if self.index == other.index:
+                return ActionChunkArtifact.ActionChunk(
+                    tag=(self.tag or "") + (other.tag or ""),
+                    name=(self.name or "") + (other.name or ""),
+                    path=(self.path or "") + (other.path or ""),
+                    input=(self.input or "") + (other.input or ""),
+                    index=self.index,
+                )
+            else:
+                raise ValueError("Cannot add together actions with different indexes.")
+
+    value: ActionChunk = field(metadata={"serializable": True})
+
+    def __add__(self, other: BaseArtifact) -> ActionChunkArtifact:
+        if isinstance(other, ActionChunkArtifact):
+            return ActionChunkArtifact(value=self.value + other.value)
+        else:
+            raise NotImplementedError

--- a/griptape/artifacts/base_artifact.py
+++ b/griptape/artifacts/base_artifact.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
-from griptape.mixins import SerializableMixin
-from typing import Any
+
 import json
 import uuid
 from abc import ABC, abstractmethod
-from attr import define, field, Factory
+from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
+
+from attr import Factory, define, field
+
+from griptape.mixins import SerializableMixin
+
+if TYPE_CHECKING:
+    from griptape.artifacts import BaseChunkArtifact
 
 
 @define()
@@ -45,3 +52,7 @@ class BaseArtifact(SerializableMixin, ABC):
 
     @abstractmethod
     def __add__(self, other: BaseArtifact) -> BaseArtifact: ...
+
+    @classmethod
+    def from_chunks(cls, chunks: Sequence[BaseChunkArtifact]) -> BaseArtifact:
+        raise NotImplementedError

--- a/griptape/artifacts/base_chunk_artifact.py
+++ b/griptape/artifacts/base_chunk_artifact.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from abc import abstractmethod
+from attrs import define
+from griptape.artifacts.base_artifact import BaseArtifact
+
+
+@define
+class BaseChunkArtifact(BaseArtifact):
+    @abstractmethod
+    def __add__(self, other: BaseArtifact) -> BaseChunkArtifact: ...

--- a/griptape/artifacts/text_artifact.py
+++ b/griptape/artifacts/text_artifact.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
+from collections.abc import Sequence
+
 from attr import define, field
-from griptape.artifacts import BaseArtifact
+
+from griptape.artifacts import BaseArtifact, BaseChunkArtifact
 
 if TYPE_CHECKING:
     from griptape.drivers import BaseEmbeddingDriver
@@ -36,3 +40,12 @@ class TextArtifact(BaseArtifact):
 
     def to_bytes(self) -> bytes:
         return self.value.encode(encoding=self.encoding, errors=self.encoding_error_handler)
+
+    @classmethod
+    def from_chunks(cls, chunks: Sequence[BaseChunkArtifact]) -> TextArtifact:
+        result = ""
+
+        for chunk in chunks:
+            result += chunk.value
+
+        return TextArtifact(result)

--- a/griptape/artifacts/text_chunk_artifact.py
+++ b/griptape/artifacts/text_chunk_artifact.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from attr import define, field
+
+from griptape.artifacts import BaseArtifact, BaseChunkArtifact
+
+if TYPE_CHECKING:
+    from griptape.tokenizers import BaseTokenizer
+
+
+@define
+class TextChunkArtifact(BaseChunkArtifact):
+    value: str = field(converter=str, metadata={"serializable": True})
+
+    def __add__(self, other: BaseArtifact) -> TextChunkArtifact:
+        return TextChunkArtifact(self.value + other.value)
+
+    def __bool__(self) -> bool:
+        return bool(self.value.strip())
+
+    def token_count(self, tokenizer: BaseTokenizer) -> int:
+        return tokenizer.count_tokens(str(self.value))

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -3,7 +3,7 @@ import json
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils import import_optional_dependency
 from .base_multi_model_prompt_driver import BaseMultiModelPromptDriver
 
@@ -36,7 +36,7 @@ class AmazonBedrockPromptDriver(BaseMultiModelPromptDriver):
         else:
             raise Exception("model response is empty")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         model_input = self.prompt_model_driver.prompt_stack_to_model_input(prompt_stack)
         payload = {**self.prompt_model_driver.prompt_stack_to_model_params(prompt_stack)}
         if isinstance(model_input, dict):
@@ -50,6 +50,6 @@ class AmazonBedrockPromptDriver(BaseMultiModelPromptDriver):
         if response_body:
             for chunk in response["body"]:
                 chunk_bytes = chunk["chunk"]["bytes"]
-                yield self.prompt_model_driver.process_output(chunk_bytes)
+                yield TextChunkArtifact(value=self.prompt_model_driver.process_output(chunk_bytes).value)
         else:
             raise Exception("model response is empty")

--- a/griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_sagemaker_prompt_driver.py
@@ -3,7 +3,7 @@ import json
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils import import_optional_dependency
 from .base_multi_model_prompt_driver import BaseMultiModelPromptDriver
 
@@ -45,5 +45,5 @@ class AmazonSageMakerPromptDriver(BaseMultiModelPromptDriver):
         else:
             raise Exception("model response is empty")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         raise NotImplementedError("streaming is not supported")

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Optional, Any
 from collections.abc import Iterator
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils import PromptStack, import_optional_dependency
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import AnthropicTokenizer
@@ -37,12 +37,12 @@ class AnthropicPromptDriver(BasePromptDriver):
 
         return TextArtifact(value=response.content[0].text)
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         response = self.client.messages.create(**self._base_params(prompt_stack), stream=True)
 
         for chunk in response:
             if chunk.type == "content_block_delta":
-                yield TextArtifact(value=chunk.delta.text)
+                yield TextChunkArtifact(value=chunk.delta.text)
 
     def _prompt_stack_to_model_input(self, prompt_stack: PromptStack) -> dict:
         messages = [

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -8,7 +8,7 @@ from griptape.mixins.serializable_mixin import SerializableMixin
 from griptape.utils import PromptStack
 from griptape.mixins import ExponentialBackoffMixin
 from griptape.tokenizers import BaseTokenizer
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, BaseChunkArtifact
 
 if TYPE_CHECKING:
     from griptape.structures import Structure
@@ -111,4 +111,4 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact: ...
 
     @abstractmethod
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]: ...
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[BaseChunkArtifact]: ...

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from collections.abc import Iterator
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import CohereTokenizer
 from griptape.utils import PromptStack, import_optional_dependency
@@ -45,14 +45,14 @@ class CoherePromptDriver(BasePromptDriver):
         else:
             raise Exception("model response is empty")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         result = self.client.generate(
             **self._base_params(prompt_stack),
             stream=True,  # pyright: ignore[reportCallIssue]
         )
 
         for chunk in result:
-            yield TextArtifact(value=chunk.text)
+            yield TextChunkArtifact(value=chunk.text)
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         prompt = self.prompt_stack_to_string(prompt_stack)

--- a/griptape/drivers/prompt/dummy_prompt_driver.py
+++ b/griptape/drivers/prompt/dummy_prompt_driver.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from attrs import field, Factory, define
 from griptape.tokenizers import DummyTokenizer
 from griptape.drivers import BasePromptDriver
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.exceptions import DummyException
 from griptape.utils.prompt_stack import PromptStack
 
@@ -15,5 +15,5 @@ class DummyPromptDriver(BasePromptDriver):
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         raise DummyException(__class__.__name__, "try_run")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         raise DummyException(__class__.__name__, "try_stream")

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Optional, Any
 from attr import define, field, Factory
 from griptape.utils import PromptStack, import_optional_dependency
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import GoogleTokenizer, BaseTokenizer
 
@@ -51,7 +51,7 @@ class GooglePromptDriver(BasePromptDriver):
 
         return TextArtifact(value=response.text)
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         GenerationConfig = import_optional_dependency("google.generativeai.types").GenerationConfig
 
         inputs = self._prompt_stack_to_model_input(prompt_stack)
@@ -68,7 +68,7 @@ class GooglePromptDriver(BasePromptDriver):
         )
 
         for chunk in response:
-            yield TextArtifact(value=chunk.text)
+            yield TextChunkArtifact(value=chunk.text)
 
     def _default_model_client(self) -> GenerativeModel:
         genai = import_optional_dependency("google.generativeai")

--- a/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from attr import Factory, define, field
 
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import PromptStack, import_optional_dependency
@@ -60,7 +60,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
 
         return TextArtifact(value=response)
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         prompt = self.prompt_stack_to_string(prompt_stack)
 
         response = self.client.text_generation(
@@ -68,4 +68,4 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
         )
 
         for token in response:
-            yield TextArtifact(value=token)
+            yield TextChunkArtifact(value=token)

--- a/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 
 from attr import Factory, define, field
 
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import PromptStack, import_optional_dependency
@@ -57,5 +57,5 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         else:
             raise Exception(f"only models with the following tasks are supported: {self.SUPPORTED_TASKS}")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         raise NotImplementedError("streaming is not supported")

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -3,7 +3,7 @@ from typing import Optional, Any, Literal
 from collections.abc import Iterator
 import openai
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils import PromptStack
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import OpenAiTokenizer, BaseTokenizer
@@ -83,7 +83,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         else:
             raise Exception("Completion with more than one choice is not supported yet.")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         result = self.client.chat.completions.create(**self._base_params(prompt_stack), stream=True)
 
         for chunk in result:
@@ -95,7 +95,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             if delta.content is not None:
                 delta_content = delta.content
 
-                yield TextArtifact(value=delta_content)
+                yield TextChunkArtifact(value=delta_content)
 
     def token_count(self, prompt_stack: PromptStack) -> int:
         if isinstance(self.tokenizer, OpenAiTokenizer):

--- a/griptape/drivers/prompt/openai_completion_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_completion_prompt_driver.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from collections.abc import Iterator
 from attr import define, field, Factory
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils import PromptStack
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import OpenAiTokenizer
@@ -58,14 +58,14 @@ class OpenAiCompletionPromptDriver(BasePromptDriver):
         else:
             raise Exception("completion with more than one choice is not supported yet")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         result = self.client.completions.create(**self._base_params(prompt_stack), stream=True)
 
         for chunk in result:
             if len(chunk.choices) == 1:
                 choice = chunk.choices[0]
                 delta_content = choice.text
-                yield TextArtifact(value=delta_content)
+                yield TextChunkArtifact(value=delta_content)
 
             else:
                 raise Exception("completion with more than one choice is not supported yet")

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -9,33 +9,24 @@ from griptape import utils
 from griptape.utils import remove_null_values_in_dict_recursively
 from griptape.mixins import ActionsSubtaskOriginMixin
 from griptape.tasks import BaseTextInputTask, BaseTask
-from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact, ListArtifact
+from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact, ListArtifact, ActionArtifact
 from griptape.events import StartActionsSubtaskEvent, FinishActionsSubtaskEvent
 
 if TYPE_CHECKING:
     from griptape.memory import TaskMemory
-    from griptape.tools import BaseTool
 
 
 @define
 class ActionsSubtask(BaseTextInputTask):
-    @define(kw_only=True)
-    class Action:
-        tag: str = field()
-        name: str = field()
-        path: Optional[str] = field(default=None)
-        input: dict = field()
-        tool: Optional[BaseTool] = field(default=None)
-
     THOUGHT_PATTERN = r"(?s)^Thought:\s*(.*?)$"
     ACTIONS_PATTERN = r"(?s)Actions:[^\[]*(\[.*\])"
     ANSWER_PATTERN = r"(?s)^Answer:\s?([\s\S]*)$"
 
     parent_task_id: Optional[str] = field(default=None, kw_only=True)
     thought: Optional[str] = field(default=None, kw_only=True)
-    actions: list[Action] = field(factory=list, kw_only=True)
+    actions: list[ActionArtifact.Action] = field(factory=list, kw_only=True)
 
-    _input: Optional[str | TextArtifact | Callable[[BaseTask], TextArtifact]] = field(default=None)
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(default=None)
     _memory: Optional[TaskMemory] = None
 
     @property
@@ -112,14 +103,14 @@ class ActionsSubtask(BaseTextInputTask):
             else:
                 return ErrorArtifact("no tool output")
 
-    def execute_actions(self, actions: list[Action]) -> list[tuple[str, BaseArtifact]]:
+    def execute_actions(self, actions: list[ActionArtifact.Action]) -> list[tuple[str, BaseArtifact]]:
         results = utils.execute_futures_dict(
             {a.tag: self.futures_executor.submit(self.execute_action, a) for a in actions}
         )
 
         return [r for r in results.values()]
 
-    def execute_action(self, action: Action) -> tuple[str, BaseArtifact]:
+    def execute_action(self, action: ActionArtifact.Action) -> tuple[str, BaseArtifact]:
         if action.tool is not None:
             if action.path is not None:
                 output = action.tool.execute(getattr(action.tool, action.path), self, action)
@@ -243,7 +234,7 @@ class ActionsSubtask(BaseTextInputTask):
                         "ActionSubtask must be attached to a Task that implements ActionSubtaskOriginMixin."
                     )
 
-                new_action = ActionsSubtask.Action(
+                new_action = ActionArtifact.Action(
                     tag=action_tag, name=action_name, path=action_path, input=action_input, tool=tool
                 )
 
@@ -266,10 +257,10 @@ class ActionsSubtask(BaseTextInputTask):
 
             self.actions.append(self.__error_to_action(f"Action input parsing error: {e}"))
 
-    def __error_to_action(self, error: str) -> Action:
-        return ActionsSubtask.Action(tag="error", name="error", input={"error": error})
+    def __error_to_action(self, error: str) -> ActionArtifact.Action:
+        return ActionArtifact.Action(tag="error", name="error", input={"error": error})
 
-    def __validate_action(self, action: Action) -> None:
+    def __validate_action(self, action: ActionArtifact.Action) -> None:
         try:
             if action.path is not None:
                 activity = getattr(action.tool, action.path)

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -10,7 +10,7 @@ from abc import ABC
 from typing import Optional
 import yaml
 from attr import define, field, Factory
-from griptape.artifacts import BaseArtifact, InfoArtifact, TextArtifact
+from griptape.artifacts import BaseArtifact, InfoArtifact, TextArtifact, ActionArtifact
 from griptape.mixins import ActivityMixin
 
 if TYPE_CHECKING:
@@ -107,18 +107,18 @@ class BaseTool(ActivityMixin, ABC):
             for activity in self.activities()
         ]
 
-    def execute(self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action) -> BaseArtifact:
+    def execute(self, activity: Callable, subtask: ActionsSubtask, action: ActionArtifact.Action) -> BaseArtifact:
         preprocessed_input = self.before_run(activity, subtask, action)
         output = self.run(activity, subtask, action, preprocessed_input)
         postprocessed_output = self.after_run(activity, subtask, action, output)
 
         return postprocessed_output
 
-    def before_run(self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action) -> Optional[dict]:
+    def before_run(self, activity: Callable, subtask: ActionsSubtask, action: ActionArtifact.Action) -> Optional[dict]:
         return action.input
 
     def run(
-        self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action, value: Optional[dict]
+        self, activity: Callable, subtask: ActionsSubtask, action: ActionArtifact.Action, value: Optional[dict]
     ) -> BaseArtifact:
         activity_result = activity(value)
 
@@ -132,7 +132,7 @@ class BaseTool(ActivityMixin, ABC):
         return result
 
     def after_run(
-        self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action, value: BaseArtifact
+        self, activity: Callable, subtask: ActionsSubtask, action: ActionArtifact.Action, value: BaseArtifact
     ) -> BaseArtifact:
         if value:
             if self.output_memory:

--- a/griptape/utils/stream.py
+++ b/griptape/utils/stream.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from collections.abc import Iterator
 from threading import Thread
 from queue import Queue
-from griptape.artifacts.text_artifact import TextArtifact
+from griptape.artifacts import TextChunkArtifact
 from griptape.events.completion_chunk_event import CompletionChunkEvent
 from griptape.events.event_listener import EventListener
 from griptape.events.base_event import BaseEvent
@@ -38,7 +38,7 @@ class Stream:
 
     _event_queue: Queue[BaseEvent] = field(default=Factory(lambda: Queue()))
 
-    def run(self, *args) -> Iterator[TextArtifact]:
+    def run(self, *args) -> Iterator[TextChunkArtifact]:
         t = Thread(target=self._run_structure, args=args)
         t.start()
 
@@ -47,9 +47,9 @@ class Stream:
             if isinstance(event, FinishStructureRunEvent):
                 break
             elif isinstance(event, FinishPromptEvent):
-                yield TextArtifact(value="\n")
+                yield TextChunkArtifact(value="\n")
             elif isinstance(event, CompletionChunkEvent):
-                yield TextArtifact(value=event.token)
+                yield TextChunkArtifact(value=event.token)
         t.join()
 
     def _run_structure(self, *args):

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -1,10 +1,10 @@
-from typing import Iterator
+from collections.abc import Iterator
 from attr import define
 
 from griptape.utils import PromptStack
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import OpenAiTokenizer, BaseTokenizer
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 
 
 @define
@@ -18,14 +18,14 @@ class MockFailingPromptDriver(BasePromptDriver):
         if self.current_attempt < self.max_failures:
             self.current_attempt += 1
 
-            raise Exception(f"failed attempt")
+            raise Exception("failed attempt")
         else:
             return TextArtifact("success")
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
         if self.current_attempt < self.max_failures:
             self.current_attempt += 1
 
-            raise Exception(f"failed attempt")
+            raise Exception("failed attempt")
         else:
-            yield TextArtifact("success")
+            yield TextChunkArtifact("success")

--- a/tests/mocks/mock_prompt_driver.py
+++ b/tests/mocks/mock_prompt_driver.py
@@ -3,7 +3,7 @@ from attr import define, field
 from griptape.utils import PromptStack
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from tests.mocks.mock_tokenizer import MockTokenizer
 
 
@@ -16,5 +16,5 @@ class MockPromptDriver(BasePromptDriver):
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         return TextArtifact(value=self.mock_output)
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        yield TextArtifact(value=self.mock_output)
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
+        yield TextChunkArtifact(value=self.mock_output)

--- a/tests/mocks/mock_value_prompt_driver.py
+++ b/tests/mocks/mock_value_prompt_driver.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from attr import define, field, Factory
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import OpenAiTokenizer, BaseTokenizer
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import TextArtifact, TextChunkArtifact
 from griptape.utils.prompt_stack import PromptStack
 
 
@@ -17,5 +17,5 @@ class MockValuePromptDriver(BasePromptDriver):
     def try_run(self, prompt_stack: PromptStack) -> TextArtifact:
         return TextArtifact(value=self.value)
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextArtifact]:
-        yield TextArtifact(value=self.value)
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[TextChunkArtifact]:
+        yield TextChunkArtifact(value=self.value)

--- a/tests/unit/artifacts/test_action_artifact.py
+++ b/tests/unit/artifacts/test_action_artifact.py
@@ -1,0 +1,42 @@
+import pytest
+from griptape.artifacts import ActionArtifact, ActionChunkArtifact
+
+
+class TestActionArtifact:
+    def test___add__(self):
+        action_artifact_1 = ActionArtifact(value=ActionArtifact.Action(tag="foo", name="bar", path="baz", input={}))
+        action_artifact_2 = ActionArtifact(value=ActionArtifact.Action(tag="bar", name="baz", path="qux", input={}))
+
+        with pytest.raises(NotImplementedError):
+            action_artifact_1 += action_artifact_2
+
+    def test_from_chunks(self):
+        chunks = [
+            ActionChunkArtifact(ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="{", index=1)),
+            ActionChunkArtifact(
+                ActionChunkArtifact.ActionChunk(tag="bar", name="baz", path="qux", input='"foo": "bar"', index=1)
+            ),
+            ActionChunkArtifact(
+                ActionChunkArtifact.ActionChunk(tag="baz", name="qux", path="quux", input="}", index=1)
+            ),
+        ]
+
+        action_artifact = ActionArtifact.from_chunks(chunks)
+
+        assert action_artifact.value == ActionArtifact.Action(
+            tag="foobarbaz", name="barbazqux", path="bazquxquux", input={"foo": "bar"}
+        )
+
+    def test_from_chunks_bad_input(self):
+        chunks = [
+            ActionChunkArtifact(ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="{", index=1)),
+            ActionChunkArtifact(
+                ActionChunkArtifact.ActionChunk(tag="bar", name="baz", path="qux", input="very very bad", index=1)
+            ),
+            ActionChunkArtifact(
+                ActionChunkArtifact.ActionChunk(tag="baz", name="qux", path="quux", input="}", index=2)
+            ),
+        ]
+
+        with pytest.raises(ValueError):
+            ActionArtifact.from_chunks(chunks)

--- a/tests/unit/artifacts/test_action_artifact.py
+++ b/tests/unit/artifacts/test_action_artifact.py
@@ -1,5 +1,5 @@
 import pytest
-from griptape.artifacts import ActionArtifact, ActionChunkArtifact
+from griptape.artifacts import ActionArtifact, ActionChunkArtifact, TextArtifact
 
 
 class TestActionArtifact:
@@ -10,6 +10,11 @@ class TestActionArtifact:
         with pytest.raises(NotImplementedError):
             action_artifact_1 += action_artifact_2
 
+    def test__str__(self):
+        action_artifact = ActionArtifact(value=ActionArtifact.Action(tag="foo", name="bar", path="baz", input={}))
+
+        assert str(action_artifact) == "bar baz {}"
+
     def test_from_chunks(self):
         chunks = [
             ActionChunkArtifact(ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="{", index=1)),
@@ -19,6 +24,7 @@ class TestActionArtifact:
             ActionChunkArtifact(
                 ActionChunkArtifact.ActionChunk(tag="baz", name="qux", path="quux", input="}", index=1)
             ),
+            TextArtifact("foobar"),
         ]
 
         action_artifact = ActionArtifact.from_chunks(chunks)

--- a/tests/unit/artifacts/test_action_chunk_artifact.py
+++ b/tests/unit/artifacts/test_action_chunk_artifact.py
@@ -1,0 +1,36 @@
+import pytest
+from griptape.artifacts import ActionChunkArtifact, TextArtifact
+
+
+class TestActionChunkArtifact:
+    def test___add__(self):
+        artifact_1 = ActionChunkArtifact(
+            value=ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="quux", index=1)
+        )
+        artifact_2 = ActionChunkArtifact(
+            value=ActionChunkArtifact.ActionChunk(tag="bar", name="baz", path="qux", input="quuz", index=1)
+        )
+        added_artifact = artifact_1 + artifact_2
+
+        assert added_artifact.value == ActionChunkArtifact.ActionChunk(
+            tag="foobar", name="barbaz", path="bazqux", input="quuxquuz", index=1
+        )
+
+    def test__add__different_index(self):
+        artifact_1 = ActionChunkArtifact(
+            value=ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="quux", index=1)
+        )
+        artifact_2 = ActionChunkArtifact(
+            value=ActionChunkArtifact.ActionChunk(tag="bar", name="baz", path="qux", input="quuz", index=2)
+        )
+
+        with pytest.raises(ValueError):
+            artifact_1 += artifact_2
+
+    def test___add__not_implemented(self):
+        artifact_1 = ActionChunkArtifact(
+            value=ActionChunkArtifact.ActionChunk(tag="foo", name="bar", path="baz", input="quux", index=1)
+        )
+
+        with pytest.raises(NotImplementedError):
+            artifact_1 += TextArtifact("foo")

--- a/tests/unit/artifacts/test_base_artifact.py
+++ b/tests/unit/artifacts/test_base_artifact.py
@@ -67,3 +67,7 @@ class TestBaseArtifact:
         dict_value = {"type": "foo", "value": "foobar"}
         with pytest.raises(ValueError):
             BaseArtifact.from_dict(dict_value)
+
+    def test_unsupported_from_chunk(self):
+        with pytest.raises(NotImplementedError):
+            BaseArtifact.from_chunks([])

--- a/tests/unit/artifacts/test_text_artifact.py
+++ b/tests/unit/artifacts/test_text_artifact.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from griptape.artifacts import TextArtifact, BaseArtifact
+from griptape.artifacts import TextArtifact, BaseArtifact, TextChunkArtifact
 from griptape.tokenizers import OpenAiTokenizer
 from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
@@ -61,3 +61,8 @@ class TestTextArtifact:
 
         assert artifact.name == artifact.id
         assert TextArtifact("foo", name="bar").name == "bar"
+
+    def test_from_chunks(self):
+        chunks = [TextChunkArtifact("foo"), TextChunkArtifact("bar")]
+
+        assert TextArtifact.from_chunks(chunks).value == "foobar"

--- a/tests/unit/artifacts/test_text_chunk_artifact.py
+++ b/tests/unit/artifacts/test_text_chunk_artifact.py
@@ -1,0 +1,50 @@
+import json
+from griptape.artifacts import BaseArtifact, TextChunkArtifact, TextArtifact
+from griptape.tokenizers import OpenAiTokenizer
+
+
+class TestTextChunkArtifact:
+    def test_value_type_conversion(self):
+        assert TextChunkArtifact("1").value == "1"
+        assert TextChunkArtifact(1).value == "1"  # pyright: ignore[reportArgumentType]
+
+    def test___add__(self):
+        assert (TextChunkArtifact("foo") + TextChunkArtifact("bar")).value == "foobar"
+
+    def test__bool__(self):
+        assert TextChunkArtifact("foo")
+        assert not TextChunkArtifact("")
+
+    def test_to_text(self):
+        assert TextChunkArtifact("foobar").to_text() == "foobar"
+
+    def test_token_count(self):
+        assert (
+            TextChunkArtifact("foobarbaz").token_count(
+                OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+            )
+            == 2
+        )
+
+    def test_to_dict(self):
+        assert TextChunkArtifact("foobar").to_dict()["value"] == "foobar"
+
+    def test_from_dict(self):
+        assert BaseArtifact.from_dict(TextChunkArtifact("foobar").to_dict()).value == "foobar"
+
+    def test_to_json(self):
+        assert json.loads(TextChunkArtifact("foobar").to_json())["value"] == "foobar"
+
+    def test_from_json(self):
+        assert BaseArtifact.from_json(TextChunkArtifact("foobar").to_json()).value == "foobar"
+
+    def test_name(self):
+        artifact = TextChunkArtifact("foo")
+
+        assert artifact.name == artifact.id
+        assert TextChunkArtifact("foo", name="bar").name == "bar"
+
+    def test_from_chunks(self):
+        chunks = [TextChunkArtifact("foo"), TextChunkArtifact("bar")]
+
+        assert TextArtifact.from_chunks(chunks).value == "foobar"

--- a/tests/unit/tasks/test_toolkit_task.py
+++ b/tests/unit/tasks/test_toolkit_task.py
@@ -1,5 +1,5 @@
 import pytest
-from griptape.artifacts import ErrorArtifact, TextArtifact
+from griptape.artifacts import ErrorArtifact, TextArtifact, ActionArtifact
 from griptape.drivers import LocalVectorStoreDriver
 from griptape.engines import VectorQueryEngine
 from griptape.structures import Agent
@@ -231,10 +231,10 @@ class TestToolkitSubtask:
     def test_add_subtask(self):
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
         subtask1 = ActionsSubtask(
-            "test1", actions=[ActionsSubtask.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
+            "test1", actions=[ActionArtifact.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
         )
         subtask2 = ActionsSubtask(
-            "test2", actions=[ActionsSubtask.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
+            "test2", actions=[ActionArtifact.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
         )
 
         Agent().add_task(task)
@@ -255,10 +255,10 @@ class TestToolkitSubtask:
     def test_find_subtask(self):
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
         subtask1 = ActionsSubtask(
-            "test1", actions=[ActionsSubtask.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
+            "test1", actions=[ActionArtifact.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
         )
         subtask2 = ActionsSubtask(
-            "test2", actions=[ActionsSubtask.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
+            "test2", actions=[ActionArtifact.Action(tag="foo", name="test", path="test", input={"values": {"f": "b"}})]
         )
 
         Agent().add_task(task)

--- a/tests/unit/tools/test_base_tool.py
+++ b/tests/unit/tools/test_base_tool.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import yaml
 from schema import SchemaMissingKeyError, Schema, Or
+from griptape.artifacts import ActionArtifact
 from griptape.tasks import ActionsSubtask, ToolkitTask
 from tests.mocks.mock_tool.tool import MockTool
 from tests.utils import defaults
@@ -171,10 +172,10 @@ class TestBaseTool:
 
     def test_invalid_config(self):
         try:
-            from tests.mocks.invalid_mock_tool.tool import InvalidMockTool
+            from tests.mocks.invalid_mock_tool.tool import InvalidMockTool  # noqa
 
             assert False
-        except SchemaMissingKeyError as e:
+        except SchemaMissingKeyError:
             assert True
 
     def test_memory(self):
@@ -206,7 +207,7 @@ class TestBaseTool:
         assert MockTool(input_memory=[defaults.text_task_memory("foo")]).find_input_memory("foo") is not None
 
     def test_execute(self, tool):
-        action = ActionsSubtask.Action(input={}, name="", tag="")
+        action = ActionArtifact.Action(input={}, name="", tag="")
         assert tool.execute(tool.test_list_output, ActionsSubtask("foo"), action).to_text() == "foo\n\nbar"
 
     def test_schema(self, tool):


### PR DESCRIPTION
Splitting out some of the work from https://github.com/griptape-ai/griptape/pull/791.

This PR introduces several new Artifact types, and makes the distinction between "full" Artifacts and "chunk" Artifacts. While the difference between a `TextArtifact` and `TextChunkArtifact` is negligible, as we get into more advanced modalities types like function calls, images, and audio, the difference is significant.

The "full" classes have a `from_chunks` method to assemble a "full" Artifact from a list of partial chunks.