### PR TITLE
Fix Conversation Memory Autoload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Conversation Memory not using `StructureConfig.conversation_memory_driver` when autoloading.
 
 ## [0.29.0] - 2024-07-30
 

--- a/docs/griptape-framework/drivers/conversation-memory-drivers.md
+++ b/docs/griptape-framework/drivers/conversation-memory-drivers.md
@@ -19,7 +19,7 @@ from griptape.drivers import LocalConversationMemoryDriver
 from griptape.memory.structure import ConversationMemory
 
 local_driver = LocalConversationMemoryDriver(file_path="memory.json")
-agent = Agent(conversation_memory=ConversationMemory(driver=local_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=local_driver))
 
 agent.run("Surfing is my favorite sport.")
 agent.run("What is my favorite sport?")
@@ -47,7 +47,7 @@ dynamodb_driver = AmazonDynamoDbConversationMemoryDriver(
     partition_key_value=conversation_id,
 )
 
-agent = Agent(conversation_memory=ConversationMemory(driver=dynamodb_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=dynamodb_driver))
 
 agent.run("My name is Jeff.")
 agent.run("What is my name?")
@@ -78,7 +78,7 @@ redis_conversation_driver = RedisConversationMemoryDriver(
     conversation_id = conversation_id
 )
 
-agent = Agent(conversation_memory=ConversationMemory(driver=redis_conversation_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=redis_conversation_driver))
 
 agent.run("My name is Jeff.")
 agent.run("What is my name?")

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -62,7 +62,7 @@ class Structure(ABC, EventPublisherMixin):
     logger_level: int = field(default=logging.INFO, kw_only=True)
     conversation_memory: Optional[BaseConversationMemory] = field(
         default=Factory(
-            lambda self: ConversationMemory(driver=self.config.conversation_memory_driver),
+            lambda self: ConversationMemory(conversation_memory_driver=self.config.conversation_memory_driver),
             takes_self=True,
         ),
         kw_only=True,
@@ -96,6 +96,8 @@ class Structure(ABC, EventPublisherMixin):
     def __attrs_post_init__(self) -> None:
         if self.conversation_memory is not None:
             self.conversation_memory.structure = self
+            if self.conversation_memory.autoload:
+                self.conversation_memory.load()
 
         self.config.structure = self
 

--- a/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
@@ -48,7 +48,7 @@ class TestDynamoDbConversationMemoryDriver:
             value_attribute_key=self.VALUE_ATTRIBUTE_KEY,
             partition_key_value=self.PARTITION_KEY_VALUE,
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -75,7 +75,7 @@ class TestDynamoDbConversationMemoryDriver:
             sort_key="sortKey",
             sort_key_value="foo",
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -97,7 +97,7 @@ class TestDynamoDbConversationMemoryDriver:
             value_attribute_key=self.VALUE_ATTRIBUTE_KEY,
             partition_key_value=self.PARTITION_KEY_VALUE,
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -123,7 +123,7 @@ class TestDynamoDbConversationMemoryDriver:
             sort_key="sortKey",
             sort_key_value="foo",
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))

--- a/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
@@ -24,7 +24,7 @@ class TestLocalConversationMemoryDriver:
     def test_store(self):
         prompt_driver = MockPromptDriver()
         memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
-        memory = ConversationMemory(driver=memory_driver, autoload=False)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver, autoload=False)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -43,7 +43,7 @@ class TestLocalConversationMemoryDriver:
     def test_load(self):
         prompt_driver = MockPromptDriver()
         memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
-        memory = ConversationMemory(driver=memory_driver, autoload=False, max_runs=5)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver, autoload=False, max_runs=5)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -62,7 +62,7 @@ class TestLocalConversationMemoryDriver:
     def test_autoload(self):
         prompt_driver = MockPromptDriver()
         memory_driver = LocalConversationMemoryDriver(file_path=self.MEMORY_FILE_PATH)
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(prompt_driver=prompt_driver, conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -70,7 +70,7 @@ class TestLocalConversationMemoryDriver:
         pipeline.run()
         pipeline.run()
 
-        autoloaded_memory = ConversationMemory(driver=memory_driver)
+        autoloaded_memory = ConversationMemory(conversation_memory_driver=memory_driver)
 
         assert autoloaded_memory.type == "ConversationMemory"
         assert len(autoloaded_memory.runs) == 2


### PR DESCRIPTION
[x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Refactors Conversation Memory to support using a Driver set in Structure Config. For instance:

```python
from griptape.config import OpenAiStructureConfig
from griptape.structures import Agent
from griptape.memory.structure import ConversationMemory
from griptape.drivers import LocalConversationMemoryDriver

agent = Agent(
    config=OpenAiStructureConfig(
        conversation_memory_driver=LocalConversationMemoryDriver(),
    ),
    conversation_memory=ConversationMemory(),
)

agent.run("My name is Collin")
agent.run("What is my name")
```
## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1033.org.readthedocs.build//1033/

<!-- readthedocs-preview griptape end -->