### PR TITLE
[hotfix] Fix token calculation in VectorQueryEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.27.2] - 2024-06-27
+- Fixed token count calculation in `VectorQueryEngine`.
+
 ## [0.27.1] - 2024-06-20
 
 ### Added

--- a/griptape/engines/query/vector_query_engine.py
+++ b/griptape/engines/query/vector_query_engine.py
@@ -49,7 +49,7 @@ class VectorQueryEngine(BaseQueryEngine):
             )
             user_message = self.user_template_generator.render(query=query)
 
-            message_token_count = self.prompt_driver.tokenizer.count_input_tokens_left(
+            message_token_count = self.prompt_driver.tokenizer.count_tokens(
                 self.prompt_driver.prompt_stack_to_string(
                     PromptStack(
                         inputs=[


### PR DESCRIPTION
This PR updates the Vector Query Engine to use the correct token calculation method when determining the number of tokens used to represent a message. We erroneously use the `count_input_tokens_left()` method, which, in most cases, returns an artificially large number (the difference between the model's maximum input tokens and message token count). 

When this happens, the Vector Query Engine tries to reduce the token count of the message by dropping query result texts. If the query has returned just a few responses, the query response will be low quality as important information may have been dropped. If the query has returned just a single response, the single response is dropped and the model is left to make an inference based on the query and its training data rather than any data returned by the vector store.

The revision uses the `count_tokens()` method to return the number of tokens used to represent the message. An accurate token count means we drop query result texts less frequently and return higher-quality answers.