### PR TITLE
Set allowlist in certain file manager examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ agent = Agent(
     tools=[
         WebScraper(off_prompt=True),
         TaskMemoryClient(off_prompt=True),
-        FileManager()
+        FileManager(allowlist=["save_memory_artifacts_to_disk"]),
     ]
 )
 agent.run("https://griptape.ai", "griptape.txt")

--- a/docs/griptape-framework/index.md
+++ b/docs/griptape-framework/index.md
@@ -151,7 +151,7 @@ pipeline.add_tasks(
     ToolkitTask(
         "{{ args[0] }}",
         # Add tools for web scraping, and file management
-        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True), TaskMemoryClient(off_prompt=False)]
+        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True, allowlist=["save_memory_artifacts_to_disk"]), TaskMemoryClient(off_prompt=False)]
     ),
     # Augment `input` from the previous task.
     PromptTask(

--- a/docs/griptape-framework/structures/task-memory.md
+++ b/docs/griptape-framework/structures/task-memory.md
@@ -237,7 +237,7 @@ agent = Agent(
     tools=[
         WebScraper(off_prompt=True),
         TaskMemoryClient(off_prompt=True, allowlist=["query"]),
-        FileManager(off_prompt=True), # FileManager returns an InfoArtifact which will not be stored in Task Memory regardless of the off_prompt setting
+        FileManager(off_prompt=True, allowlist=["save_memory_artifacts_to_disk"]), # FileManager returns an InfoArtifact which will not be stored in Task Memory regardless of the off_prompt setting
     ],
 )
 

--- a/docs/griptape-framework/structures/tasks.md
+++ b/docs/griptape-framework/structures/tasks.md
@@ -103,7 +103,7 @@ agent = Agent()
 agent.add_task(
     ToolkitTask(
         "Load https://www.griptape.ai, summarize it, and store it in a file called griptape.txt", 
-        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True), TaskMemoryClient(off_prompt=True)]
+        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True), TaskMemoryClient(off_prompt=True, allowlist=["save_memory_artifacts_to_disk"])]
     ),
 )
 

--- a/docs/griptape-framework/tools/index.md
+++ b/docs/griptape-framework/tools/index.md
@@ -18,7 +18,7 @@ pipeline = Pipeline()
 pipeline.add_tasks(
     ToolkitTask(
         "Load https://www.griptape.ai, summarize it, and store it in a file called griptape.txt", 
-        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True), TaskMemoryClient(off_prompt=False)]
+        tools=[WebScraper(off_prompt=True), FileManager(off_prompt=True, allowlist=["save_memory_artifacts_to_disk"]), TaskMemoryClient(off_prompt=False)]
     ),
 )
 


### PR DESCRIPTION
`gpt-4o` appears to get confused when using the `FileManager`, and is occasionally hallucinating invalid json. Until native function calling is ready, we're updating the examples to remove all non-relevant Activities from `FileManager`

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--864.org.readthedocs.build//864/

<!-- readthedocs-preview griptape end -->