### PR TITLE
Add span_id to framework events and add GriptapeCloudObservabilityDriver.SpanExporter

### DIFF
--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -24,7 +24,8 @@ class BaseEventListenerDriver(ABC):
         return self._batch
 
     def publish_event(self, event: BaseEvent | dict, flush: bool = False) -> None:
-        self.futures_executor_fn().submit(self._safe_try_publish_event, event, flush)
+        with self.futures_executor_fn() as executor:
+            executor.submit(self._safe_try_publish_event, event, flush)
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...

--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 from attrs import define, field, Factory
 
 from griptape.drivers.event_listener.base_event_listener_driver import BaseEventListenerDriver
+from griptape.events.base_event import BaseEvent
 
 
 @define
@@ -35,6 +36,17 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
             raise ValueError(
                 "structure_run_id must be set either in the constructor or as an environment variable (GT_CLOUD_STRUCTURE_RUN_ID)."
             )
+
+    def publish_event(self, event: BaseEvent | dict, flush: bool = False) -> None:
+        from griptape.observability.observability import Observability
+
+        event_payload = event.to_dict() if isinstance(event, BaseEvent) else event
+
+        span_id = Observability.get_span_id()
+        if span_id is not None:
+            event_payload["span_id"] = span_id
+
+        super().publish_event(event_payload, flush)
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
         url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{self.structure_run_id}/events")

--- a/griptape/drivers/observability/base_observability_driver.py
+++ b/griptape/drivers/observability/base_observability_driver.py
@@ -20,3 +20,6 @@ class BaseObservabilityDriver(ABC):
 
     @abstractmethod
     def observe(self, call: Observable.Call) -> Any: ...
+
+    @abstractmethod
+    def get_span_id(self) -> Optional[str]: ...

--- a/griptape/drivers/observability/griptape_cloud_observability_driver.py
+++ b/griptape/drivers/observability/griptape_cloud_observability_driver.py
@@ -1,10 +1,14 @@
 import os
+import requests
+
+from collections.abc import Sequence
 
 from attrs import define, Factory, field
 from griptape.drivers.observability.open_telemetry_observability_driver import OpenTelemetryObservabilityDriver
-from opentelemetry.sdk.trace import SpanProcessor
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.trace import format_trace_id, format_span_id
+from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.sdk.util import ns_to_iso_str
 from urllib.parse import urljoin
 
 
