### PR TITLE
fixing bug for upserting csv artifacts

### DIFF
--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -54,7 +54,11 @@ class BaseVectorStoreDriver(SerializableMixin, ABC):
         **kwargs,
     ) -> str:
         meta = {} if meta is None else meta
-        vector_id = utils.str_to_hash(artifact.value) if vector_id is None else vector_id
+
+        # Properly handle CSVs
+        artifact_value_string = artifact.value if isinstance(artifact.value, str) else str(artifact.value)
+
+        vector_id = utils.str_to_hash(artifact_value_string) if vector_id is None else vector_id
 
         if self.does_entry_exist(vector_id, namespace):
             return vector_id

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -54,11 +54,7 @@ class BaseVectorStoreDriver(SerializableMixin, ABC):
         **kwargs,
     ) -> str:
         meta = {} if meta is None else meta
-
-        # Properly handle CSVs
-        artifact_value_string = artifact.value if isinstance(artifact.value, str) else str(artifact.value)
-
-        vector_id = utils.str_to_hash(artifact_value_string) if vector_id is None else vector_id
+        vector_id = utils.str_to_hash(artifact.to_text()) if vector_id is None else vector_id
 
         if self.does_entry_exist(vector_id, namespace):
             return vector_id

--- a/tests/unit/drivers/vector/test_base_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_base_local_vector_store_driver.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import pytest
 from unittest.mock import patch
 from griptape.artifacts import TextArtifact
+from griptape.artifacts.csv_row_artifact import CsvRowArtifact
 
 
 class BaseLocalVectorStoreDriver(ABC):
@@ -20,6 +21,20 @@ class BaseLocalVectorStoreDriver(ABC):
         assert len(driver.entries) == 1
 
         driver.upsert_text_artifact(TextArtifact(id="foo2", value="foobar2"))
+
+        assert len(driver.entries) == 2
+
+    def test_upsert_csv_row(self, driver):
+        namespace = driver.upsert_text_artifact(CsvRowArtifact(id="foo1", value={"col": "value"}))
+
+        assert len(driver.entries) == 1
+        assert list(driver.entries.keys())[0] == namespace
+
+        driver.upsert_text_artifact(CsvRowArtifact(id="foo1", value={"col": "value"}))
+
+        assert len(driver.entries) == 1
+
+        driver.upsert_text_artifact(CsvRowArtifact(id="foo2", value={"col": "value2"}))
 
         assert len(driver.entries) == 2
 


### PR DESCRIPTION
- `CSVRowArtifact` inherits from `TextArtifact` and therefore needs to be supported in `upsert_text_artifact`
- This converts the value to a string if it's not a string before hashing