### PR TITLE
Update `GriptapeCloudKnowledgeBaseClient` description fetching

### DIFF
--- a/griptape/tools/griptape_cloud_knowledge_base_client/tool.py
+++ b/griptape/tools/griptape_cloud_knowledge_base_client/tool.py
@@ -48,10 +48,14 @@ class GriptapeCloudKnowledgeBaseClient(BaseGriptapeCloudClient):
         else:
             url = urljoin(self.base_url.strip("/"), f"/api/knowledge-bases/{self.knowledge_base_id}/")
 
-            response = get(url, headers=self.headers).json()
-            if "description" in response:
-                return response["description"]
+            response = get(url, headers=self.headers)
+            response_body = response.json()
+            if response.status_code == 200:
+                if "description" in response_body:
+                    return response_body["description"]
+                else:
+                    raise ValueError(
+                        f"No description found for Knowledge Base {self.knowledge_base_id}. Please set a description, or manually set the `GriptapeCloudKnowledgeBaseClient.description` attribute."
+                    )
             else:
-                raise ValueError(
-                    f"No description found for Knowledge Base {self.knowledge_base_id}. Please set a description, or manually set the `GriptapeCloudKnowledgeBaseClient.description` attribute."
-                )
+                raise ValueError(f"Error accessing Knowledge Base {self.knowledge_base_id}.")

--- a/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
+++ b/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
@@ -1,6 +1,9 @@
 import pytest
 from requests import exceptions
 from griptape.artifacts import TextArtifact, ErrorArtifact
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
 class TestGriptapeCloudKnowledgeBaseClient:
@@ -28,6 +31,7 @@ class TestGriptapeCloudKnowledgeBaseClient:
 
         mock_response = mocker.Mock()
         mock_response.json.return_value = {}
+        mock_response.status_code = 200
         mocker.patch("requests.get", return_value=mock_response)
 
         return GriptapeCloudKnowledgeBaseClient(
@@ -74,13 +78,9 @@ class TestGriptapeCloudKnowledgeBaseClient:
         assert client._get_knowledge_base_description() == "foo bar"
 
     def test_get_knowledge_base_description_error(self, client_no_description):
-        with pytest.raises(ValueError) as e:
+        exception_match_text = f"No description found for Knowledge Base {client_no_description.knowledge_base_id}. Please set a description, or manually set the `GriptapeCloudKnowledgeBaseClient.description` attribute."
+        with pytest.raises(ValueError, match=exception_match_text) as e:
             client_no_description._get_knowledge_base_description()
-
-            assert (
-                str(e)
-                == f"No description found for Knowledge Base {client_no_description.knowledge_base_id}. Please set a description, or manually set the `GriptapeCloudKnowledgeBaseClient.description` attribute."
-            )
 
     def test_get_knowledge_base_kb_error(self, client_kb_not_found):
         with pytest.raises(ValueError) as e:

--- a/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
+++ b/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
@@ -8,10 +8,12 @@ class TestGriptapeCloudKnowledgeBaseClient:
         from griptape.tools import GriptapeCloudKnowledgeBaseClient
 
         mock_response = mocker.Mock()
+        mock_response.status_code = 201
         mock_response.text.return_value = "foo bar"
         mocker.patch("requests.post", return_value=mock_response)
 
         mock_response = mocker.Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"description": "fizz buzz"}
         mocker.patch("requests.get", return_value=mock_response)
 

--- a/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
+++ b/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
@@ -53,8 +53,7 @@ class TestGriptapeCloudKnowledgeBaseClient:
         from griptape.tools import GriptapeCloudKnowledgeBaseClient
 
         mock_response = mocker.Mock()
-        mock_response.status_code = 201
-        mock_response.text.return_value = "foo bar"
+        mock_response.status_code = 500
         mocker.patch("requests.post", return_value=mock_response, side_effect=exceptions.RequestException("error"))
 
         return GriptapeCloudKnowledgeBaseClient(
@@ -80,7 +79,6 @@ class TestGriptapeCloudKnowledgeBaseClient:
             client_no_description._get_knowledge_base_description()
 
     def test_get_knowledge_base_kb_error(self, client_kb_not_found):
-        with pytest.raises(ValueError) as e:
+        exception_match_text = f"Error accessing Knowledge Base {client_kb_not_found.knowledge_base_id}."
+        with pytest.raises(ValueError, match=exception_match_text) as e:
             client_kb_not_found._get_knowledge_base_description()
-
-            assert str(e) == f"Error accessing Knowledge Base {client_kb_not_found.knowledge_base_id}."

--- a/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
+++ b/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
@@ -1,9 +1,6 @@
 import pytest
 from requests import exceptions
 from griptape.artifacts import TextArtifact, ErrorArtifact
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 
 class TestGriptapeCloudKnowledgeBaseClient:

--- a/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
+++ b/tests/unit/tools/test_griptape_cloud_knowledge_base_client.py
@@ -31,6 +31,19 @@ class TestGriptapeCloudKnowledgeBaseClient:
             base_url="https://api.griptape.ai", api_key="foo bar", knowledge_base_id="1"
         )
 
+    @pytest.fixture
+    def client_kb_error(self, mocker):
+        from griptape.tools import GriptapeCloudKnowledgeBaseClient
+
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {}
+        mock_response.status_code = 404
+        mocker.patch("requests.get", return_value=mock_response)
+
+        return GriptapeCloudKnowledgeBaseClient(
+            base_url="https://api.griptape.ai", api_key="foo bar", knowledge_base_id="1"
+        )
+
     def test_query(self, client):
         assert isinstance(client.query({"values": {"query": "foo bar"}}), TextArtifact)
 
@@ -48,3 +61,9 @@ class TestGriptapeCloudKnowledgeBaseClient:
                 str(e)
                 == f"No description found for Knowledge Base {client_no_description.knowledge_base_id}. Please set a description, or manually set the `GriptapeCloudKnowledgeBaseClient.description` attribute."
             )
+
+    def test_get_knowledge_base_kb_error(self, client_kb_error):
+        with pytest.raises(ValueError) as e:
+            client_kb_error._get_knowledge_base_description()
+
+            assert str(e) == f"Error accessing Knowledge Base {client_kb_error.knowledge_base_id}."


### PR DESCRIPTION
- returns an error if the knowledge base cannot be fetched.