### PR TITLE
Add structure to Task init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `AstraDbVectorStoreDriver` to support DataStax Astra DB as a vector store.
 - Ability to set custom schema properties on Tool Activities via `extra_schema_properties`.
+- Parameter `structure` to `BaseTask`.
+- Method `try_find_task` to `Structure`.
+
+### Changed
+- `BaseTask.add_parent/child` will now call `self.structure.add_task` if possible.
 
 ## [0.29.0] - 2024-07-30
 

--- a/docs/griptape-framework/structures/workflows.md
+++ b/docs/griptape-framework/structures/workflows.md
@@ -269,17 +269,16 @@ from griptape.tasks import PromptTask
 from griptape.structures import Workflow
 from griptape.rules import Rule
 
-animal_task = PromptTask("Name an animal", id="animal")
-adjective_task = PromptTask("Describe {{ parent_outputs['animal'] }} with an adjective", id="adjective")
-new_animal_task = PromptTask("Name a {{ parent_outputs['adjective'] }} animal", id="new-animal")
+workflow = Workflow(
+    rules=[Rule("output a single lowercase word")],
+)
+
+animal_task = PromptTask("Name an animal", id="animal", structure=workflow)
+adjective_task = PromptTask("Describe {{ parent_outputs['animal'] }} with an adjective", id="adjective", structure=workflow)
+new_animal_task = PromptTask("Name a {{ parent_outputs['adjective'] }} animal", id="new-animal", structure=workflow)
 
 adjective_task.add_parent(animal_task)
 adjective_task.add_child(new_animal_task)
