### PR TITLE
Set default service_name for GriptapeCloudObservabilityDriver

### DIFF
--- a/docs/griptape-framework/drivers/observability-drivers.md
+++ b/docs/griptape-framework/drivers/observability-drivers.md
@@ -23,9 +23,7 @@ from griptape.rules import Rule
 from griptape.structures import Agent
 from griptape.observability import Observability
 
-observability_driver = GriptapeCloudObservabilityDriver(
-    service_name="my-gt-app",
-)
+observability_driver = GriptapeCloudObservabilityDriver()
 
 with Observability(observability_driver=observability_driver):
     agent = Agent(rules=[Rule("Output one word")])

--- a/docs/griptape-framework/structures/observability.md
+++ b/docs/griptape-framework/structures/observability.md
@@ -9,7 +9,7 @@ from griptape.drivers import GriptapeCloudObservabilityDriver
 from griptape.structures import Agent
 from griptape.observability import Observability
 
-observability_driver = GriptapeCloudObservabilityDriver(service_name="hot-fire")
+observability_driver = GriptapeCloudObservabilityDriver()
 
 with Observability(observability_driver=observability_driver):
     # Important! Only code within this block is subject to observability
@@ -47,7 +47,7 @@ class MyClass:
         my_function()
         time.sleep(2)
 
-observability_driver = GriptapeCloudObservabilityDriver(service_name="my-app")
+observability_driver = GriptapeCloudObservabilityDriver()
 
 # When invoking the instrumented code from within the Observability context manager, the
 # telemetry for the custom code will be sent to the destination specified by the driver.

--- a/griptape/common/observable.py
+++ b/griptape/common/observable.py
@@ -23,7 +23,7 @@ class Observable:
         decorator_args: tuple[Any, ...] = field(default=Factory(tuple), kw_only=True)
         decorator_kwargs: dict[str, Any] = field(default=Factory(dict), kw_only=True)
 
-        def __call__(self):
+        def __call__(self) -> Any:
             # If self.func has a __self__ attribute, it is a bound method and we do not need to pass the instance.
             args = (self.instance, *self.args) if self.instance and not hasattr(self.func, "__self__") else self.args
             return self.func(*args, **self.kwargs)
@@ -32,7 +32,7 @@ class Observable:
         def tags(self) -> Optional[list[str]]:
             return self.decorator_kwargs.get("tags")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._instance = None
         if len(args) == 1 and len(kwargs) == 0 and isfunction(args[0]):
             # Parameterless call. In otherwords, the `@observable` annotation
@@ -49,11 +49,11 @@ class Observable:
             self.decorator_args = args
             self.decorator_kwargs = kwargs
 
-    def __get__(self, obj, objtype=None):
+    def __get__(self, obj: Any, objtype: Any = None) -> Observable:
         self._instance = obj
         return self
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Any:
         if self._func:
             # Parameterless call (self._func was a set in __init__)
             from griptape.observability.observability import Observability

--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -39,7 +39,7 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
                 "structure_run_id must be set either in the constructor or as an environment variable (GT_CLOUD_STRUCTURE_RUN_ID).",
             )
 
-    def publish_event(self, event: BaseEvent | dict, flush: bool = False) -> None:
+    def publish_event(self, event: BaseEvent | dict, *, flush: bool = False) -> None:
         from griptape.observability.observability import Observability
 
         event_payload = event.to_dict() if isinstance(event, BaseEvent) else event
@@ -48,7 +48,7 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
         if span_id is not None:
             event_payload["span_id"] = span_id
 
-        super().publish_event(event_payload, flush)
+        super().publish_event(event_payload, flush=flush)
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
         url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{self.structure_run_id}/events")

--- a/griptape/drivers/observability/base_observability_driver.py
+++ b/griptape/drivers/observability/base_observability_driver.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from types import TracebackType
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define
 
-from griptape.common import Observable
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from griptape.common import Observable
 
 
 @define

--- a/griptape/drivers/observability/no_op_observability_driver.py
+++ b/griptape/drivers/observability/no_op_observability_driver.py
@@ -1,9 +1,13 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define
 
-from griptape.common import Observable
 from griptape.drivers import BaseObservabilityDriver
