### PR TITLE
[hotfix] Don't add ToolkitTask stop sequence if already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.2] - 2024-06-27
+
+### Fixed
+- Avoid adding duplicate Tokenizer stop sequences in a ToolkitTask
+
 ## [0.27.1] - 2024-06-20
 
 ### Added

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -130,7 +130,9 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
 
         self.subtasks.clear()
 
-        self.prompt_driver.tokenizer.stop_sequences.extend([self.response_stop_sequence])
+        if self.response_stop_sequence not in self.prompt_driver.tokenizer.stop_sequences:
+            self.prompt_driver.tokenizer.stop_sequences.extend([self.response_stop_sequence])
+
         subtask = self.add_subtask(ActionsSubtask(self.prompt_driver.run(prompt_stack=self.prompt_stack).to_text()))
 
         while True:


### PR DESCRIPTION
This fix updates the ToolkitTask to avoid adding a stop sequence to a Tokenizer if the it's already present in the Tokenizer's list of stop sequences.

### Why?

In long-running workflows, one Prompt Driver (and its Tokenizer) may be used across many ToolkitTasks. Each time a ToolkitTask is run, we add its stop sequence to the list maintained by the Tokenizer whether or not it is already present.

The Tokenizer's stop sequences are then provided by the Prompt Driver to the model. For example, the OpenAI Chat Prompt Driver's `_build_params()` method:

```python
params = {
  "model": self.model,
  "temperature": self.temperature,
  "stop": self.tokenizer.stop_sequences,
  "user": self.user,
  "seed": self.seed,
}
```

OpenAI accepts a maximum of four stop sequences. As a Prompt Driver is used by several ToolkitTasks, its Tokenizer's stop sequence list grows until it exceeds this maximum value and OpenAI's API responds with an `HTTP 400`:

> "Invalid 'stop': array too long. Expected an array with maximum length 4, but got an array with length 13 instead."

Here, we avoid adding the ToolkitTask stop sequence if it's already present. This prevents exceeding the model's maximum number of supported stop sequences in normal usage.

#### Why not use a `set`?

A `set` is a native way to enforce uniqueness among elements, but they are not natively JSON-serializable. Addressing the offending logic in ToolkitTask is more direct than updating every consumer of this set (i.e. every Prompt Driver) to convert the `set` to a `list` before serialization.

Closes #895 