### PR TITLE
Feature/observable tags

### DIFF
--- a/docs/griptape-framework/drivers/observability-drivers.md
+++ b/docs/griptape-framework/drivers/observability-drivers.md
@@ -56,7 +56,7 @@ with Observability(observability_driver=observability_driver):
     agent.run("Name an animal")
 ```
 
-Ouput (only relevant because of use of `ConsoleSpanExporter`):
+Output (only relevant because of use of `ConsoleSpanExporter`):
 ```
 [06/18/24 06:57:22] INFO     PromptTask 2d8ef95bf817480188ae2f74e754308a
                              Input: Name an animal

--- a/griptape/common/__init__.py
+++ b/griptape/common/__init__.py
@@ -26,5 +26,5 @@ __all__ = [
     "PromptStack",
     "Reference",
     "observable",
-    "Observable"
+    "Observable",
 ]

--- a/griptape/common/observable.py
+++ b/griptape/common/observable.py
@@ -29,6 +29,10 @@ class Observable:
             args = (self.instance, *self.args) if self.instance and not hasattr(self.func, "__self__") else self.args
             return self.func(*args, **self.kwargs)
 
+        @property
+        def tags(self) -> Optional[list[str]]:
+            return self.decorator_kwargs.get("tags")
+
     def __init__(self, *args, **kwargs):
         self._instance = None
         if len(args) == 1 and len(kwargs) == 0 and isfunction(args[0]):

--- a/griptape/drivers/observability/base_observability_driver.py
+++ b/griptape/drivers/observability/base_observability_driver.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 
 @define
 class BaseObservabilityDriver(ABC):
-    def __enter__(self) -> None:
+    def __enter__(self) -> None:  # noqa: B027
         pass
 
     def __exit__(

--- a/griptape/drivers/observability/open_telemetry_observability_driver.py
+++ b/griptape/drivers/observability/open_telemetry_observability_driver.py
@@ -56,10 +56,14 @@ class OpenTelemetryObservabilityDriver(BaseObservabilityDriver):
     def observe(self, call: Observable.Call) -> Any:
         func = call.func
         instance = call.instance
+        tags = call.tags
 
         class_name = f"{instance.__class__.__name__}." if instance else ""
         span_name = f"{class_name}{func.__name__}()"
         with self._tracer.start_as_current_span(span_name) as span:  # pyright: ignore[reportCallIssue]
+            if tags is not None:
+                span.set_attribute("tags", tags)
+
             try:
                 result = call()
                 span.set_status(Status(StatusCode.OK))

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -13,6 +13,7 @@ from griptape.common import (
     BaseMessageContent,
     TextMessageContent,
     ImageMessageContent,
+    observable,
 )
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import AmazonBedrockTokenizer, BaseTokenizer
@@ -35,6 +36,7 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
         default=Factory(lambda self: AmazonBedrockTokenizer(model=self.model), takes_self=True), kw_only=True
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         response = self.bedrock_client.converse(**self._base_params(prompt_stack))
 
@@ -47,6 +49,7 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=usage["inputTokens"], output_tokens=usage["outputTokens"]),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         response = self.bedrock_client.converse_stream(**self._base_params(prompt_stack))
 

--- a/griptape/drivers/prompt/amazon_sagemaker_jumpstart_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_sagemaker_jumpstart_prompt_driver.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from attrs import Factory, define, field
 
 from griptape.artifacts import TextArtifact
-from griptape.common import PromptStack, Message, TextMessageContent, DeltaMessage
+from griptape.common import PromptStack, Message, TextMessageContent, DeltaMessage, observable
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import import_optional_dependency
@@ -41,6 +41,7 @@ class AmazonSageMakerJumpstartPromptDriver(BasePromptDriver):
         if stream:
             raise ValueError("streaming is not supported")
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         payload = {
             "inputs": self.prompt_stack_to_string(prompt_stack),
@@ -78,6 +79,7 @@ class AmazonSageMakerJumpstartPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=input_tokens, output_tokens=output_tokens),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         raise NotImplementedError("streaming is not supported")
 

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -14,6 +14,7 @@ from griptape.common import (
     PromptStack,
     Message,
     TextMessageContent,
+    observable,
 )
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import AnthropicTokenizer, BaseTokenizer
@@ -48,6 +49,7 @@ class AnthropicPromptDriver(BasePromptDriver):
     top_k: int = field(default=250, kw_only=True, metadata={"serializable": True})
     max_tokens: int = field(default=1000, kw_only=True, metadata={"serializable": True})
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         response = self.client.messages.create(**self._base_params(prompt_stack))
 
