### PR TITLE
Bug Fix: Cohere prompts with no history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Replaced `query_engine` with `vector_store_driver` in `VectorStoreClient`.
 - **BREAKING**: removed parameters `google_api_lang`, `google_api_key`, `google_api_search_id`, `google_api_country` on `WebSearch` in favor of `web_search_driver`.
 - `GriptapeCloudKnowledgeBaseClient` migrated to `/search` api.
+- Fixed bug in `CoherePromptDriver` to properly handle empty history
 
 ## [0.27.1] - 2024-06-20
 

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -141,7 +141,7 @@ from griptape.config import StructureConfig
 agent = Agent(
     config=StructureConfig(
         prompt_driver=CoherePromptDriver(
-            model="command",
+            model="command-r",
             api_key=os.environ['COHERE_API_KEY'],
         )
     )

--- a/docs/griptape-framework/structures/config.md
+++ b/docs/griptape-framework/structures/config.md
@@ -95,6 +95,21 @@ agent = Agent(
 )
 ```
 
+#### Cohere
+
+The [Cohere Structure Config](../../reference/griptape/config/cohere_structure_config.md) provides default Drivers for Cohere's APIs.
+
+
+```python
+import os
+from griptape.config import CohereStructureConfig
+from griptape.structures import Agent
+
+load_dotenv()
+
+agent = Agent(config=CohereStructureConfig(api_key=os.environ["COHERE_API_KEY"]))
+```
+
 ### Custom Configs
 
 You can create your own [StructureConfig](../../reference/griptape/config/structure_config.md) by overriding relevant Drivers.

--- a/docs/griptape-framework/structures/config.md
+++ b/docs/griptape-framework/structures/config.md
@@ -105,8 +105,6 @@ import os
 from griptape.config import CohereStructureConfig
 from griptape.structures import Agent
 
-load_dotenv()
-
 agent = Agent(config=CohereStructureConfig(api_key=os.environ["COHERE_API_KEY"]))
 ```
 

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -52,12 +52,18 @@ class CoherePromptDriver(BasePromptDriver):
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         user_message = prompt_stack.inputs[-1].content
 
-        history_messages = [self._prompt_stack_input_to_message(input) for input in prompt_stack.inputs[:-1]]
+        history_messages = [
+            self._prompt_stack_input_to_message(input) for input in prompt_stack.inputs[:-1] if input.content
+        ]
 
-        return {
+        params = {
             "message": user_message,
-            "chat_history": history_messages,
             "temperature": self.temperature,
             "stop_sequences": self.tokenizer.stop_sequences,
             "max_tokens": self.max_tokens,
         }
+
+        if history_messages:
+            params["chat_history"] = history_messages
+
+        return params

--- a/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
@@ -7,16 +7,16 @@ import pytest
 class TestCoherePromptDriver:
     @pytest.fixture
     def mock_client(self, mocker):
-        mock_client = mocker.patch("cohere.Client").return_value
-        mock_client.chat.return_value = Mock(text="model-output")
+        mock_client = mocker.patch("cohere.Client")
+        mock_client.return_value.chat.return_value = Mock(text="model-output")
 
         return mock_client
 
     @pytest.fixture
     def mock_stream_client(self, mocker):
-        mock_client = mocker.patch("cohere.Client").return_value
+        mock_client = mocker.patch("cohere.Client")
         mock_chunk = Mock(text="model-output", event_type="text-generation")
-        mock_client.chat_stream.return_value = iter([mock_chunk])
+        mock_client.return_value.chat_stream.return_value = iter([mock_chunk])
 
         return mock_client
 
@@ -42,8 +42,41 @@ class TestCoherePromptDriver:
 
         # When
         text_artifact = driver.try_run(prompt_stack)
+        print(f"Called methods: {mock_client}")
 
         # Then
+        expected_message = "assistant-input"
+        expected_history = [
+            {"role": "ASSISTANT", "text": "generic-input"},
+            {"role": "SYSTEM", "text": "system-input"},
+            {"role": "USER", "text": "user-input"},
+        ]
+        mock_client.return_value.chat.assert_called_once_with(
+            message=expected_message,
+            temperature=driver.temperature,
+            stop_sequences=driver.tokenizer.stop_sequences,
+            max_tokens=driver.max_tokens,
+            chat_history=expected_history,
+        )
+        assert text_artifact.value == "model-output"
+
+    def test_try_run_no_history(self, mock_client, prompt_stack):
+        # Given
+        prompt_stack_no_history = PromptStack()
+        prompt_stack_no_history.add_user_input("user-input")
+        driver = CoherePromptDriver(model="command", api_key="api-key")
+
+        # When
+        text_artifact = driver.try_run(prompt_stack_no_history)
+
+        # Then
+        expected_message = "user-input"
+        mock_client.return_value.chat.assert_called_once_with(
+            message=expected_message,
+            temperature=driver.temperature,
+            stop_sequences=driver.tokenizer.stop_sequences,
+            max_tokens=driver.max_tokens,
+        )
         assert text_artifact.value == "model-output"
 
     def test_try_stream_run(self, mock_stream_client, prompt_stack):  # pyright: ignore


### PR DESCRIPTION
- Updating the CoherePromptDriver to properly account for empty history
- Updating the docs to `command-r` model, which is recommended for Cohere

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--900.org.readthedocs.build//900/

<!-- readthedocs-preview griptape end -->