### PR TITLE
Refactor tasks to use ListArtifact as input

### DIFF
--- a/griptape/artifacts/list_artifact.py
+++ b/griptape/artifacts/list_artifact.py
@@ -8,10 +8,11 @@ from griptape.artifacts import BaseArtifact
 class ListArtifact(BaseArtifact):
     value: Sequence[BaseArtifact] = field(factory=list, metadata={"serializable": True})
     item_separator: str = field(default="\n\n", kw_only=True, metadata={"serializable": True})
+    validate_uniform_types: bool = field(default=False, kw_only=True, metadata={"serializable": True})
 
     @value.validator  # pyright: ignore
     def validate_value(self, _, value: list[BaseArtifact]) -> None:
-        if len(value) > 0:
+        if self.validate_uniform_types and len(value) > 0:
             first_type = type(value[0])
 
             if not all(isinstance(v, first_type) for v in value):

--- a/griptape/events/base_task_event.py
+++ b/griptape/events/base_task_event.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from attrs import define, field
 from abc import ABC
-from typing import Optional, Union
-from collections.abc import Sequence
+from typing import Optional
 from griptape.artifacts import BaseArtifact
 from .base_event import BaseEvent
 
@@ -13,7 +12,5 @@ class BaseTaskEvent(BaseEvent, ABC):
     task_parent_ids: list[str] = field(kw_only=True, metadata={"serializable": True})
     task_child_ids: list[str] = field(kw_only=True, metadata={"serializable": True})
 
-    task_input: Union[BaseArtifact, tuple[BaseArtifact, ...], tuple[BaseArtifact, Sequence[BaseArtifact]]] = field(
-        kw_only=True, metadata={"serializable": True}
-    )
+    task_input: BaseArtifact = field(kw_only=True, metadata={"serializable": True})
     task_output: Optional[BaseArtifact] = field(kw_only=True, metadata={"serializable": True})

--- a/griptape/events/finish_structure_run_event.py
+++ b/griptape/events/finish_structure_run_event.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-from collections.abc import Sequence
+from typing import Optional
 
 from attrs import define, field
 
@@ -10,7 +9,5 @@ from griptape.events.base_event import BaseEvent
 @define
 class FinishStructureRunEvent(BaseEvent):
     structure_id: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
-    output_task_input: Union[BaseArtifact, tuple[BaseArtifact, ...], tuple[BaseArtifact, Sequence[BaseArtifact]]] = (
-        field(kw_only=True, metadata={"serializable": True})
-    )
+    output_task_input: BaseArtifact = field(kw_only=True, metadata={"serializable": True})
     output_task_output: Optional[BaseArtifact] = field(kw_only=True, metadata={"serializable": True})

--- a/griptape/events/start_structure_run_event.py
+++ b/griptape/events/start_structure_run_event.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-from collections.abc import Sequence
+from typing import Optional
 
 from attrs import define, field
 
@@ -10,7 +9,5 @@ from griptape.events.base_event import BaseEvent
 @define
 class StartStructureRunEvent(BaseEvent):
     structure_id: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
-    input_task_input: Union[BaseArtifact, tuple[BaseArtifact, ...], tuple[BaseArtifact, Sequence[BaseArtifact]]] = (
-        field(kw_only=True, metadata={"serializable": True})
-    )
+    input_task_input: BaseArtifact = field(kw_only=True, metadata={"serializable": True})
     input_task_output: Optional[BaseArtifact] = field(kw_only=True, metadata={"serializable": True})

--- a/griptape/tasks/base_multi_text_input_task.py
+++ b/griptape/tasks/base_multi_text_input_task.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from attrs import define, field, Factory
 
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import ListArtifact, TextArtifact
 from griptape.mixins.rule_mixin import RuleMixin
 from griptape.tasks import BaseTask
 from griptape.utils import J2
@@ -20,20 +20,19 @@ class BaseMultiTextInputTask(RuleMixin, BaseTask, ABC):
     )
 
     @property
-    def input(self) -> tuple[TextArtifact, ...]:
+    def input(self) -> ListArtifact:
         if all(isinstance(elem, TextArtifact) for elem in self._input):
