### PR TITLE
Improve performance of image generation tools

### DIFF
--- a/griptape/tools/__init__.py
+++ b/griptape/tools/__init__.py
@@ -1,4 +1,5 @@
 from .base_tool import BaseTool
+from .base_image_generation_client import BaseImageGenerationClient
 from .calculator.tool import Calculator
 from .web_search.tool import WebSearch
 from .web_scraper.tool import WebScraper
@@ -32,6 +33,7 @@ from .audio_transcription_client.tool import AudioTranscriptionClient
 
 __all__ = [
     "BaseTool",
+    "BaseImageGenerationClient",
     "BaseAwsClient",
     "AwsIamClient",
     "AwsS3Client",

--- a/griptape/tools/base_image_generation_client.py
+++ b/griptape/tools/base_image_generation_client.py
@@ -1,0 +1,16 @@
+from attrs import define
+
+from griptape.mixins import BlobArtifactFileOutputMixin
+from griptape.tools import BaseTool
+
+
+@define
+class BaseImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
+    """A base class for tools that generate images from text prompts."""
+
+    PROMPT_DESCRIPTION = "Features and qualities to include in the generated image, descriptive and succinct."
+    NEGATIVE_PROMPT_DESCRIPTION = (
+        "Features and qualities to avoid in the generated image. Affirmatively describe "
+        "what to avoid, for example: to avoid the color red, include 'red' "
+        "rather than 'no red'."
+    )

--- a/griptape/tools/inpainting_image_generation_client/tool.py
+++ b/griptape/tools/inpainting_image_generation_client/tool.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from attrs import define, field
 from schema import Literal, Schema
 
 from griptape.artifacts import ErrorArtifact, ImageArtifact
 from griptape.loaders import ImageLoader
-from griptape.mixins import BlobArtifactFileOutputMixin
-from griptape.tools import BaseTool
+from griptape.tools.base_image_generation_client import BaseImageGenerationClient
 from griptape.utils.decorators import activity
 from griptape.utils.load_artifact_from_memory import load_artifact_from_memory
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @define
-class InpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
+class InpaintingImageGenerationClient(BaseImageGenerationClient):
     """A tool that can be used to generate prompted inpaintings of an image.
 
     Attributes:
@@ -31,17 +31,11 @@ class InpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
 
     @activity(
         config={
-            "description": "Can be used to modify an image within a specified mask area using image and mask files.",
+            "description": "Modifies an image within a specified mask area using image and mask files.",
             "schema": Schema(
                 {
-                    Literal(
-                        "prompts",
-                        description="A detailed list of features and descriptions to include in the generated image.",
-                    ): list[str],
-                    Literal(
-                        "negative_prompts",
-                        description="A detailed list of features and descriptions to avoid in the generated image.",
-                    ): list[str],
+                    Literal("prompt", description=BaseImageGenerationClient.PROMPT_DESCRIPTION): str,
+                    Literal("negative_prompt", description=BaseImageGenerationClient.NEGATIVE_PROMPT_DESCRIPTION): str,
                     Literal(
                         "image_file",
                         description="The path to an image file to be used as a base to generate variations from.",
@@ -51,40 +45,26 @@ class InpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             ),
         },
     )
-    def image_inpainting_from_file(self, params: dict[str, Any]) -> ImageArtifact | ErrorArtifact:
-        prompts = params["values"]["prompts"]
-        negative_prompts = params["values"]["negative_prompts"]
+    def image_inpainting_from_file(self, params: dict[str, dict[str, str]]) -> ImageArtifact | ErrorArtifact:
+        prompt = params["values"]["prompt"]
+        negative_prompt = params["values"]["negative_prompt"]
         image_file = params["values"]["image_file"]
         mask_file = params["values"]["mask_file"]
 
-        input_artifact = self.image_loader.load(image_file)
-        mask_artifact = self.image_loader.load(mask_file)
+        input_artifact = self.image_loader.load(Path(image_file).read_bytes())
+        mask_artifact = self.image_loader.load(Path(mask_file).read_bytes())
 
-        output_artifact = self.engine.run(
-            prompts=prompts,
-            negative_prompts=negative_prompts,
-            image=input_artifact,
-            mask=mask_artifact,
+        return self._generate_inpainting(
+            prompt, negative_prompt, cast(ImageArtifact, input_artifact), cast(ImageArtifact, mask_artifact)
         )
-
-        if self.output_dir or self.output_file:
-            self._write_to_file(output_artifact)
-
-        return output_artifact
 
     @activity(
         config={
-            "description": "Can be used to modify an image within a specified mask area using image and mask artifacts in memory.",
+            "description": "Modifies an image within a specified mask area using image and mask artifacts in memory.",
             "schema": Schema(
                 {
-                    Literal(
-                        "prompts",
-                        description="A detailed list of features and descriptions to include in the generated image.",
-                    ): list[str],
-                    Literal(
-                        "negative_prompts",
-                        description="A detailed list of features and descriptions to avoid in the generated image.",
-                    ): list[str],
+                    Literal("prompt", description=BaseImageGenerationClient.PROMPT_DESCRIPTION): str,
+                    Literal("negative_prompt", description=BaseImageGenerationClient.NEGATIVE_PROMPT_DESCRIPTION): str,
                     "memory_name": str,
                     "image_artifact_namespace": str,
                     "image_artifact_name": str,
@@ -94,9 +74,9 @@ class InpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             ),
         },
     )
-    def image_inpainting_from_memory(self, params: dict[str, Any]) -> ImageArtifact | ErrorArtifact:
-        prompts = params["values"]["prompts"]
-        negative_prompts = params["values"]["negative_prompts"]
+    def image_inpainting_from_memory(self, params: dict[str, dict[str, str]]) -> ImageArtifact | ErrorArtifact:
+        prompt = params["values"]["prompt"]
+        negative_prompt = params["values"]["negative_prompt"]
         image_artifact_namespace = params["values"]["image_artifact_namespace"]
         image_artifact_name = params["values"]["image_artifact_name"]
         mask_artifact_namespace = params["values"]["mask_artifact_namespace"]
@@ -123,24 +103,14 @@ class InpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             return ErrorArtifact(str(e))
 
         return self._generate_inpainting(
-            prompts,
-            negative_prompts,
-            cast(ImageArtifact, image_artifact),
-            cast(ImageArtifact, mask_artifact),
+            prompt, negative_prompt, cast(ImageArtifact, image_artifact), cast(ImageArtifact, mask_artifact)
         )
 
     def _generate_inpainting(
-        self,
-        prompts: list[str],
-        negative_prompts: list[str],
-        image_artifact: ImageArtifact,
-        mask_artifact: ImageArtifact,
+        self, prompt: str, negative_prompt: str, image_artifact: ImageArtifact, mask_artifact: ImageArtifact
     ) -> ImageArtifact:
         output_artifact = self.engine.run(
-            prompts=prompts,
-            negative_prompts=negative_prompts,
-            image=image_artifact,
-            mask=mask_artifact,
+            prompts=[prompt], negative_prompts=[negative_prompt], image=image_artifact, mask=mask_artifact
         )
 
         if self.output_dir or self.output_file:

--- a/griptape/tools/outpainting_image_generation_client/tool.py
+++ b/griptape/tools/outpainting_image_generation_client/tool.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from attrs import define, field
 from schema import Literal, Schema
 
 from griptape.artifacts import ErrorArtifact, ImageArtifact
 from griptape.loaders import ImageLoader
-from griptape.mixins import BlobArtifactFileOutputMixin
-from griptape.tools import BaseTool
+from griptape.tools import BaseImageGenerationClient
 from griptape.utils.decorators import activity
 from griptape.utils.load_artifact_from_memory import load_artifact_from_memory
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @define
-class OutpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
+class OutpaintingImageGenerationClient(BaseImageGenerationClient):
     """A tool that can be used to generate prompted outpaintings of an image.
 
     Attributes:
@@ -31,17 +31,11 @@ class OutpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
 
     @activity(
         config={
-            "description": "Can be used to modify an image outside a specified mask area using image and mask files.",
+            "description": "Modifies an image outside a specified mask area using image and mask files.",
             "schema": Schema(
                 {
-                    Literal(
-                        "prompts",
-                        description="A detailed list of features and descriptions to include in the generated image.",
-                    ): list[str],
-                    Literal(
-                        "negative_prompts",
-                        description="A detailed list of features and descriptions to avoid in the generated image.",
-                    ): list[str],
+                    Literal("prompt", description=BaseImageGenerationClient.PROMPT_DESCRIPTION): str,
+                    Literal("negative_prompt", description=BaseImageGenerationClient.NEGATIVE_PROMPT_DESCRIPTION): str,
                     Literal(
                         "image_file",
                         description="The path to an image file to be used as a base to generate variations from.",
@@ -51,30 +45,24 @@ class OutpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             ),
         },
     )
-    def image_outpainting_from_file(self, params: dict[str, Any]) -> ImageArtifact | ErrorArtifact:
-        prompts = params["values"]["prompts"]
-        negative_prompts = params["values"]["negative_prompts"]
+    def image_outpainting_from_file(self, params: dict[str, dict[str, str]]) -> ImageArtifact | ErrorArtifact:
+        prompt = params["values"]["prompt"]
+        negative_prompt = params["values"]["negative_prompt"]
         image_file = params["values"]["image_file"]
         mask_file = params["values"]["mask_file"]
 
-        input_artifact = self.image_loader.load(image_file)
-        mask_artifact = self.image_loader.load(mask_file)
+        input_artifact = self.image_loader.load(Path(image_file).read_bytes())
+        mask_artifact = self.image_loader.load(Path(mask_file).read_bytes())
 
-        return self._generate_outpainting(prompts, negative_prompts, input_artifact, mask_artifact)
+        return self._generate_outpainting(prompt, negative_prompt, input_artifact, mask_artifact)
 
     @activity(
         config={
-            "description": "Can be used to modify an image outside a specified mask area using image and mask artifacts in memory.",
+            "description": "Modifies an image outside a specified mask area using image and mask artifacts in memory.",
             "schema": Schema(
                 {
-                    Literal(
-                        "prompts",
-                        description="A detailed list of features and descriptions to include in the generated image.",
-                    ): list[str],
-                    Literal(
-                        "negative_prompts",
-                        description="A detailed list of features and descriptions to avoid in the generated image.",
-                    ): list[str],
+                    Literal("prompt", description=BaseImageGenerationClient.PROMPT_DESCRIPTION): str,
+                    Literal("negative_prompt", description=BaseImageGenerationClient.NEGATIVE_PROMPT_DESCRIPTION): str,
                     "memory_name": str,
                     "image_artifact_namespace": str,
                     "mask_artifact_namespace": str,
@@ -82,9 +70,9 @@ class OutpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             ),
         },
     )
-    def image_outpainting_from_memory(self, params: dict[str, Any]) -> ImageArtifact | ErrorArtifact:
-        prompts = params["values"]["prompts"]
-        negative_prompts = params["values"]["negative_prompts"]
+    def image_outpainting_from_memory(self, params: dict[str, dict[str, str]]) -> ImageArtifact | ErrorArtifact:
+        prompt = params["values"]["prompt"]
+        negative_prompt = params["values"]["negative_prompt"]
         image_artifact_namespace = params["values"]["image_artifact_namespace"]
         image_artifact_name = params["values"]["image_artifact_name"]
         mask_artifact_namespace = params["values"]["mask_artifact_namespace"]
@@ -111,24 +99,14 @@ class OutpaintingImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
             return ErrorArtifact(str(e))
 
         return self._generate_outpainting(
-            prompts,
-            negative_prompts,
-            cast(ImageArtifact, image_artifact),
-            cast(ImageArtifact, mask_artifact),
+            prompt, negative_prompt, cast(ImageArtifact, image_artifact), cast(ImageArtifact, mask_artifact)
         )
 
     def _generate_outpainting(
-        self,
-        prompts: list[str],
-        negative_prompts: list[str],
-        image_artifact: ImageArtifact,
-        mask_artifact: ImageArtifact,
-    ) -> ImageArtifact:
+        self, prompt: str, negative_prompt: str, image_artifact: ImageArtifact, mask_artifact: ImageArtifact
+    ) -> ImageArtifact | ErrorArtifact:
         output_artifact = self.engine.run(
-            prompts=prompts,
-            negative_prompts=negative_prompts,
-            image=image_artifact,
-            mask=mask_artifact,
+            prompts=[prompt], negative_prompts=[negative_prompt], image=image_artifact, mask=mask_artifact
         )
 
         if self.output_dir or self.output_file:

--- a/griptape/tools/prompt_image_generation_client/tool.py
+++ b/griptape/tools/prompt_image_generation_client/tool.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 from attrs import define, field
 from schema import Literal, Schema
 
-from griptape.mixins import BlobArtifactFileOutputMixin
-from griptape.tools import BaseTool
+from griptape.tools import BaseImageGenerationClient
 from griptape.utils.decorators import activity
 
 if TYPE_CHECKING:
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 
 @define
-class PromptImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
+class PromptImageGenerationClient(BaseImageGenerationClient):
     """A tool that can be used to generate an image from a text prompt.
 
     Attributes:
@@ -28,21 +27,20 @@ class PromptImageGenerationClient(BlobArtifactFileOutputMixin, BaseTool):
 
     @activity(
         config={
-            "description": "Can be used to generate an image from text prompts.",
+            "description": "Generates an image from text prompts.",
             "schema": Schema(
                 {
-                    Literal(
-                        "prompts",
-                        description="A detailed list of features and descriptions to include in the generated image.",
-                    ): list[str],
-                },
+                    Literal("prompt", description=BaseImageGenerationClient.PROMPT_DESCRIPTION): str,
+                    Literal("negative_prompt", description=BaseImageGenerationClient.NEGATIVE_PROMPT_DESCRIPTION): str,
+                }
             ),
         },
     )
-    def generate_image(self, params: dict[str, dict[str, list[str]]]) -> ImageArtifact | ErrorArtifact:
-        prompts = params["values"]["prompts"]
+    def generate_image(self, params: dict[str, dict[str, str]]) -> ImageArtifact | ErrorArtifact:
+        prompt = params["values"]["prompt"]
+        negative_prompt = params["values"]["negative_prompt"]
 
-        output_artifact = self.engine.run(prompts=prompts)
+        output_artifact = self.engine.run(prompts=[prompt], negative_prompts=[negative_prompt])
 
         if self.output_dir or self.output_file:
             self._write_to_file(output_artifact)

--- a/tests/unit/tools/conftest.py
+++ b/tests/unit/tools/conftest.py
@@ -1,0 +1,12 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def path_from_resource_path():
+    def create_source(resource_path: str) -> Path:
+        return Path(os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../resources", resource_path))
+
+    return create_source

--- a/tests/unit/tools/test_inpainting_image_generation_client.py
+++ b/tests/unit/tools/test_inpainting_image_generation_client.py
@@ -11,6 +11,10 @@ from griptape.tools import InpaintingImageGenerationClient
 
 class TestInpaintingImageGenerationClient:
     @pytest.fixture()
+    def image_artifact(self) -> ImageArtifact:
+        return ImageArtifact(value=b"image_data", format="png", width=512, height=512, name="name")
+
+    @pytest.fixture()
     def image_generation_engine(self) -> Mock:
         return Mock()
 
@@ -72,3 +76,29 @@ class TestInpaintingImageGenerationClient:
 
         assert image_artifact
         assert os.path.exists(outfile)
+
+    def test_image_inpainting_from_memory(self, image_generation_engine, image_artifact):
+        image_generator = InpaintingImageGenerationClient(engine=image_generation_engine)
+        memory = Mock()
+        memory.load_artifacts = Mock(return_value=[image_artifact])
+        image_generator.find_input_memory = Mock(return_value=memory)
+
+        image_generator.engine.run.return_value = Mock(  # pyright: ignore[reportFunctionMemberAccess]
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
+        )
+
+        image_artifact = image_generator.image_inpainting_from_memory(
+            params={
+                "values": {
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_artifact_namespace": "namespace",
+                    "image_artifact_name": "name",
+                    "mask_artifact_namespace": "namespace",
+                    "mask_artifact_name": "name",
+                    "memory_name": "memory",
+                }
+            }
+        )
+
+        assert image_artifact

--- a/tests/unit/tools/test_inpainting_image_generation_client.py
+++ b/tests/unit/tools/test_inpainting_image_generation_client.py
@@ -29,7 +29,7 @@ class TestInpaintingImageGenerationClient:
         with pytest.raises(ValueError):
             InpaintingImageGenerationClient(engine=image_generation_engine, output_dir="test", output_file="test")
 
-    def test_image_inpainting(self, image_generator) -> None:
+    def test_image_inpainting(self, image_generator, path_from_resource_path) -> None:
         image_generator.engine.run.return_value = Mock(
             value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
@@ -37,17 +37,19 @@ class TestInpaintingImageGenerationClient:
         image_artifact = image_generator.image_inpainting_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
-                    "mask_file": "mask.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
+                    "mask_file": path_from_resource_path("small.png"),
                 }
             }
         )
 
         assert image_artifact
 
-    def test_image_inpainting_with_outfile(self, image_generation_engine, image_loader) -> None:
+    def test_image_inpainting_with_outfile(
+        self, image_generation_engine, image_loader, path_from_resource_path
+    ) -> None:
         outfile = f"{tempfile.gettempdir()}/{str(uuid.uuid4())}.png"
         image_generator = InpaintingImageGenerationClient(
             engine=image_generation_engine, output_file=outfile, image_loader=image_loader
@@ -60,10 +62,10 @@ class TestInpaintingImageGenerationClient:
         image_artifact = image_generator.image_inpainting_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
-                    "mask_file": "mask.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
+                    "mask_file": path_from_resource_path("small.png"),
                 }
             }
         )

--- a/tests/unit/tools/test_outpainting_image_variation_client.py
+++ b/tests/unit/tools/test_outpainting_image_variation_client.py
@@ -11,13 +11,17 @@ from griptape.tools import OutpaintingImageGenerationClient
 
 class TestOutpaintingImageGenerationClient:
     @pytest.fixture()
+    def image_artifact(self) -> ImageArtifact:
+        return ImageArtifact(value=b"image_data", format="png", width=512, height=512, name="name")
+
+    @pytest.fixture()
     def image_generation_engine(self) -> Mock:
         return Mock()
 
     @pytest.fixture()
-    def image_loader(self) -> Mock:
+    def image_loader(self, image_artifact) -> Mock:
         loader = Mock()
-        loader.load.return_value = ImageArtifact(value=b"image_data", format="png", width=512, height=512)
+        loader.load.return_value = image_artifact
 
         return loader
 
@@ -72,3 +76,29 @@ class TestOutpaintingImageGenerationClient:
 
         assert image_artifact
         assert os.path.exists(outfile)
+
+    def test_image_outpainting_from_memory(self, image_generation_engine, image_artifact):
+        image_generator = OutpaintingImageGenerationClient(engine=image_generation_engine)
+        memory = Mock()
+        memory.load_artifacts = Mock(return_value=[image_artifact])
+        image_generator.find_input_memory = Mock(return_value=memory)
+
+        image_generator.engine.run.return_value = Mock(  # pyright: ignore[reportFunctionMemberAccess]
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
+        )
+
+        image_artifact = image_generator.image_outpainting_from_memory(
+            params={
+                "values": {
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_artifact_namespace": "namespace",
+                    "image_artifact_name": "name",
+                    "mask_artifact_namespace": "namespace",
+                    "mask_artifact_name": "name",
+                    "memory_name": "memory",
+                }
+            }
+        )
+
+        assert image_artifact

--- a/tests/unit/tools/test_outpainting_image_variation_client.py
+++ b/tests/unit/tools/test_outpainting_image_variation_client.py
@@ -29,7 +29,7 @@ class TestOutpaintingImageGenerationClient:
         with pytest.raises(ValueError):
             OutpaintingImageGenerationClient(engine=image_generation_engine, output_dir="test", output_file="test")
 
-    def test_image_outpainting(self, image_generator) -> None:
+    def test_image_outpainting(self, image_generator, path_from_resource_path) -> None:
         image_generator.engine.run.return_value = Mock(
             value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
@@ -37,17 +37,19 @@ class TestOutpaintingImageGenerationClient:
         image_artifact = image_generator.image_outpainting_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
-                    "mask_file": "mask.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
+                    "mask_file": path_from_resource_path("small.png"),
                 }
             }
         )
 
         assert image_artifact
 
-    def test_image_outpainting_with_outfile(self, image_generation_engine, image_loader) -> None:
+    def test_image_outpainting_with_outfile(
+        self, image_generation_engine, image_loader, path_from_resource_path
+    ) -> None:
         outfile = f"{tempfile.gettempdir()}/{str(uuid.uuid4())}.png"
         image_generator = OutpaintingImageGenerationClient(
             engine=image_generation_engine, output_file=outfile, image_loader=image_loader
@@ -60,10 +62,10 @@ class TestOutpaintingImageGenerationClient:
         image_artifact = image_generator.image_outpainting_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
-                    "mask_file": "mask.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
+                    "mask_file": path_from_resource_path("small.png"),
                 }
             }
         )

--- a/tests/unit/tools/test_prompt_image_generation_client.py
+++ b/tests/unit/tools/test_prompt_image_generation_client.py
@@ -27,7 +27,7 @@ class TestPromptImageGenerationClient:
         )
 
         image_artifact = image_generator.generate_image(
-            params={"values": {"prompts": ["test prompt"], "negative_prompts": ["test negative prompt"]}}
+            params={"values": {"prompt": "test prompt", "negative_prompt": "test negative prompt"}}
         )
 
         assert image_artifact
@@ -41,7 +41,7 @@ class TestPromptImageGenerationClient:
         )
 
         image_artifact = image_generator.generate_image(
-            params={"values": {"prompts": ["test prompt"], "negative_prompts": ["test negative prompt"]}}
+            params={"values": {"prompt": "test prompt", "negative_prompt": "test negative prompt"}}
         )
 
         assert image_artifact

--- a/tests/unit/tools/test_variation_image_generation_client.py
+++ b/tests/unit/tools/test_variation_image_generation_client.py
@@ -31,7 +31,7 @@ class TestVariationImageGenerationClient:
                 engine=image_generation_engine, output_dir="test", output_file="test", image_loader=image_loader
             )
 
-    def test_image_variation(self, image_generator) -> None:
+    def test_image_variation(self, image_generator, path_from_resource_path) -> None:
         image_generator.engine.run.return_value = Mock(
             value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
         )
@@ -39,16 +39,16 @@ class TestVariationImageGenerationClient:
         image_artifact = image_generator.image_variation_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
                 }
             }
         )
 
         assert image_artifact
 
-    def test_image_variation_with_outfile(self, image_generation_engine, image_loader) -> None:
+    def test_image_variation_with_outfile(self, image_generation_engine, image_loader, path_from_resource_path) -> None:
         outfile = f"{tempfile.gettempdir()}/{str(uuid.uuid4())}.png"
         image_generator = VariationImageGenerationClient(
             engine=image_generation_engine, output_file=outfile, image_loader=image_loader
@@ -61,9 +61,9 @@ class TestVariationImageGenerationClient:
         image_artifact = image_generator.image_variation_from_file(
             params={
                 "values": {
-                    "prompts": ["test prompt"],
-                    "negative_prompts": ["test negative prompt"],
-                    "image_file": "image.png",
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "image_file": path_from_resource_path("small.png"),
                 }
             }
         )

--- a/tests/unit/tools/test_variation_image_generation_client.py
+++ b/tests/unit/tools/test_variation_image_generation_client.py
@@ -11,6 +11,10 @@ from griptape.tools import VariationImageGenerationClient
 
 class TestVariationImageGenerationClient:
     @pytest.fixture()
+    def image_artifact(self) -> ImageArtifact:
+        return ImageArtifact(value=b"image_data", format="png", width=512, height=512, name="name")
+
+    @pytest.fixture()
     def image_generation_engine(self) -> Mock:
         return Mock()
 
@@ -70,3 +74,27 @@ class TestVariationImageGenerationClient:
 
         assert image_artifact
         assert os.path.exists(outfile)
+
+    def test_image_variation_from_memory(self, image_generation_engine, image_artifact):
+        image_generator = VariationImageGenerationClient(engine=image_generation_engine)
+        memory = Mock()
+        memory.load_artifacts = Mock(return_value=[image_artifact])
+        image_generator.find_input_memory = Mock(return_value=memory)
+
+        image_generator.engine.run.return_value = Mock(  # pyright: ignore[reportFunctionMemberAccess]
+            value=b"image data", format="png", width=512, height=512, model="test model", prompt="test prompt"
+        )
+
+        image_artifact = image_generator.image_variation_from_memory(
+            params={
+                "values": {
+                    "prompt": "test prompt",
+                    "negative_prompt": "test negative prompt",
+                    "artifact_namespace": "namespace",
+                    "artifact_name": "name",
+                    "memory_name": "memory",
+                }
+            }
+        )
+
+        assert image_artifact


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

This change primarily updates the schema descriptions of positive and negative prompts for image generation tools. Past experience has shown that models can be confused by the more complex prompt schema being replaced here. In cases where the wrong prompt schema was provided to a tool, the likely outcome was an empty prompt sent to the image generation model which would then return an irrelevant and undesirable image.

By replacing the more complex prompt schema (`{values: {prompts: [prompt1, prompt2, ...]}}`) with a single prompt string (`{values: {prompt: "prompt1, prompt2"}}`), models are more likely to correctly format activity inputs.

Other changes here include correctly loading input image artifacts from files after a previous update to how the ImageLoader.load() method works, factoring out some duplicated code, and improvements to schema descriptions of image generation tools, as well as pyright, linting, and formatting changes.