### PR TITLE
Update Structure task syntax

### DIFF
--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 from attrs import Attribute, define, field
 
 from griptape.artifacts.text_artifact import TextArtifact
-from griptape.common import observable
-from griptape.memory.structure import Run
 from griptape.structures import Structure
 from griptape.tasks import PromptTask, ToolkitTask
 
@@ -24,6 +22,9 @@ class Agent(Structure):
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
     fail_fast: bool = field(default=False, kw_only=True)
+    task: Optional[BaseTask] = field(default=None, kw_only=True)
+
+    _has_default_task: bool = field(default=False, init=False, kw_only=True)
 
     @fail_fast.validator  # pyright: ignore[reportAttributeAccessIssue]
     def validate_fail_fast(self, _: Attribute, fail_fast: bool) -> None:  # noqa: FBT001
@@ -32,39 +33,31 @@ class Agent(Structure):
 
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
-        if len(self.tasks) == 0:
-            if self.tools:
-                task = ToolkitTask(self.input, tools=self.tools, max_meta_memory_entries=self.max_meta_memory_entries)
-            else:
-                task = PromptTask(self.input, max_meta_memory_entries=self.max_meta_memory_entries)
 
-            self.add_task(task)
+        if self.task is None:
+            if self.tools:
+                self.task = ToolkitTask(
+                    self.input, tools=self.tools, max_meta_memory_entries=self.max_meta_memory_entries
+                )
+            else:
+                self.task = PromptTask(self.input, max_meta_memory_entries=self.max_meta_memory_entries)
+            self._has_default_task = True
 
     @property
-    def task(self) -> BaseTask:
-        return self.tasks[0]
+    def task_graph(self) -> dict[BaseTask, set[BaseTask]]:
+        return {self.task: set()} if self.task else {}
 
-    def add_task(self, task: BaseTask) -> BaseTask:
-        self.tasks.clear()
+    @property
+    def tasks(self) -> list[BaseTask]:
+        return [self.task] if self.task else []
 
-        task.preprocess(self)
-
-        self.tasks.append(task)
-
-        return task
-
-    def add_tasks(self, *tasks: BaseTask) -> list[BaseTask]:
-        if len(tasks) > 1:
-            raise ValueError("Agents can only have one task.")
-        return super().add_tasks(*tasks)
-
-    @observable
-    def try_run(self, *args) -> Agent:
-        self.task.execute()
-
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
-
-            self.conversation_memory.add_run(run)
-
+    def add_task(self, task: Optional[BaseTask], **kwargs) -> Agent:
+        if task is None:
+            raise ValueError("Task must be provided.")
+        self.task = task
         return self
+
+    def add_tasks(self, *tasks: BaseTask, **kwargs) -> Structure:
+        if len(tasks) > 1:
+            raise ValueError("Agents can only have 1 task.")
+        return self.add_task(tasks[0]) if tasks else self

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from attrs import Factory, define, field
 
@@ -103,3 +103,9 @@ class PromptTask(RuleMixin, BaseTask):
             return ListArtifact([self._process_task_input(elem) for elem in task_input])
         else:
             return self._process_task_input(TextArtifact(task_input))
+
+    def __hash__(self) -> int:
+        return BaseTask.__hash__(self)
+
+    def __eq__(self, other: Any) -> bool:
+        return BaseTask.__eq__(self, other)

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from attrs import Attribute, Factory, define, field
 
@@ -200,9 +200,10 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
     def add_subtask(self, subtask: ActionsSubtask) -> ActionsSubtask:
         subtask.attach_to(self)
 
-        if len(self.subtasks) > 0:
-            self.subtasks[-1].add_child(subtask)
-            subtask.add_parent(self.subtasks[-1])
+        # TODO: do something here
+        # if len(self.subtasks) > 0:
+        #     self.subtasks[-1].add_child(subtask)
+        #     subtask.add_parent(self.subtasks[-1])
 
         self.subtasks.append(subtask)
 
@@ -219,3 +220,9 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
             if memory.name == memory_name:
                 return memory
         raise ValueError(f"Memory with name {memory_name} not found.")
+
+    def __hash__(self) -> int:
+        return PromptTask.__hash__(self)
+
+    def __eq__(self, other: Any) -> bool:
+        return PromptTask.__eq__(self, other)

--- a/griptape/utils/structure_visualizer.py
+++ b/griptape/utils/structure_visualizer.py
@@ -26,9 +26,7 @@ class StructureVisualizer:
         Returns:
             str: URL to the rendered image
         """
-        self.structure.resolve_relationships()
-
-        tasks = "\n\t" + "\n\t".join([self.__render_task(task) for task in self.structure.tasks])
+        tasks = "\n\t" + "\n\t".join([self.__render_task(task) for task in self.structure.ordered_tasks])
         graph = f"{self.header}{tasks}"
 
         graph_bytes = graph.encode("utf-8")
@@ -38,9 +36,9 @@ class StructureVisualizer:
         return url
 
     def __render_task(self, task: BaseTask) -> str:
-        if task.children:
-            children = " & ".join([f"{self.__get_id(child.id)}({child.id})" for child in task.children])
-            return f"{self.__get_id(task.id)}({task.id})--> {children};"
+        if task.child_ids:
+            next_task = " & ".join([f"{self.__get_id(child_id)}({child_id})" for child_id in task.child_ids])
+            return f"{self.__get_id(task.id)}({task.id})--> {next_task};"
         else:
             return f"{self.__get_id(task.id)}({task.id});"
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Main changes:
- Update `Workflow` to simplify creation.
- Remove all methods for defining relationships between Tasks directly on a Task.

### Context for changes
relevant: #896

currently the two different syntaxes (declarative and imperative) for defining relationships between Tasks for the sake of running them in a Structure (primarily a Workflow). the API for doing so can be confusing because of the many different entrypoints for defining the relationships, and the implementation can be confusing because of the way that the full state of Task relationships are split between Structures and Tasks.

### Assumptions made for these changes
- All Structures can generate a _graphs_ of _Tasks_ by calling `structure.task_graph`. This returns a graph of BaseTask objects.


## Issue ticket number and link


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--945.org.readthedocs.build//945/

<!-- readthedocs-preview griptape end -->