-            return self._input  # pyright: ignore
+            return ListArtifact([artifact for artifact in self._input if isinstance(artifact, TextArtifact)])
         elif all(isinstance(elem, Callable) for elem in self._input):
-            return tuple([elem(self) for elem in self._input])  # pyright: ignore
-        elif isinstance(self._input, tuple):
-            return tuple(
+            return ListArtifact([callable(self) for callable in self._input if isinstance(callable, Callable)])
+        else:
+            return ListArtifact(
                 [
-                    TextArtifact(J2().render_from_string(input_template, **self.full_context))  # pyright: ignore
+                    TextArtifact(J2().render_from_string(input_template, **self.full_context))
                     for input_template in self._input
+                    if isinstance(input_template, str)
                 ]
             )
-        else:
-            return tuple([TextArtifact(J2().render_from_string(self._input, **self.full_context))])
 
     @input.setter
     def input(

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from concurrent import futures
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
-from collections.abc import Sequence
 
 from attrs import define, field, Factory
 
@@ -38,7 +37,7 @@ class BaseTask(ABC):
 
     @property
     @abstractmethod
-    def input(self) -> BaseArtifact | tuple[BaseArtifact, ...] | tuple[BaseArtifact, Sequence[BaseArtifact]]: ...
+    def input(self) -> BaseArtifact: ...
 
     @property
     def parents(self) -> list[BaseTask]:

--- a/griptape/tasks/inpainting_image_generation_task.py
+++ b/griptape/tasks/inpainting_image_generation_task.py
@@ -5,7 +5,7 @@ from typing import Callable
 from attrs import define, field
 
 from griptape.engines import InpaintingImageGenerationEngine
-from griptape.artifacts import ImageArtifact, TextArtifact
+from griptape.artifacts import ImageArtifact, TextArtifact, ListArtifact
 from griptape.tasks import BaseImageGenerationTask, BaseTask
 from griptape.utils import J2
 
@@ -30,26 +30,29 @@ class InpaintingImageGenerationTask(BaseImageGenerationTask):
         default=None, kw_only=True, alias="image_generation_engine"
     )
     _input: (
-        tuple[str | TextArtifact, ImageArtifact, ImageArtifact]
-        | Callable[[BaseTask], tuple[TextArtifact, ImageArtifact, ImageArtifact]]
+        tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact
     ) = field(default=None)
 
     @property
-    def input(self) -> tuple[TextArtifact, ImageArtifact, ImageArtifact]:
-        if isinstance(self._input, tuple):
+    def input(self) -> ListArtifact:
+        if isinstance(self._input, ListArtifact):
+            return self._input
+        elif isinstance(self._input, tuple):
             if isinstance(self._input[0], TextArtifact):
                 input_text = self._input[0]
             else:
                 input_text = TextArtifact(J2().render_from_string(self._input[0], **self.full_context))
 
-            return input_text, self._input[1], self._input[2]
+            return ListArtifact([input_text, self._input[1], self._input[2]])
         elif isinstance(self._input, Callable):
             return self._input(self)
         else:
             raise ValueError("Input must be a tuple of (text, image, mask) or a callable that returns such a tuple.")
 
     @input.setter
-    def input(self, value: tuple[TextArtifact, ImageArtifact, ImageArtifact]) -> None:
+    def input(
+        self, value: tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact]
+    ) -> None:
         self._input = value
 
     @property
@@ -69,8 +72,14 @@ class InpaintingImageGenerationTask(BaseImageGenerationTask):
 
     def run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
+
         image_artifact = self.input[1]
+        if not isinstance(image_artifact, ImageArtifact):
+            raise ValueError("Image must be an ImageArtifact.")
+
         mask_artifact = self.input[2]
