### PR TITLE
Move `try_run`, `order_tasks` to `Structure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OpenAiAudioTranscriptionDriver` for integration with OpenAI's speech-to-text models, including Whisper.
 - Parameter `env` to `BaseStructureRunDriver` to set environment variables for a Structure Run.
 - `PusherEventListenerDriver` to enable sending of framework events over a Pusher WebSocket.
+- Parameter `futures_executor_fn` and methods `try_run` and `order_tasks` to `Structure` from `Workflow`.
 
 ### Changed
 - **BREAKING**: Updated OpenAI-based image query drivers to remove Vision from the name.

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING, Callable, Optional
 from attrs import Attribute, Factory, define, field
 
 from griptape.artifacts.text_artifact import TextArtifact
-from griptape.common import observable
 from griptape.configs import Defaults
-from griptape.memory.structure import Run
+from griptape.tools import BaseTool
 from griptape.structures import Structure
 from griptape.tasks import PromptTask, ToolkitTask
 
@@ -73,13 +72,6 @@ class Agent(Structure):
             raise ValueError("Agents can only have one task.")
         return super().add_tasks(*tasks)
 
-    @observable
-    def try_run(self, *args) -> Agent:
-        self.task.execute()
-
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
-
-            self.conversation_memory.add_run(run)
-
-        return self
+    def resolve_relationships(self) -> None:
+        if len(self.tasks) > 1:
+            raise ValueError("Agents can only have one task.")

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -88,33 +88,6 @@ class Workflow(Structure):
 
         return task
 
-    @observable
-    def try_run(self, *args) -> Workflow:
-        exit_loop = False
-
-        while not self.is_finished() and not exit_loop:
-            futures_list = {}
-            ordered_tasks = self.order_tasks()
-
-            for task in ordered_tasks:
-                if task.can_execute():
-                    future = self.futures_executor.submit(task.execute)
-                    futures_list[future] = task
-
-            # Wait for all tasks to complete
-            for future in futures.as_completed(futures_list):
-                if isinstance(future.result(), ErrorArtifact) and self.fail_fast:
-                    exit_loop = True
-
-                    break
-
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
-
-            self.conversation_memory.add_run(run)
-
-        return self
-
     def context(self, task: BaseTask) -> dict[str, Any]:
         context = super().context(task)
 

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -237,3 +237,9 @@ class TestAgent:
     def test_fail_fast(self):
         with pytest.raises(ValueError):
             Agent(prompt_driver=MockPromptDriver(), fail_fast=True)
+
+    def test_fail_too_many_tasks(self):
+        with pytest.raises(ValueError, match="Agents can only have one task."):
+            agent = Agent()
+            agent.tasks = [PromptTask("input"), PromptTask("input")]
+            agent.run()


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
moving `try_run` and `order_tasks` to the top-level `Structure` to normalize how Structures execute Tasks.

## Issue ticket number and link
