### PR TITLE
Ensure Executor.shutdown() called after task submission in BaseEventListenerDriver.publish_event()

### DIFF
--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -24,7 +24,8 @@ class BaseEventListenerDriver(ABC):
         return self._batch
 
     def publish_event(self, event: BaseEvent | dict, flush: bool = False) -> None:
-        self.futures_executor_fn().submit(self._safe_try_publish_event, event, flush)
+        with self.futures_executor_fn() as executor:
+            executor.submit(self._safe_try_publish_event, event, flush)
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -1,8 +1,20 @@
+from unittest.mock import MagicMock
 from tests.mocks.mock_event import MockEvent
 from tests.mocks.mock_event_listener_driver import MockEventListenerDriver
 
 
 class TestBaseEventListenerDriver:
+    def test_publish_event(self):
+        executor = MagicMock()
+        executor.__enter__.return_value = executor
+        driver = MockEventListenerDriver(futures_executor_fn=lambda: executor)
+
+        driver.publish_event(MockEvent().to_dict())
+
+        executor.__enter__.assert_called_once()
+        executor.submit.assert_called_once()
+        executor.__exit__.assert_called_once()
+
     def test__safe_try_publish_event(self):
         driver = MockEventListenerDriver(batched=False)
 


### PR DESCRIPTION
Problem: Missed one instance of context manager use for executors in `BaseEventListenerDriver.publish_event()` related to the existing changelog note:

> All `futures_executor` fields renamed to `futures_executor_fn` and now accept callables instead of futures; wrapped all future `submit` calls with the `with` block to address future executor shutdown issues.

This particular instance was causing some intermittent unit tests failures in a feature I'm working on.

Changes:
- Use the `Executor` context manager when submitting tasks in `BaseEventListenerDriver.publish_event()`.