+        if not isinstance(mask_artifact, ImageArtifact):
+            raise ValueError("Mask must be an ImageArtifact.")
 
         output_image_artifact = self.image_generation_engine.run(
             prompts=[prompt_artifact.to_text()],

--- a/griptape/tasks/outpainting_image_generation_task.py
+++ b/griptape/tasks/outpainting_image_generation_task.py
@@ -5,7 +5,7 @@ from typing import Callable
 from attrs import define, field
 
 from griptape.engines import OutpaintingImageGenerationEngine
-from griptape.artifacts import ImageArtifact, TextArtifact
+from griptape.artifacts import ImageArtifact, TextArtifact, ListArtifact
 from griptape.tasks import BaseImageGenerationTask, BaseTask
 from griptape.utils import J2
 
@@ -30,26 +30,29 @@ class OutpaintingImageGenerationTask(BaseImageGenerationTask):
         default=None, kw_only=True, alias="image_generation_engine"
     )
     _input: (
-        tuple[str | TextArtifact, ImageArtifact, ImageArtifact]
-        | Callable[[BaseTask], tuple[TextArtifact, ImageArtifact, ImageArtifact]]
+        tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact
     ) = field(default=None)
 
     @property
-    def input(self) -> tuple[TextArtifact, ImageArtifact, ImageArtifact]:
-        if isinstance(self._input, tuple):
+    def input(self) -> ListArtifact:
+        if isinstance(self._input, ListArtifact):
+            return self._input
+        elif isinstance(self._input, tuple):
             if isinstance(self._input[0], TextArtifact):
                 input_text = self._input[0]
             else:
                 input_text = TextArtifact(J2().render_from_string(self._input[0], **self.full_context))
 
-            return input_text, self._input[1], self._input[2]
+            return ListArtifact([input_text, self._input[1], self._input[2]])
         elif isinstance(self._input, Callable):
             return self._input(self)
         else:
             raise ValueError("Input must be a tuple of (text, image, mask) or a callable that returns such a tuple.")
 
     @input.setter
-    def input(self, value: tuple[TextArtifact, ImageArtifact, ImageArtifact]) -> None:
+    def input(
+        self, value: tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact]
+    ) -> None:
         self._input = value
 
     @property
@@ -70,8 +73,14 @@ class OutpaintingImageGenerationTask(BaseImageGenerationTask):
 
     def run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
+
         image_artifact = self.input[1]
+        if not isinstance(image_artifact, ImageArtifact):
+            raise ValueError("Image must be an ImageArtifact.")
+
         mask_artifact = self.input[2]