@@ -57,6 +59,7 @@ class AnthropicPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=response.usage.input_tokens, output_tokens=response.usage.output_tokens),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         events = self.client.messages.create(**self._base_params(prompt_stack), stream=True)
 

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -13,6 +13,7 @@ from griptape.common import (
     PromptStack,
     Message,
     TextMessageContent,
+    observable,
 )
 from griptape.events import CompletionChunkEvent, FinishPromptEvent, StartPromptEvent
 from griptape.mixins import ExponentialBackoffMixin, SerializableMixin
@@ -60,6 +61,7 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
                 )
             )
 
+    @observable
     def run(self, prompt_stack: PromptStack) -> Message:
         for attempt in self.retrying():
             with attempt:

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -61,7 +61,7 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
                 )
             )
 
-    @observable
+    @observable(tags=["PromptDriver.run()"])
     def run(self, prompt_stack: PromptStack) -> Message:
         for attempt in self.retrying():
             with attempt:

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -12,6 +12,7 @@ from griptape.common import (
     TextMessageContent,
     BaseMessageContent,
     TextDeltaMessageContent,
+    observable,
 )
 from griptape.utils import import_optional_dependency
 from griptape.tokenizers import BaseTokenizer
@@ -38,6 +39,7 @@ class CoherePromptDriver(BasePromptDriver):
         default=Factory(lambda self: CohereTokenizer(model=self.model, client=self.client), takes_self=True)
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         result = self.client.chat(**self._base_params(prompt_stack))
         usage = result.meta.tokens
@@ -48,6 +50,7 @@ class CoherePromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=usage.input_tokens, output_tokens=usage.output_tokens),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         result = self.client.chat_stream(**self._base_params(prompt_stack))
 

--- a/griptape/drivers/prompt/dummy_prompt_driver.py
+++ b/griptape/drivers/prompt/dummy_prompt_driver.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 
 from attrs import Factory, define, field
 
-from griptape.common import PromptStack, Message, DeltaMessage
+from griptape.common import PromptStack, Message, DeltaMessage, observable
 from griptape.drivers import BasePromptDriver
 from griptape.exceptions import DummyException
 from griptape.tokenizers import DummyTokenizer
@@ -14,8 +14,10 @@ class DummyPromptDriver(BasePromptDriver):
     model: None = field(init=False, default=None, kw_only=True)
     tokenizer: DummyTokenizer = field(default=Factory(lambda: DummyTokenizer()), kw_only=True)
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         raise DummyException(__class__.__name__, "try_run")
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         raise DummyException(__class__.__name__, "try_stream")

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -14,6 +14,7 @@ from griptape.common import (
     PromptStack,
     Message,
     TextMessageContent,
+    observable,
 )
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer, GoogleTokenizer
@@ -45,6 +46,7 @@ class GooglePromptDriver(BasePromptDriver):
     top_p: Optional[float] = field(default=None, kw_only=True, metadata={"serializable": True})
     top_k: Optional[int] = field(default=None, kw_only=True, metadata={"serializable": True})
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         GenerationConfig = import_optional_dependency("google.generativeai.types").GenerationConfig
 
@@ -70,6 +72,7 @@ class GooglePromptDriver(BasePromptDriver):
             ),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         GenerationConfig = import_optional_dependency("google.generativeai.types").GenerationConfig
 

--- a/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
@@ -7,7 +7,7 @@ from attrs import Factory, define, field
 
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
-from griptape.common import PromptStack, Message, DeltaMessage, TextDeltaMessageContent
+from griptape.common import PromptStack, Message, DeltaMessage, TextDeltaMessageContent, observable
 from griptape.utils import import_optional_dependency
 
 if TYPE_CHECKING:
@@ -47,6 +47,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
         kw_only=True,
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         prompt = self.prompt_stack_to_string(prompt_stack)
 
@@ -62,6 +63,7 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=input_tokens, output_tokens=output_tokens),
         )
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         prompt = self.prompt_stack_to_string(prompt_stack)
 

--- a/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from attrs import Factory, define, field
 
 from griptape.artifacts import TextArtifact