-
-workflow = Workflow(
-    tasks=[animal_task, adjective_task, new_animal_task],
-    rules=[Rule("output a single lowercase word")],
-)
 
 workflow.run()
 ```

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 @define
 class Pipeline(Structure):
     def add_task(self, task: BaseTask) -> BaseTask:
+        if (existing_task := self.try_find_task(task.id)) is not None:
+            return existing_task
+
         task.preprocess(self)
 
         if self.output_task:

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -23,10 +23,17 @@ class Workflow(Structure):
     )
 
     @property
+    def input_task(self) -> Optional[BaseTask]:
+        return self.order_tasks()[0] if self.tasks else None
+
+    @property
     def output_task(self) -> Optional[BaseTask]:
         return self.order_tasks()[-1] if self.tasks else None
 
     def add_task(self, task: BaseTask) -> BaseTask:
+        if (existing_task := self.try_find_task(task.id)) is not None:
+            return existing_task
+
         task.preprocess(self)
 
         self.tasks.append(task)

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -64,6 +64,18 @@ class ActionsSubtask(BaseTask):
         else:
             raise Exception("ActionSubtask must be attached to a Task that implements ActionSubtaskOriginMixin.")
 
+    def add_child(self, child: str | BaseTask) -> None:
+        child_id = child if isinstance(child, str) else child.id
+
+        if child_id not in self.child_ids:
+            self.child_ids.append(child_id)
+
+    def add_parent(self, parent: str | BaseTask) -> None:
+        parent_id = parent if isinstance(parent, str) else parent.id
+
+        if parent_id not in self.parent_ids:
+            self.parent_ids.append(parent_id)
+
     def attach_to(self, parent_task: BaseTask) -> None:
         self.parent_task_id = parent_task.id
         self.structure = parent_task.structure

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -84,34 +84,32 @@ class BaseTask(ABC):
             self.add_parent(parent)
 
     def add_parent(self, parent: str | BaseTask) -> None:
-        parent_task = parent if isinstance(parent, BaseTask) else None
         parent_id = parent if isinstance(parent, str) else parent.id
 
         if parent_id not in self.parent_ids:
             self.parent_ids.append(parent_id)
 
-        if parent_task is not None:
-            parent_task.add_child(self.id)
+        if isinstance(parent, BaseTask):
+            parent.add_child(self.id)
 
             if self.structure is not None:
-                self.structure.add_task(parent_task)
+                self.structure.add_task(parent)
 
     def add_children(self, children: list[str | BaseTask]) -> None:
         for child in children:
             self.add_child(child)
 
     def add_child(self, child: str | BaseTask) -> None:
-        child_task = child if isinstance(child, BaseTask) else None
         child_id = child if isinstance(child, str) else child.id
 
         if child_id not in self.child_ids:
             self.child_ids.append(child_id)
 
-        if child_task is not None:
-            child_task.add_parent(self.id)
+        if isinstance(child, BaseTask):
+            child.add_parent(self.id)
 
             if self.structure is not None:
-                self.structure.add_task(child_task)
+                self.structure.add_task(child)
 
     def preprocess(self, structure: Structure) -> BaseTask:
         self.structure = structure

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -199,6 +199,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
 
     def add_subtask(self, subtask: ActionsSubtask) -> ActionsSubtask:
         subtask.attach_to(self)
+        subtask.structure = self.structure
 
         if len(self.subtasks) > 0:
             self.subtasks[-1].add_child(subtask)

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -390,3 +390,22 @@ class TestPipeline:
         pipeline.run()
 
         assert pipeline.output is not None
+
+    def test_add_duplicate_task(self):
+        task = PromptTask("test")
+        pipeline = Pipeline(prompt_driver=MockPromptDriver())
+
+        pipeline + task
+        pipeline + task
+
+        assert len(pipeline.tasks) == 1
+
+    def test_add_duplicate_task_directly(self):
+        task = PromptTask("test")
+        pipeline = Pipeline(prompt_driver=MockPromptDriver())
+
+        pipeline + task
+        pipeline.tasks.append(task)
+
+        with pytest.raises(ValueError, match=f"Duplicate task with id {task.id} found."):
+            pipeline.run()

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -321,6 +321,34 @@ class TestWorkflow:
 
         self._validate_topology_1(workflow)
 
+    def test_run_topology_1_imperative_parents_structure_init(self):
+        workflow = Workflow(prompt_driver=MockPromptDriver())
+        task1 = PromptTask("test1", id="task1")
+        task2 = PromptTask("test2", id="task2", structure=workflow)
+        task3 = PromptTask("test3", id="task3", structure=workflow)
+        task4 = PromptTask("test4", id="task4", structure=workflow)
+        task2.add_parent(task1)
+        task3.add_parent("task1")
+        task4.add_parents([task2, "task3"])
+
+        workflow.run()
+
+        self._validate_topology_1(workflow)
+
+    def test_run_topology_1_imperative_children_structure_init(self):
+        workflow = Workflow(prompt_driver=MockPromptDriver())
+        task1 = PromptTask("test1", id="task1", structure=workflow)
+        task2 = PromptTask("test2", id="task2", structure=workflow)
+        task3 = PromptTask("test3", id="task3", structure=workflow)
+        task4 = PromptTask("test4", id="task4")
+        task1.add_children([task2, task3])
+        task2.add_child(task4)
+        task3.add_child(task4)
+
+        workflow.run()
+
+        self._validate_topology_1(workflow)
+
     def test_run_topology_1_imperative_mixed(self):
         task1 = PromptTask("test1", id="task1")
         task2 = PromptTask("test2", id="task2")
@@ -781,8 +809,6 @@ class TestWorkflow:
         assert len(workflow.tasks) == 4
         assert workflow.input_task.id == "task1"
         assert workflow.output_task.id == "task4"
-        assert workflow.input_task.id == workflow.tasks[0].id
-        assert workflow.output_task.id == workflow.tasks[-1].id
 
         task1 = workflow.find_task("task1")
         assert task1.state == BaseTask.State.FINISHED
@@ -810,8 +836,6 @@ class TestWorkflow:
         assert len(workflow.tasks) == 5
         assert workflow.input_task.id == "taska"
         assert workflow.output_task.id == "taske"
-        assert workflow.input_task.id == workflow.tasks[0].id
-        assert workflow.output_task.id == workflow.tasks[-1].id
 
         taska = workflow.find_task("taska")
         assert taska.state == BaseTask.State.FINISHED
@@ -843,9 +867,6 @@ class TestWorkflow:
         assert len(workflow.tasks) == 4
         assert workflow.input_task.id == "task1"
         assert workflow.output_task.id == "task3"
-        assert workflow.input_task.id == workflow.tasks[0].id
-        assert workflow.output_task.id == workflow.tasks[-1].id
-
         task1 = workflow.find_task("task1")
         assert task1.state == BaseTask.State.FINISHED
         assert task1.parent_ids == []
@@ -871,8 +892,6 @@ class TestWorkflow:
         assert len(workflow.tasks) == 9
         assert workflow.input_task.id == "collect_movie_info"
         assert workflow.output_task.id == "summarize_to_slack"
-        assert workflow.input_task.id == workflow.tasks[0].id
-        assert workflow.output_task.id == workflow.tasks[-1].id
 
         collect_movie_info = workflow.find_task("collect_movie_info")
         assert collect_movie_info.parent_ids == []

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -809,6 +809,8 @@ class TestWorkflow:
         assert len(workflow.tasks) == 4
         assert workflow.input_task.id == "task1"
         assert workflow.output_task.id == "task4"
+        assert workflow.input_task.id == workflow.order_tasks()[0].id
+        assert workflow.output_task.id == workflow.order_tasks()[-1].id
 
         task1 = workflow.find_task("task1")
         assert task1.state == BaseTask.State.FINISHED
@@ -856,6 +858,8 @@ class TestWorkflow:
         assert taskd.state == BaseTask.State.FINISHED
         assert sorted(taskd.parent_ids) == ["taska", "taskb", "taskc"]
         assert taskd.child_ids == ["taske"]
+        assert workflow.input_task.id == workflow.order_tasks()[0].id
+        assert workflow.output_task.id == workflow.order_tasks()[-1].id
 
         taske = workflow.find_task("taske")
         assert taske.state == BaseTask.State.FINISHED
@@ -876,6 +880,8 @@ class TestWorkflow:
         assert task2.state == BaseTask.State.FINISHED
         assert task2.parent_ids == ["task4"]
         assert task2.child_ids == ["task3"]
+        assert workflow.input_task.id == workflow.order_tasks()[0].id
+        assert workflow.output_task.id == workflow.order_tasks()[-1].id
 
         task3 = workflow.find_task("task3")
         assert task3.state == BaseTask.State.FINISHED
@@ -892,6 +898,8 @@ class TestWorkflow:
         assert len(workflow.tasks) == 9
         assert workflow.input_task.id == "collect_movie_info"
         assert workflow.output_task.id == "summarize_to_slack"
+        assert workflow.input_task.id == workflow.order_tasks()[0].id
+        assert workflow.output_task.id == workflow.order_tasks()[-1].id
 
         collect_movie_info = workflow.find_task("collect_movie_info")
         assert collect_movie_info.parent_ids == []

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -76,6 +76,44 @@ class TestBaseTask:
 
         assert child.parents_output_text == "foobar1\nfoobar3"
 
+    def test_parents_property_no_structure(self, task):
+        workflow = Workflow()
+        task1 = MockTask("foobar1", id="foobar1")
+        task2 = MockTask("foobar2", id="foobar2")
+        task3 = MockTask("foobar3", id="foobar3")
+        child = MockTask("foobar", id="foobar")
+
+        child.add_parent(task1)
+        child.add_parent(task2)
+        child.add_parent(task3)
+
+        with pytest.raises(ValueError, match="Structure must be set to access parents"):
+            child.parents  # noqa: B018
+
+        workflow.add_tasks(task1, task2, task3, child)
+        child.structure = workflow
+
+        assert len(child.parents) == 3
+
+    def test_children_property_no_structure(self, task):
+        workflow = Workflow()
+        task1 = MockTask("foobar1", id="foobar1")
+        task2 = MockTask("foobar2", id="foobar2")
+        task3 = MockTask("foobar3", id="foobar3")
+        parent = MockTask("foobar", id="foobar")
+
+        parent.add_child(task1)
+        parent.add_child(task2)
+        parent.add_child(task3)
+
+        with pytest.raises(ValueError, match="Structure must be set to access children"):
+            parent.children  # noqa: B018
+
+        workflow.add_tasks(task1, task2, task3, parent)
+        parent.structure = workflow
+
+        assert len(parent.children) == 3
+
     def test_execute_publish_events(self, task):
         task.execute()
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
- adds `structure` parameter to `Task` init, and updates `add_parent/child` methods to add the `task` to the `structure` if it exists.

## Issue ticket number and link
improves syntax: #896 