+        if not isinstance(mask_artifact, ImageArtifact):
+            raise ValueError("Mask must be an ImageArtifact.")
 
         output_image_artifact = self.image_generation_engine.run(
             prompts=[prompt_artifact.to_text()],

--- a/griptape/tasks/variation_image_generation_task.py
+++ b/griptape/tasks/variation_image_generation_task.py
@@ -5,7 +5,7 @@ from typing import Callable
 from attrs import define, field
 
 from griptape.engines import VariationImageGenerationEngine
-from griptape.artifacts import ImageArtifact, TextArtifact
+from griptape.artifacts import ImageArtifact, TextArtifact, ListArtifact
 from griptape.tasks import BaseImageGenerationTask, BaseTask
 from griptape.utils import J2
 
@@ -29,26 +29,28 @@ class VariationImageGenerationTask(BaseImageGenerationTask):
     _image_generation_engine: VariationImageGenerationEngine = field(
         default=None, kw_only=True, alias="image_generation_engine"
     )
-    _input: tuple[str | TextArtifact, ImageArtifact] | Callable[[BaseTask], tuple[TextArtifact, ImageArtifact]] = field(
+    _input: tuple[str | TextArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact = field(
         default=None
     )
 
     @property
-    def input(self) -> tuple[TextArtifact, ImageArtifact]:
-        if isinstance(self._input, tuple):
+    def input(self) -> ListArtifact:
+        if isinstance(self._input, ListArtifact):
+            return self._input
+        elif isinstance(self._input, tuple):
             if isinstance(self._input[0], TextArtifact):
                 input_text = self._input[0]
             else:
                 input_text = TextArtifact(J2().render_from_string(self._input[0], **self.full_context))
 
-            return input_text, self._input[1]
+            return ListArtifact([input_text, self._input[1]])
         elif isinstance(self._input, Callable):
             return self._input(self)
         else:
             raise ValueError("Input must be a tuple of (text, image) or a callable that returns such a tuple.")
 
     @input.setter
-    def input(self, value: tuple[TextArtifact, ImageArtifact]) -> None:
+    def input(self, value: tuple[str | TextArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact]) -> None:
         self._input = value
 
     @property
@@ -68,7 +70,10 @@ class VariationImageGenerationTask(BaseImageGenerationTask):
 
     def run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
+
         image_artifact = self.input[1]
+        if not isinstance(image_artifact, ImageArtifact):
+            raise ValueError("Image must be an ImageArtifact.")
 
         output_image_artifact = self.image_generation_engine.run(
             prompts=[prompt_artifact.to_text()],

--- a/tests/unit/artifacts/test_list_artifact.py
+++ b/tests/unit/artifacts/test_list_artifact.py
@@ -24,7 +24,7 @@ class TestListArtifact:
 
     def test_validate_value(self):
         with pytest.raises(ValueError):
-            ListArtifact([TextArtifact("foo"), BlobArtifact(b"bar")])
+            ListArtifact([TextArtifact("foo"), BlobArtifact(b"bar")], validate_uniform_types=True)
 
     def test_child_type(self):
         assert ListArtifact([TextArtifact("foo")]).child_type == TextArtifact

--- a/tests/unit/events/test_finish_structure_run_event.py
+++ b/tests/unit/events/test_finish_structure_run_event.py
@@ -1,5 +1,6 @@
 import pytest
-from griptape.artifacts.text_artifact import TextArtifact
+
+from griptape.artifacts import ImageArtifact, ListArtifact, TextArtifact
 from griptape.events import FinishStructureRunEvent
 
 
@@ -7,12 +8,19 @@ class TestFinishStructureRunEvent:
     @pytest.fixture
     def finish_structure_run_event(self):
         return FinishStructureRunEvent(
-            structure_id="fizz", output_task_input=TextArtifact("foo"), output_task_output=TextArtifact("bar")
+            structure_id="fizz",
+            output_task_input=ListArtifact(
+                [TextArtifact("foo"), ImageArtifact(b"", format="png", width=100, height=100)]
+            ),
+            output_task_output=TextArtifact("bar"),
         )
 
     def test_to_dict(self, finish_structure_run_event):
         assert finish_structure_run_event.to_dict() is not None
 
         assert finish_structure_run_event.to_dict()["structure_id"] == "fizz"
-        assert finish_structure_run_event.to_dict()["output_task_input"]["value"] == "foo"
+        assert finish_structure_run_event.to_dict()["output_task_input"]["value"][0]["value"] == "foo"
         assert finish_structure_run_event.to_dict()["output_task_output"]["value"] == "bar"
+
+    def test_from_dict(self, finish_structure_run_event):
+        assert FinishStructureRunEvent.from_dict(finish_structure_run_event.to_dict()) == finish_structure_run_event

--- a/tests/unit/tasks/test_base_multi_text_input_task.py
+++ b/tests/unit/tasks/test_base_multi_text_input_task.py
@@ -1,7 +1,6 @@
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 from griptape.structures import Pipeline
 from griptape.artifacts import TextArtifact
-from griptape.rules import Ruleset, Rule
 from tests.mocks.mock_multi_text_input_task import MockMultiTextInputTask
 
 

--- a/tests/unit/tasks/test_image_query_task.py
+++ b/tests/unit/tasks/test_image_query_task.py
@@ -1,14 +1,24 @@
-from griptape.engines import ImageQueryEngine
+from unittest.mock import Mock
 
 import pytest
-from griptape.tasks import BaseTask, ImageQueryTask
-from griptape.artifacts import TextArtifact, ImageArtifact
+
+from griptape.artifacts import ImageArtifact, TextArtifact
+from griptape.artifacts.list_artifact import ListArtifact
+from griptape.engines import ImageQueryEngine
 from griptape.structures import Agent
+from griptape.tasks import BaseTask, ImageQueryTask
 from tests.mocks.mock_image_query_driver import MockImageQueryDriver
 from tests.mocks.mock_structure_config import MockStructureConfig
 
 
 class TestImageQueryTask:
+    @pytest.fixture
+    def image_query_engine(self) -> Mock:
+        mock = Mock()
+        mock.run.return_value = TextArtifact("image")
+
+        return mock
+
     @pytest.fixture
     def text_artifact(self):
         return TextArtifact(value="some text")
@@ -20,24 +30,34 @@ class TestImageQueryTask:
     def test_text_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         task = ImageQueryTask((text_artifact.value, [image_artifact, image_artifact]))
 
-        assert task.input[0].value == text_artifact.value
-        assert task.input[1] == [image_artifact, image_artifact]
+        assert task.input.value[0].value == text_artifact.value
+        assert task.input.value[1] == image_artifact
+        assert task.input.value[2] == image_artifact
 
     def test_artifact_inputs(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
         input_tuple = (text_artifact, [image_artifact, image_artifact])
         task = ImageQueryTask(input_tuple)
 
-        assert task.input == input_tuple
+        assert task.input.value[0] == text_artifact
+        assert task.input.value[1] == image_artifact
+        assert task.input.value[2] == image_artifact
 
     def test_callable_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
-        input_tuple = (text_artifact, [image_artifact, image_artifact])
+        input = [text_artifact, image_artifact, image_artifact]
 
-        def callable(task: BaseTask) -> tuple[TextArtifact, list[ImageArtifact]]:
-            return input_tuple
+        def callable(task: BaseTask) -> ListArtifact:
+            return ListArtifact(value=input)
 
         task = ImageQueryTask(callable)
 
-        assert task.input == input_tuple
+        assert task.input.value == input
+
+    def test_list_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
+        input = [text_artifact, image_artifact, image_artifact]
+
+        task = ImageQueryTask(ListArtifact(value=input))
+
+        assert task.input.value == input
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = ImageQueryTask((text_artifact, [image_artifact, image_artifact]))
@@ -49,5 +69,15 @@ class TestImageQueryTask:
     def test_missing_image_generation_engine(self, text_artifact, image_artifact):
         task = ImageQueryTask((text_artifact, [image_artifact, image_artifact]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Image Query Engine"):
             task.image_query_engine
+
+    def test_run(self, image_query_engine, text_artifact, image_artifact):
+        task = ImageQueryTask((text_artifact, [image_artifact, image_artifact]), image_query_engine=image_query_engine)
+        task.run()
+
+        assert task.output.value == "image"
+
+    def test_bad_run(self, image_query_engine, text_artifact, image_artifact):
+        with pytest.raises(ValueError, match="All inputs"):
+            ImageQueryTask(("foo", [image_artifact, text_artifact]), image_query_engine=image_query_engine).run()

--- a/tests/unit/tasks/test_inpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_inpainting_image_generation_task.py
@@ -1,5 +1,5 @@
+from griptape.artifacts.list_artifact import ListArtifact
 from griptape.engines import InpaintingImageGenerationEngine
-from typing import Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -23,17 +23,30 @@ class TestInpaintingImageGenerationTask:
         input_tuple = (text_artifact, image_artifact, image_artifact)
         task = InpaintingImageGenerationTask(input_tuple, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == list(input_tuple)
 
     def test_callable_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
-        input_tuple = (text_artifact, image_artifact, image_artifact)
+        input = [text_artifact, image_artifact, image_artifact]
 
-        def callable(task: BaseTask) -> tuple[TextArtifact, ImageArtifact, ImageArtifact]:
-            return input_tuple
+        def callable(task: BaseTask) -> ListArtifact:
+            return ListArtifact(value=list(input))
 
         task = InpaintingImageGenerationTask(callable, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == input
+
+    def test_list_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
+        input = [text_artifact, image_artifact]
+        task = InpaintingImageGenerationTask(ListArtifact(input), image_generation_engine=Mock())
+
+        assert task.input.value == input
+
+    def test_bad_input(self, image_artifact):
+        with pytest.raises(ValueError):
+            InpaintingImageGenerationTask(("foo", "bar", image_artifact)).run()  # pyright: ignore[reportArgumentType]
+
+        with pytest.raises(ValueError):
+            InpaintingImageGenerationTask(("foo", image_artifact, "baz")).run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = InpaintingImageGenerationTask((text_artifact, image_artifact, image_artifact))

--- a/tests/unit/tasks/test_outpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_outpainting_image_generation_task.py
@@ -1,5 +1,5 @@
+from griptape.artifacts.list_artifact import ListArtifact
 from griptape.engines import OutpaintingImageGenerationEngine
-from typing import Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -24,17 +24,30 @@ class TestOutpaintingImageGenerationTask:
         input_tuple = (text_artifact, image_artifact, image_artifact)
         task = OutpaintingImageGenerationTask(input_tuple, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == list(input_tuple)
 
     def test_callable_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
-        input_tuple = (text_artifact, image_artifact, image_artifact)
+        input = [text_artifact, image_artifact, image_artifact]
 
-        def callable(task: BaseTask) -> tuple[TextArtifact, ImageArtifact, ImageArtifact]:
-            return input_tuple
+        def callable(task: BaseTask) -> ListArtifact:
+            return ListArtifact(input)
 
         task = OutpaintingImageGenerationTask(callable, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == input
+
+    def test_list_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
+        input = [text_artifact, image_artifact]
+        task = OutpaintingImageGenerationTask(ListArtifact(input), image_generation_engine=Mock())
+
+        assert task.input.value == input
+
+    def test_bad_input(self, image_artifact):
+        with pytest.raises(ValueError):
+            OutpaintingImageGenerationTask(("foo", "bar", image_artifact)).run()  # pyright: ignore[reportArgumentType]
+
+        with pytest.raises(ValueError):
+            OutpaintingImageGenerationTask(("foo", image_artifact, "baz")).run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = OutpaintingImageGenerationTask((text_artifact, image_artifact, image_artifact))

--- a/tests/unit/tasks/test_variation_image_generation_task.py
+++ b/tests/unit/tasks/test_variation_image_generation_task.py
@@ -1,6 +1,6 @@
+from griptape.artifacts.list_artifact import ListArtifact
 from tests.mocks.mock_image_generation_driver import MockImageGenerationDriver
 from tests.mocks.mock_structure_config import MockStructureConfig
-from typing import Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -23,17 +23,27 @@ class TestVariationImageGenerationTask:
         input_tuple = (text_artifact, image_artifact)
         task = VariationImageGenerationTask(input_tuple, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == list(input_tuple)
 
     def test_callable_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
-        input_tuple = (text_artifact, image_artifact)
+        input = [text_artifact, image_artifact]
 
-        def callable(task: BaseTask) -> tuple[TextArtifact, ImageArtifact]:
-            return input_tuple
+        def callable(task: BaseTask) -> ListArtifact:
+            return ListArtifact(input)
 
         task = VariationImageGenerationTask(callable, image_generation_engine=Mock())
 
-        assert task.input == input_tuple
+        assert task.input.value == input
+
+    def test_list_input(self, text_artifact: TextArtifact, image_artifact: ImageArtifact):
+        input = [text_artifact, image_artifact]
+        task = VariationImageGenerationTask(ListArtifact(input), image_generation_engine=Mock())
+
+        assert task.input.value == input
+
+    def test_bad_input(self, image_artifact):
+        with pytest.raises(ValueError):
+            VariationImageGenerationTask(("foo", "bar")).run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = VariationImageGenerationTask((text_artifact, image_artifact))


### PR DESCRIPTION
Several Tasks have non-`BaseArtifact` `input` fields. For instance, `ImageQueryTask.input` has a type of:

```
tuple[TextArtifact, list[ImageArtifact]]
```

The complexity of this type makes it very difficult to serialize the inputs of these Tasks in downstream abstractions like Events. Additionally, it make the Task API inconsistent across Task types.

This PR changes the input type to `ListArtifact`, making it consistent with other Task types. Note that the `setter` for the field is mostly unchanged, only the `getter` has changed.