+
+if TYPE_CHECKING:
+    from griptape.common import Observable
 
 
 @define

--- a/griptape/drivers/observability/open_telemetry_observability_driver.py
+++ b/griptape/drivers/observability/open_telemetry_observability_driver.py
@@ -1,5 +1,6 @@
-from types import TracebackType
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import Factory, define, field
 from opentelemetry.instrumentation.threading import ThreadingInstrumentor
@@ -7,8 +8,12 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.trace import INVALID_SPAN, Status, StatusCode, Tracer, format_span_id, get_current_span, get_tracer
 
-from griptape.common import Observable
 from griptape.drivers import BaseObservabilityDriver
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from griptape.common import Observable
 
 
 @define
@@ -25,7 +30,7 @@ class OpenTelemetryObservabilityDriver(BaseObservabilityDriver):
     _tracer: Optional[Tracer] = None
     _root_span_context_manager: Any = None
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         self.trace_provider.add_span_processor(self.span_processor)
         self._tracer = get_tracer(self.service_name, tracer_provider=self.trace_provider)
 

--- a/griptape/observability/observability.py
+++ b/griptape/observability/observability.py
@@ -1,5 +1,6 @@
-from types import TracebackType
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define, field
 
@@ -8,6 +9,11 @@ from griptape.drivers import BaseObservabilityDriver, NoOpObservabilityDriver
 
 _no_op_observability_driver = NoOpObservabilityDriver()
 _global_observability_driver: Optional[BaseObservabilityDriver] = None
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from griptape.common import Observable
 
 
 @define
@@ -20,7 +26,7 @@ class Observability:
         return _global_observability_driver
 
     @staticmethod
-    def set_global_driver(driver: Optional[BaseObservabilityDriver]):
+    def set_global_driver(driver: Optional[BaseObservabilityDriver]) -> None:
         global _global_observability_driver
         _global_observability_driver = driver
 
@@ -34,7 +40,7 @@ class Observability:
         driver = Observability.get_global_driver() or _no_op_observability_driver
         return driver.get_span_id()
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         if Observability.get_global_driver() is not None:
             raise ValueError("Observability driver already set.")
         Observability.set_global_driver(self.observability_driver)

--- a/griptape/tools/calculator/tool.py
+++ b/griptape/tools/calculator/tool.py
@@ -21,7 +21,7 @@ class Calculator(BaseTool):
         },
     )
     def calculate(self, params: dict) -> BaseArtifact:
-        import numexpr
+        import numexpr  # pyright: ignore[reportMissingImports]
 
         try:
             expression = params["values"]["expression"]

--- a/tests/unit/drivers/observability/test_griptape_cloud_observability_driver.py
+++ b/tests/unit/drivers/observability/test_griptape_cloud_observability_driver.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import pytest
 from griptape.common import Observable
 from griptape.drivers import GriptapeCloudObservabilityDriver
@@ -11,7 +10,7 @@ class TestGriptapeCloudObservabilityDriver:
     @pytest.fixture
     def driver(self):
         return GriptapeCloudObservabilityDriver(
-            service_name="test", base_url="http://base-url:1234", api_key="api-key", structure_run_id="structure-run-id"
+            base_url="http://base-url:1234", api_key="api-key", structure_run_id="structure-run-id"
         )
 
     @pytest.fixture(autouse=True)
@@ -26,7 +25,7 @@ class TestGriptapeCloudObservabilityDriver:
 
     def test_init(self, mock_span_exporter_class, mock_span_exporter):
         GriptapeCloudObservabilityDriver(
-            service_name="test", base_url="http://base-url:1234", api_key="api-key", structure_run_id="structure-run-id"
+            base_url="http://base-url:1234", api_key="api-key", structure_run_id="structure-run-id"
         )
 
         assert mock_span_exporter_class.call_count == 1


### PR DESCRIPTION
Changes:
- Set a default open telemetry service name in GriptapeCloudObservabilityDriver as it is not meaningful within in Griptape cloud.
- Fixing ruff changes after rebase

## Merging into `release/cloud-unreleased`

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--988.org.readthedocs.build//988/

<!-- readthedocs-preview griptape end -->