-from griptape.common import DeltaMessage, PromptStack, Message, TextMessageContent
+from griptape.common import DeltaMessage, PromptStack, Message, TextMessageContent, observable
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import import_optional_dependency
@@ -42,6 +42,7 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         )
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         messages = self._prompt_stack_to_messages(prompt_stack)
 
@@ -66,6 +67,7 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         else:
             raise Exception("invalid output format")
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         raise NotImplementedError("streaming is not supported")
 

--- a/griptape/drivers/prompt/ollama_prompt_driver.py
+++ b/griptape/drivers/prompt/ollama_prompt_driver.py
@@ -5,7 +5,7 @@ from attrs import define, field, Factory
 from griptape.artifacts import TextArtifact
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers.base_tokenizer import BaseTokenizer
-from griptape.common import PromptStack, TextMessageContent
+from griptape.common import PromptStack, TextMessageContent, observable
 from griptape.utils import import_optional_dependency
 from griptape.tokenizers import SimpleTokenizer
 from griptape.common import Message, DeltaMessage, TextDeltaMessageContent
@@ -49,6 +49,7 @@ class OllamaPromptDriver(BasePromptDriver):
         kw_only=True,
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         response = self.client.chat(**self._base_params(prompt_stack))
 
@@ -60,6 +61,7 @@ class OllamaPromptDriver(BasePromptDriver):
         else:
             raise Exception("invalid model response")
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         stream = self.client.chat(**self._base_params(prompt_stack), stream=True)
 

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -15,6 +15,7 @@ from griptape.common import (
     PromptStack,
     Message,
     TextMessageContent,
+    observable,
 )
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer, OpenAiTokenizer
@@ -73,6 +74,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         kw_only=True,
     )
 
+    @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         result = self.client.chat.completions.create(**self._base_params(prompt_stack))
 
@@ -89,6 +91,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         else:
             raise Exception("Completion with more than one choice is not supported yet.")
 
+    @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         result = self.client.chat.completions.create(
             **self._base_params(prompt_stack), stream=True, stream_options={"include_usage": True}

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -11,6 +11,7 @@ from typing import Optional
 import yaml
 from attrs import define, field, Factory
 from griptape.artifacts import BaseArtifact, InfoArtifact, TextArtifact
+from griptape.common import observable
 from griptape.mixins import ActivityMixin
 
 if TYPE_CHECKING:
@@ -113,6 +114,7 @@ class BaseTool(ActivityMixin, ABC):
     def before_run(self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action) -> Optional[dict]:
         return action.input
 
+    @observable(tags=["Tool.run()"])
     def run(
         self, activity: Callable, subtask: ActionsSubtask, action: ActionsSubtask.Action, value: Optional[dict]
     ) -> BaseArtifact:

--- a/tests/utils/expected_spans.py
+++ b/tests/utils/expected_spans.py
@@ -11,6 +11,7 @@ class ExpectedSpan:
     parent: str = field(kw_only=True)
     status_code: StatusCode = field(kw_only=True)
     exception: Optional[Exception] = field(default=None, kw_only=True)
+    attributes: Optional[dict] = field(default=None, kw_only=True)
 
 
 @define
@@ -75,5 +76,13 @@ class ExpectedSpans:
             expected_parent = parent and other_span_by_name[parent].context.span_id
             if actual_parent != expected_parent:
                 raise Exception(f"Span {child} has wrong parent")
+
+        expected_attributes = {span.name: span.attributes for span in self.spans}
+        for span_name, expected_attributes in expected_attributes.items():
+            other_span = other_span_by_name[span_name]
+            if expected_attributes is not None and other_span.attributes != expected_attributes:
+                raise Exception(
+                    f"Span {span_name} has attributes {other_span.attributes} instead of {expected_attributes}"
+                )
 
         return True


### PR DESCRIPTION
Changes:
- Small fixes after rebasing the `release/cloud-unreleased` branch.
- Add an optional list of `tags` to `Observable.Call`. This allows us to easily group spans.
- Add `tags` as a span attribute in OpenTelemetryObservabilityDriver
- Annotate prompt driver run with `@observable(tags=["PromptDriver.run()"])`.
- Annotate prompt driver try_run and try_stream with `@observable`. These spans will be useful for debugging exceptions that occur during retries.
- Annotate tool run `@observable(tags=["Tool.run()"])`.


## Note: merging into `release/cloud-unreleased` rather than `dev`

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--954.org.readthedocs.build//954/

<!-- readthedocs-preview griptape end -->