### PR TITLE
Fix inserting conversation into  when no system content is present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.28.2] - 2024-07-12
+### Fixed
+- Conversation Memory being incorrectly inserted into the `PromptTask.prompt_stack` when no system content is present.
+
 ## [0.28.1] - 2024-07-10
 
 ### Fixed

--- a/griptape/memory/structure/base_conversation_memory.py
+++ b/griptape/memory/structure/base_conversation_memory.py
@@ -88,9 +88,9 @@ class BaseConversationMemory(SerializableMixin, ABC):
 
         if num_runs_to_fit_in_prompt:
             memory_inputs = self.to_prompt_stack(num_runs_to_fit_in_prompt).messages
-            if index is not None:
-                prompt_stack.messages[index:index] = memory_inputs
-            else:
+            if index is None:
                 prompt_stack.messages.extend(memory_inputs)
+            else:
+                prompt_stack.messages[index:index] = memory_inputs
 
         return prompt_stack

--- a/griptape/memory/structure/base_conversation_memory.py
+++ b/griptape/memory/structure/base_conversation_memory.py
@@ -88,7 +88,7 @@ class BaseConversationMemory(SerializableMixin, ABC):
 
         if num_runs_to_fit_in_prompt:
             memory_inputs = self.to_prompt_stack(num_runs_to_fit_in_prompt).messages
-            if index:
+            if index is not None:
                 prompt_stack.messages[index:index] = memory_inputs
             else:
                 prompt_stack.messages.extend(memory_inputs)

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -51,9 +51,9 @@ class PromptTask(RuleMixin, BaseTask):
         if self.output:
             stack.add_assistant_message(self.output)
 
-        if memory:
-            # inserting at index 1 to place memory right after system prompt
-            memory.add_to_prompt_stack(stack, 1)
+        if memory is not None:
+            # insert memory into the stack right before the user messages
+            memory.add_to_prompt_stack(stack, 1 if system_template else 0)
 
         return stack
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Conversation Memory is being incorrectly inserted into index 1 in the Prompt Stack when there is no system message.
## Issue ticket number and link
NA