### PR TITLE
Refactor CsvRowArtifact to inherit from BaseTextArtifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Observability` context manager for enabling observability and configuring which Observability Driver to use.
 - `@observable` decorator for selecting which functions/methods to provide observability for.
 - `GenericArtifact` for storing any data.
+- `BaseTextArtifact` for text-based Artifacts to subclass.
 
 ### Changed
 - **BREAKING**: `BaseVectorStoreDriver.upsert_text_artifacts` optional arguments are now keyword-only arguments.
@@ -40,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary `sqlalchemy-redshift` dependency in `drivers-sql-amazon-redshift` extra.
 - Removed unnecessary `transformers` dependency in `drivers-prompt-huggingface` extra.
 - Removed unnecessary `huggingface-hub` dependency in `drivers-prompt-huggingface-pipeline` extra.
+- `CsvRowArtifact` now inherits from `BaseTextArtifact`.
+- `TextArtifact` now inherits from `BaseTextArtifact`.
 
 ### Fixed
 - Parameter `count` for `QdrantVectorStoreDriver.query` now optional as per documentation.

--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -1,4 +1,5 @@
 from .base_artifact import BaseArtifact
+from .base_text_artifact import BaseTextArtifact
 from .error_artifact import ErrorArtifact
 from .info_artifact import InfoArtifact
 from .text_artifact import TextArtifact
@@ -15,6 +16,7 @@ from .generic_artifact import GenericArtifact
 
 __all__ = [
     "BaseArtifact",
+    "BaseTextArtifact",
     "ErrorArtifact",
     "InfoArtifact",
     "TextArtifact",

--- a/griptape/artifacts/base_text_artifact.py
+++ b/griptape/artifacts/base_text_artifact.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from attrs import define, field
+
+from griptape.artifacts import BaseArtifact
+
+if TYPE_CHECKING:
+    from griptape.drivers import BaseEmbeddingDriver
+    from griptape.tokenizers import BaseTokenizer
+
+
+@define
+class BaseTextArtifact(BaseArtifact):
+    encoding: str = field(default="utf-8", kw_only=True)
+    encoding_error_handler: str = field(default="strict", kw_only=True)
+    _embedding: list[float] = field(factory=list, kw_only=True)
+
+    @property
+    def embedding(self) -> Optional[list[float]]:
+        return None if len(self._embedding) == 0 else self._embedding
+
+    def generate_embedding(self, driver: BaseEmbeddingDriver) -> Optional[list[float]]:
+        self._embedding.clear()
+        self._embedding.extend(driver.embed_string(str(self.value)))
+
+        return self.embedding
+
+    def token_count(self, tokenizer: BaseTokenizer) -> int:
+        return tokenizer.count_tokens(str(self.value))
+
+    def to_bytes(self) -> bytes:
+        return str(self.value).encode(encoding=self.encoding, errors=self.encoding_error_handler)

--- a/griptape/artifacts/csv_row_artifact.py
+++ b/griptape/artifacts/csv_row_artifact.py
@@ -5,16 +5,19 @@ import io
 
 from attrs import define, field
 
-from griptape.artifacts import BaseArtifact, TextArtifact
+from griptape.artifacts import BaseArtifact, BaseTextArtifact
 
 
 @define
-class CsvRowArtifact(TextArtifact):
+class CsvRowArtifact(BaseTextArtifact):
     value: dict[str, str] = field(converter=BaseArtifact.value_to_dict, metadata={"serializable": True})
     delimiter: str = field(default=",", kw_only=True, metadata={"serializable": True})
 
     def __add__(self, other: BaseArtifact) -> CsvRowArtifact:
         return CsvRowArtifact(self.value | other.value)
+
+    def __bool__(self) -> bool:
+        return len(self) > 0
 
     def to_text(self) -> str:
         with io.StringIO() as csvfile:
@@ -28,6 +31,3 @@ class CsvRowArtifact(TextArtifact):
             writer.writerow(self.value)
 
             return csvfile.getvalue().strip()
-
-    def __bool__(self) -> bool:
-        return len(self) > 0

--- a/griptape/artifacts/text_artifact.py
+++ b/griptape/artifacts/text_artifact.py
@@ -1,41 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attrs import define, field
 
-from griptape.artifacts import BaseArtifact
+from griptape.artifacts import BaseTextArtifact
 
 if TYPE_CHECKING:
-    from griptape.drivers import BaseEmbeddingDriver
-    from griptape.tokenizers import BaseTokenizer
+    from griptape.artifacts import BaseArtifact
 
 
 @define
-class TextArtifact(BaseArtifact):
+class TextArtifact(BaseTextArtifact):
     value: str = field(converter=str, metadata={"serializable": True})
-    encoding: str = field(default="utf-8", kw_only=True)
-    encoding_error_handler: str = field(default="strict", kw_only=True)
-    _embedding: list[float] = field(factory=list, kw_only=True)
-
-    @property
-    def embedding(self) -> Optional[list[float]]:
-        return None if len(self._embedding) == 0 else self._embedding
 
     def __add__(self, other: BaseArtifact) -> TextArtifact:
         return TextArtifact(self.value + other.value)
 
     def __bool__(self) -> bool:
         return bool(self.value.strip())
-
-    def generate_embedding(self, driver: BaseEmbeddingDriver) -> Optional[list[float]]:
-        self._embedding.clear()
-        self._embedding.extend(driver.embed_string(str(self.value)))
-
-        return self.embedding
-
-    def token_count(self, tokenizer: BaseTokenizer) -> int:
-        return tokenizer.count_tokens(str(self.value))
-
-    def to_bytes(self) -> bytes:
-        return self.value.encode(encoding=self.encoding, errors=self.encoding_error_handler)

--- a/tests/unit/artifacts/test_base_text_artifact.py
+++ b/tests/unit/artifacts/test_base_text_artifact.py
@@ -1,0 +1,35 @@
+import pytest
+
+from griptape.artifacts import TextArtifact
+from griptape.tokenizers import OpenAiTokenizer
+from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
+
+
+class TestBaseTextArtifact:
+    def test_generate_embedding(self):
+        assert TextArtifact("foobar").generate_embedding(MockEmbeddingDriver()) == [0, 1]
+
+    def test_embedding(self):
+        artifact = TextArtifact("foobar")
+
+        assert artifact.embedding is None
+        assert artifact.generate_embedding(MockEmbeddingDriver()) == [0, 1]
+        assert artifact.embedding == [0, 1]
+
+    def test_to_bytes_encoding(self):
+        assert (
+            TextArtifact("ß", name="foobar.txt", encoding="ascii", encoding_error_handler="backslashreplace").to_bytes()
+            == b"\\xdf"
+        )
+
+    def test_to_bytes_encoding_error(self):
+        with pytest.raises(ValueError):
+            assert TextArtifact("ß", encoding="ascii").to_bytes()
+
+    def test_token_count(self):
+        assert (
+            TextArtifact("foobarbaz").token_count(
+                OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
+            )
+            == 2
+        )

--- a/tests/unit/artifacts/test_csv_row_artifact.py
+++ b/tests/unit/artifacts/test_csv_row_artifact.py
@@ -1,5 +1,4 @@
 from griptape.artifacts import CsvRowArtifact
-from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
 
 class TestCsvRowArtifact:
@@ -13,9 +12,6 @@ class TestCsvRowArtifact:
             "test1": "foo",
             "test2": "bar",
         }
-
-    def test_generate_embedding(self):
-        assert CsvRowArtifact({"test1": "foo"}).generate_embedding(MockEmbeddingDriver()) == [0, 1]
 
     def test_to_text(self):
         assert CsvRowArtifact({"test1": "foo|bar", "test2": 1}, delimiter="|").to_text() == '"foo|bar"|1'

--- a/tests/unit/artifacts/test_list_artifact.py
+++ b/tests/unit/artifacts/test_list_artifact.py
@@ -1,6 +1,6 @@
 import pytest
 
-from griptape.artifacts import BlobArtifact, CsvRowArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import BaseTextArtifact, BlobArtifact, CsvRowArtifact, ListArtifact, TextArtifact
 
 
 class TestListArtifact:
@@ -32,7 +32,7 @@ class TestListArtifact:
 
     def test_is_type(self):
         assert ListArtifact([TextArtifact("foo")]).is_type(TextArtifact)
-        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(TextArtifact)
+        assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(BaseTextArtifact)
         assert ListArtifact([CsvRowArtifact({"foo": "bar"})]).is_type(CsvRowArtifact)
 
     def test_has_items(self):

--- a/tests/unit/artifacts/test_text_artifact.py
+++ b/tests/unit/artifacts/test_text_artifact.py
@@ -1,10 +1,6 @@
 import json
 
-import pytest
-
 from griptape.artifacts import BaseArtifact, TextArtifact
-from griptape.tokenizers import OpenAiTokenizer
-from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
 
 class TestTextArtifact:
@@ -14,37 +10,6 @@ class TestTextArtifact:
 
     def test___add__(self):
         assert (TextArtifact("foo") + TextArtifact("bar")).value == "foobar"
-
-    def test_generate_embedding(self):
-        assert TextArtifact("foobar").generate_embedding(MockEmbeddingDriver()) == [0, 1]
-
-    def test_embedding(self):
-        artifact = TextArtifact("foobar")
-
-        assert artifact.embedding is None
-        assert artifact.generate_embedding(MockEmbeddingDriver()) == [0, 1]
-        assert artifact.embedding == [0, 1]
-
-    def test_to_text(self):
-        assert TextArtifact("foobar").to_text() == "foobar"
-
-    def test_to_bytes_encoding(self):
-        assert (
-            TextArtifact("ß", name="foobar.txt", encoding="ascii", encoding_error_handler="backslashreplace").to_bytes()
-            == b"\\xdf"
-        )
-
-    def test_to_bytes_encoding_error(self):
-        with pytest.raises(ValueError):
-            assert TextArtifact("ß", encoding="ascii").to_bytes()
-
-    def test_token_count(self):
-        assert (
-            TextArtifact("foobarbaz").token_count(
-                OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
-            )
-            == 2
-        )
 
     def test_to_dict(self):
         assert TextArtifact("foobar").to_dict()["value"] == "foobar"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Added:
- `BaseTextArtifact` for text-based Artifacts to subclass.
Changed:
- `CsvRowArtifact` now inherits from `BaseTextArtifact`.
## Issue ticket number and link
Offline discussion (**Longterm fix for CsvRowArtifact NOT being a TextArtifact**)