### PR TITLE
Add docs for OpenAI compatible services

### DIFF
--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -27,6 +27,25 @@ print(embeddings[:3])
 [0.0017853748286142945, 0.006118456833064556, -0.005811543669551611]
 ```
 
+### OpenAI Compatible
+
+Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) are compatible with the OpenAI API. You can use the [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md) to interact with these services.
+Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
+
+```python title="PYTEST_IGNORE"
+from griptape.drivers import OpenAiEmbeddingDriver
+
+embedding_driver = OpenAiEmbeddingDriver(
+    base_url="http://127.0.0.1:1234/v1",
+    model="nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q2_K",
+)
+
+embeddings = embedding_driver.embed_string("Hello world!")
+
+# display the first 3 embeddings
+print(embeddings[:3])
+```
+
 ### Azure OpenAI
 
 The [AzureOpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/azure_openai_embedding_driver.md) uses the same parameters as [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md)

--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -29,7 +29,7 @@ print(embeddings[:3])
 
 ### OpenAI Compatible
 
-Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) are compatible with the OpenAI API. You can use the [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md) to interact with these services.
+Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) provide OpenAI-compatible APIs. You can use the [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md) to interact with these services.
 Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
 
 ```python title="PYTEST_IGNORE"

--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -30,7 +30,7 @@ print(embeddings[:3])
 ### OpenAI Compatible
 
 Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) provide OpenAI-compatible APIs. You can use the [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md) to interact with these services.
-Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
+Simply set the `base_url` to the service's API endpoint and the `model` to the model name. If the service requires an API key, you can set it in the `api_key` field.
 
 ```python title="PYTEST_IGNORE"
 from griptape.drivers import OpenAiEmbeddingDriver

--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -46,6 +46,9 @@ embeddings = embedding_driver.embed_string("Hello world!")
 print(embeddings[:3])
 ```
 
+!!! tip
+    Make sure to include `v1` at the end of the `base_url` to match the OpenAI API endpoint.
+
 ### Azure OpenAI
 
 The [AzureOpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/azure_openai_embedding_driver.md) uses the same parameters as [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_embedding_driver.md)

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -100,7 +100,7 @@ agent.run("Blue sky at dusk.")
 ### OpenAI Compatible
 
 Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) provide OpenAI-compatible APIs. You can use the [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) to interact with these services.
-Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
+Simply set the `base_url` to the service's API endpoint and the `model` to the model name. If the service requires an API key, you can set it in the `api_key` field.
 
 ```python title="PYTEST_IGNORE"
 from griptape.structures import Agent

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -94,6 +94,9 @@ agent = Agent(
 agent.run("Blue sky at dusk.")
 ```
 
+!!! info
+    `response_format` and `seed` are unique to the OpenAI Chat Prompt Driver and Azure OpenAi Chat Prompt Driver.
+
 ### OpenAI Compatible
 
 Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) provide OpenAI-compatible APIs. You can use the [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) to interact with these services.
@@ -118,8 +121,8 @@ agent = Agent(
 agent.run("How do I init and update a git submodule?")
 ```
 
-!!! info
-    `response_format` and `seed` are unique to the OpenAI Chat Prompt Driver and Azure OpenAi Chat Prompt Driver.
+!!! tip
+    Make sure to include `v1` at the end of the `base_url` to match the OpenAI API endpoint.
 
 ### Azure OpenAI Chat
 

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -94,6 +94,30 @@ agent = Agent(
 agent.run("Blue sky at dusk.")
 ```
 
+### OpenAI Compatible
+
+Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) are compatible with the OpenAI API. You can use the [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) to interact with these services.
+Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
+
+```python title="PYTEST_IGNORE"
+from griptape.structures import Agent
+from griptape.drivers import OpenAiChatPromptDriver
+from griptape.rules import Rule
+from griptape.config import StructureConfig
+
+agent = Agent(
+    config=StructureConfig(
+        prompt_driver=OpenAiChatPromptDriver(
+            base_url="http://127.0.0.1:1234/v1",
+            model="lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF", stream=True
+        )
+    ),
+    rules=[Rule(value="You are a helpful coding assistant.")],
+)
+
+agent.run("How do I init and update a git submodule?")
+```
+
 !!! info
     `response_format` and `seed` are unique to the OpenAI Chat Prompt Driver and Azure OpenAi Chat Prompt Driver.
 

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -96,7 +96,7 @@ agent.run("Blue sky at dusk.")
 
 ### OpenAI Compatible
 
-Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) are compatible with the OpenAI API. You can use the [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) to interact with these services.
+Many services such as [LMStudio](https://lmstudio.ai/) and [OhMyGPT](https://www.ohmygpt.com/) provide OpenAI-compatible APIs. You can use the [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) to interact with these services.
 Simply set the `base_url` to the service's API endpoint and the `model` to the model name.
 
 ```python title="PYTEST_IGNORE"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Adds docs describing how users can configure `OpenAiChatPromptDriver` and `OpenAiEmbeddingDriver` with OpenAI API compatible services.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/943, https://github.com/griptape-ai/griptape/pull/955, https://github.com/griptape-ai/griptape/issues/890

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--962.org.readthedocs.build//962/

<!-- readthedocs-preview griptape end -->