@@ -21,15 +25,50 @@ class GriptapeCloudObservabilityDriver(OpenTelemetryObservabilityDriver):
     span_processor: SpanProcessor = field(
         default=Factory(
             lambda self: BatchSpanProcessor(
-                OTLPSpanExporter(
-                    endpoint=urljoin(self.base_url.strip("/"), f"/api/structure-runs/{self.structure_run_id}/traces"),
+                GriptapeCloudObservabilityDriver.SpanExporter(
+                    base_url=self.base_url,
+                    api_key=self.api_key,
                     headers=self.headers,
+                    structure_run_id=self.structure_run_id,
                 )
             ),
             takes_self=True,
         ),
         kw_only=True,
     )
+
+    @define
+    class SpanExporter(SpanExporter):
+        base_url: str = field(kw_only=True)
+        api_key: str = field(kw_only=True)
+        headers: dict = field(kw_only=True)
+        structure_run_id: str = field(kw_only=True)
+
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{self.structure_run_id}/spans")
+            payload = [
+                {
+                    "trace_id": format_trace_id(span.context.trace_id),
+                    "span_id": format_span_id(span.context.span_id),
+                    "parent_id": format_span_id(span.parent.span_id) if span.parent else None,
+                    "name": span.name,
+                    "start_time": ns_to_iso_str(span.start_time) if span.start_time else None,
+                    "end_time": ns_to_iso_str(span.end_time) if span.end_time else None,
+                    "status": span.status.status_code.name,
+                    "attributes": {**span.attributes} if span.attributes else {},
+                    "events": [
+                        {
+                            "name": event.name,
+                            "timestamp": ns_to_iso_str(event.timestamp) if event.timestamp else None,
+                            "attributes": {**event.attributes} if event.attributes else {},
+                        }
+                        for event in span.events
+                    ],
+                }
+                for span in spans
+            ]
+            response = requests.post(url=url, json=payload, headers=self.headers)
+            return SpanExportResult.SUCCESS if response.status_code == 200 else SpanExportResult.FAILURE
 
     @structure_run_id.validator  # pyright: ignore
     def validate_run_id(self, _, structure_run_id: str):

--- a/griptape/drivers/observability/no_op_observability_driver.py
+++ b/griptape/drivers/observability/no_op_observability_driver.py
@@ -1,10 +1,13 @@
 from attrs import define
 from griptape.common import Observable
 from griptape.drivers import BaseObservabilityDriver
-from typing import Any
+from typing import Any, Optional
 
 
 @define
 class NoOpObservabilityDriver(BaseObservabilityDriver):
     def observe(self, call: Observable.Call) -> Any:
         return call()
+
+    def get_span_id(self) -> Optional[str]:
+        return None

--- a/griptape/drivers/observability/open_telemetry_observability_driver.py
+++ b/griptape/drivers/observability/open_telemetry_observability_driver.py
@@ -2,6 +2,7 @@ from attrs import define, Factory, field
 from griptape.common import Observable
 from griptape.drivers import BaseObservabilityDriver
 from opentelemetry import trace
+from opentelemetry.trace import format_span_id
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
@@ -68,3 +69,6 @@ class OpenTelemetryObservabilityDriver(BaseObservabilityDriver):
                 span.set_status(Status(StatusCode.ERROR))
                 span.record_exception(e)
                 raise e
+
+    def get_span_id(self) -> Optional[str]:
+        return format_span_id(trace.get_current_span().get_span_context().span_id)

--- a/griptape/observability/observability.py
+++ b/griptape/observability/observability.py
@@ -27,6 +27,11 @@ class Observability:
         driver = Observability.get_global_driver() or _no_op_observability_driver
         return driver.observe(call)
 
+    @staticmethod
+    def get_span_id() -> Optional[str]:
+        driver = Observability.get_global_driver() or _no_op_observability_driver
+        return driver.get_span_id()
+
     def __enter__(self):
         if Observability.get_global_driver() is not None:
             raise ValueError("Observability driver already set.")

--- a/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
@@ -1,10 +1,11 @@
 import os
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from pytest import fixture
 
 from griptape.drivers.event_listener.griptape_cloud_event_listener_driver import GriptapeCloudEventListenerDriver
+from griptape.observability.observability import Observability
 from tests.mocks.mock_event import MockEvent
 
 
@@ -28,6 +29,30 @@ class TestGriptapeCloudEventListenerDriver:
         assert driver
         assert driver.api_key == "foo bar"
         assert driver.structure_run_id == "bar baz"
+
+    def test_publish_event_without_span_id(self, mock_post, driver):
+        event = MockEvent()
+        driver.publish_event(event, flush=True)
+
+        mock_post.assert_called_with(
+            url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
+            json=[event.to_dict()],
+            headers={"Authorization": "Bearer foo bar"},
+        )
+
+    def test_publish_event_with_span_id(self, mock_post, driver):
+        event = MockEvent()
+        observability_driver = MagicMock()
+        observability_driver.get_span_id.return_value = "test"
+
+        with Observability(observability_driver=observability_driver):
+            driver.publish_event(event, flush=True)
+
+        mock_post.assert_called_with(
+            url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
+            json=[{**event.to_dict(), "span_id": "test"}],
+            headers={"Authorization": "Bearer foo bar"},
+        )
 
     def test_try_publish_event_payload(self, mock_post, driver):
         event = MockEvent()


### PR DESCRIPTION
Changes:
- Add `span_id` to framework events when publishing events with `GriptapeCloudEventListenerDriver`.
- Add GriptapeCloudObservabilityDriver.SpanExporter for Griptape Cloud specific span API model. (Previously was relying on the protobuf schemas provided by open telemetry, but I'd rather not introduce that into the service at this point in time)
-  Use the executor context manager in BaseEventListenerDriver (also published in a separate PR against dev [here](https://github.com/griptape-ai/griptape/pull/919))

### **Note: This is merging into `release/cloud-unreleased` and not `dev`.