### PR TITLE
Format span and trace id as UUIDs in Griptape Cloud

### DIFF
--- a/griptape/drivers/observability/griptape_cloud_observability_driver.py
+++ b/griptape/drivers/observability/griptape_cloud_observability_driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import Optional
 import requests
 
 from uuid import UUID
@@ -80,7 +81,7 @@ class GriptapeCloudObservabilityDriver(OpenTelemetryObservabilityDriver):
                 "structure_run_id must be set either in the constructor or as an environment variable (GT_CLOUD_STRUCTURE_RUN_ID)."
             )
 
-    def get_span_id(self) -> str | None:
+    def get_span_id(self) -> Optional[str]:
         span = get_current_span()
         if span is INVALID_SPAN:
             return None

--- a/tests/unit/drivers/observability/test_griptape_cloud_observability_driver.py
+++ b/tests/unit/drivers/observability/test_griptape_cloud_observability_driver.py
@@ -205,8 +205,8 @@ class TestGriptapeCloudObservabilityDriverSpanExporter:
             url="http://base-url:1234/api/structure-runs/structure-run-id/spans",
             json=[
                 {
-                    "trace_id": "00000000000000000000000000000001",
-                    "span_id": "0000000000000002",
+                    "trace_id": "00000000-0000-0000-0000-000000000001",
+                    "span_id": "00000000-0000-0000-0000-000000000002",
                     "parent_id": None,
                     "name": "main",
                     "start_time": "1970-01-01T00:00:00.000003Z",
@@ -216,9 +216,9 @@ class TestGriptapeCloudObservabilityDriverSpanExporter:
                     "events": [],
                 },
                 {
-                    "trace_id": "00000000000000000000000000000001",
-                    "span_id": "0000000000000003",
-                    "parent_id": "0000000000000002",
+                    "trace_id": "00000000-0000-0000-0000-000000000001",
+                    "span_id": "00000000-0000-0000-0000-000000000003",
+                    "parent_id": "00000000-0000-0000-0000-000000000002",
                     "name": "thing-1",
                     "start_time": "1970-01-01T00:00:00.000008Z",
                     "end_time": "1970-01-01T00:00:00.000009Z",
@@ -227,9 +227,9 @@ class TestGriptapeCloudObservabilityDriverSpanExporter:
                     "events": [],
                 },
                 {
-                    "trace_id": "00000000000000000000000000000001",
-                    "span_id": "0000000000000003",
-                    "parent_id": "0000000000000002",
+                    "trace_id": "00000000-0000-0000-0000-000000000001",
+                    "span_id": "00000000-0000-0000-0000-000000000003",
+                    "parent_id": "00000000-0000-0000-0000-000000000002",
                     "name": "thing-2",
                     "start_time": "1970-01-01T00:00:00.000008Z",
                     "end_time": "1970-01-01T00:00:00.000009Z",


### PR DESCRIPTION
Changes:
- Format span and trace id as UUIDs in Griptape Cloud

## NOTE: Merging into `release/cloud-unreleased` rather than dev!