### PR TITLE
Add PromptEngine that adds events to PromptDrivers

### DIFF
--- a/griptape/config/base_structure_config.py
+++ b/griptape/config/base_structure_config.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Optional
 from attrs import define, field
 
 from griptape.config import BaseConfig
-from griptape.events import EventListener
-from griptape.mixins.event_publisher_mixin import EventPublisherMixin
 from griptape.utils import dict_merge
 
 if TYPE_CHECKING:
@@ -21,7 +19,6 @@ if TYPE_CHECKING:
         BaseTextToSpeechDriver,
         BaseVectorStoreDriver,
     )
-    from griptape.structures import Structure
 
 
 @define
@@ -38,43 +35,6 @@ class BaseStructureConfig(BaseConfig, ABC):
     )
     text_to_speech_driver: BaseTextToSpeechDriver = field(kw_only=True, metadata={"serializable": True})
     audio_transcription_driver: BaseAudioTranscriptionDriver = field(kw_only=True, metadata={"serializable": True})
-
-    _structure: Structure = field(default=None, kw_only=True, alias="structure")
-    _event_listener: Optional[EventListener] = field(default=None, kw_only=True, alias="event_listener")
-
-    @property
-    def drivers(self) -> list:
-        return [
-            self.prompt_driver,
-            self.image_generation_driver,
-            self.image_query_driver,
-            self.embedding_driver,
-            self.vector_store_driver,
-            self.conversation_memory_driver,
-            self.text_to_speech_driver,
-            self.audio_transcription_driver,
-        ]
-
-    @property
-    def structure(self) -> Optional[Structure]:
-        return self._structure
-
-    @structure.setter
-    def structure(self, structure: Structure) -> None:
-        if structure != self.structure:
-            event_publisher_drivers = [
-                driver for driver in self.drivers if driver is not None and isinstance(driver, EventPublisherMixin)
-            ]
-
-            for driver in event_publisher_drivers:
-                if self._event_listener is not None:
-                    driver.remove_event_listener(self._event_listener)
-
-            self._event_listener = EventListener(structure.publish_event)
-            for driver in event_publisher_drivers:
-                driver.add_event_listener(self._event_listener)
-
-        self._structure = structure
 
     def merge_config(self, config: dict) -> BaseStructureConfig:
         base_config = self.to_dict()

--- a/griptape/config/base_structure_config.py
+++ b/griptape/config/base_structure_config.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Optional
 from attrs import define, field
 
 from griptape.config import BaseConfig
+from griptape.events import EventListener
+from griptape.mixins.event_publisher_mixin import EventPublisherMixin
 from griptape.utils import dict_merge
 
 if TYPE_CHECKING:
@@ -19,6 +21,7 @@ if TYPE_CHECKING:
         BaseTextToSpeechDriver,
         BaseVectorStoreDriver,
     )
+    from griptape.structures import Structure
 
 
 @define
@@ -35,6 +38,43 @@ class BaseStructureConfig(BaseConfig, ABC):
     )
     text_to_speech_driver: BaseTextToSpeechDriver = field(kw_only=True, metadata={"serializable": True})
     audio_transcription_driver: BaseAudioTranscriptionDriver = field(kw_only=True, metadata={"serializable": True})
+
+    _structure: Structure = field(default=None, kw_only=True, alias="structure")
+    _event_listener: Optional[EventListener] = field(default=None, kw_only=True, alias="event_listener")
+
+    @property
+    def drivers(self) -> list:
+        return [
+            self.prompt_driver,
+            self.image_generation_driver,
+            self.image_query_driver,
+            self.embedding_driver,
+            self.vector_store_driver,
+            self.conversation_memory_driver,
+            self.text_to_speech_driver,
+            self.audio_transcription_driver,
+        ]
+
+    @property
+    def structure(self) -> Optional[Structure]:
+        return self._structure
+
+    @structure.setter
+    def structure(self, structure: Structure) -> None:
+        if structure != self.structure:
+            event_publisher_drivers = [
+                driver for driver in self.drivers if driver is not None and isinstance(driver, EventPublisherMixin)
+            ]
+
+            for driver in event_publisher_drivers:
+                if self._event_listener is not None:
+                    driver.remove_event_listener(self._event_listener)
+
+            self._event_listener = EventListener(structure.publish_event)
+            for driver in event_publisher_drivers:
+                driver.add_event_listener(self._event_listener)
+
+        self._structure = structure
 
     def merge_config(self, config: dict) -> BaseStructureConfig:
         base_config = self.to_dict()

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -56,8 +56,8 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
     use_native_tools: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     tool_choice: dict = field(default=Factory(lambda: {"auto": {}}), kw_only=True, metadata={"serializable": True})
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
         response = self.bedrock_client.converse(**self._base_params(prompt_stack))
 
         usage = response["usage"]
@@ -69,8 +69,8 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=usage["inputTokens"], output_tokens=usage["outputTokens"]),
         )
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         response = self.bedrock_client.converse_stream(**self._base_params(prompt_stack))
 
         stream = response.get("stream")

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -71,8 +71,8 @@ class AnthropicPromptDriver(BasePromptDriver):
     use_native_tools: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     max_tokens: int = field(default=1000, kw_only=True, metadata={"serializable": True})
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
         response = self.client.messages.create(**self._base_params(prompt_stack))
 
         return Message(
@@ -81,8 +81,8 @@ class AnthropicPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=response.usage.input_tokens, output_tokens=response.usage.output_tokens),
         )
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         events = self.client.messages.create(**self._base_params(prompt_stack), stream=True)
 
         for event in events:

--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -52,8 +52,8 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
         ),
     )
 
-    def _base_params(self, prompt_stack: PromptStack) -> dict:
-        params = super()._base_params(prompt_stack)
+    def _base_params(self, prompt_stack: PromptStack, *, stream: bool) -> dict:
+        params = super()._base_params(prompt_stack, stream=stream)
         # TODO: Add `seed` parameter once Azure supports it.
         if "seed" in params:
             del params["seed"]

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -5,28 +5,21 @@ from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
 
-from griptape.common import (
-    ActionCallDeltaMessageContent,
-    ActionCallMessageContent,
-    BaseDeltaMessageContent,
-    DeltaMessage,
-    Message,
-    PromptStack,
-    TextDeltaMessageContent,
-    TextMessageContent,
-    observable,
-)
-from griptape.events import CompletionChunkEvent, FinishPromptEvent, StartPromptEvent
-from griptape.mixins import EventPublisherMixin, ExponentialBackoffMixin, SerializableMixin
+from griptape.mixins import SerializableMixin
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from griptape.common import (
+        DeltaMessage,
+        Message,
+        PromptStack,
+    )
     from griptape.tokenizers import BaseTokenizer
 
 
 @define(kw_only=True)
-class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, EventPublisherMixin, ABC):
+class BasePromptDriver(SerializableMixin, ABC):
     """Base class for the Prompt Drivers.
 
     Attributes:
@@ -45,35 +38,13 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, EventPublishe
     ignored_exception_types: tuple[type[Exception], ...] = field(default=Factory(lambda: (ImportError, ValueError)))
     model: str = field(metadata={"serializable": True})
     tokenizer: BaseTokenizer
-    stream: bool = field(default=False, kw_only=True, metadata={"serializable": True})
     use_native_tools: bool = field(default=False, kw_only=True, metadata={"serializable": True})
 
-    def before_run(self, prompt_stack: PromptStack) -> None:
-        self.publish_event(StartPromptEvent(model=self.model, prompt_stack=prompt_stack))
+    @abstractmethod
+    def run(self, prompt_stack: PromptStack) -> Message: ...
 
-    def after_run(self, result: Message) -> None:
-        self.publish_event(
-            FinishPromptEvent(
-                model=self.model,
-                result=result.value,
-                input_token_count=result.usage.input_tokens,
-                output_token_count=result.usage.output_tokens,
-            ),
-        )
-
-    @observable(tags=["PromptDriver.run()"])
-    def run(self, prompt_stack: PromptStack) -> Message:
-        for attempt in self.retrying():
-            with attempt:
-                self.before_run(prompt_stack)
-
-                result = self.__process_stream(prompt_stack) if self.stream else self.__process_run(prompt_stack)
-
-                self.after_run(result)
-
-                return result
-        else:
-            raise Exception("prompt driver failed after all retry attempts")
+    @abstractmethod
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]: ...
 
     def prompt_stack_to_string(self, prompt_stack: PromptStack) -> str:
         """Converts a Prompt Stack to a string for token counting or model input.
@@ -100,63 +71,3 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, EventPublishe
         prompt_lines.append("Assistant:")
 
         return "\n\n".join(prompt_lines)
-
-    @abstractmethod
-    def try_run(self, prompt_stack: PromptStack) -> Message: ...
-
-    @abstractmethod
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]: ...
-
-    def __process_run(self, prompt_stack: PromptStack) -> Message:
-        result = self.try_run(prompt_stack)
-
-        return result
-
-    def __process_stream(self, prompt_stack: PromptStack) -> Message:
-        delta_contents: dict[int, list[BaseDeltaMessageContent]] = {}
-        usage = DeltaMessage.Usage()
-
-        # Aggregate all content deltas from the stream
-        message_deltas = self.try_stream(prompt_stack)
-        for message_delta in message_deltas:
-            usage += message_delta.usage
-            content = message_delta.content
-
-            if content is not None:
-                if content.index in delta_contents:
-                    delta_contents[content.index].append(content)
-                else:
-                    delta_contents[content.index] = [content]
-                if isinstance(content, TextDeltaMessageContent):
-                    self.publish_event(CompletionChunkEvent(token=content.text))
-                elif isinstance(content, ActionCallDeltaMessageContent):
-                    if content.tag is not None and content.name is not None and content.path is not None:
-                        self.publish_event(CompletionChunkEvent(token=str(content)))
-                    elif content.partial_input is not None:
-                        self.publish_event(CompletionChunkEvent(token=content.partial_input))
-
-        # Build a complete content from the content deltas
-        result = self.__build_message(list(delta_contents.values()), usage)
-
-        return result
-
-    def __build_message(
-        self, delta_contents: list[list[BaseDeltaMessageContent]], usage: DeltaMessage.Usage
-    ) -> Message:
-        content = []
-        for delta_content in delta_contents:
-            text_deltas = [delta for delta in delta_content if isinstance(delta, TextDeltaMessageContent)]
-            action_deltas = [delta for delta in delta_content if isinstance(delta, ActionCallDeltaMessageContent)]
-
-            if text_deltas:
-                content.append(TextMessageContent.from_deltas(text_deltas))
-            if action_deltas:
-                content.append(ActionCallMessageContent.from_deltas(action_deltas))
-
-        result = Message(
-            content=content,
-            role=Message.ASSISTANT_ROLE,
-            usage=Message.Usage(input_tokens=usage.input_tokens, output_tokens=usage.output_tokens),
-        )
-
-        return result

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -54,8 +54,8 @@ class CoherePromptDriver(BasePromptDriver):
     force_single_step: bool = field(default=False, kw_only=True, metadata={"serializable": True})
     use_native_tools: bool = field(default=True, kw_only=True, metadata={"serializable": True})
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
         result = self.client.chat(**self._base_params(prompt_stack))
         usage = result.meta.tokens
 
@@ -65,8 +65,8 @@ class CoherePromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=usage.input_tokens, output_tokens=usage.output_tokens),
         )
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         result = self.client.chat_stream(**self._base_params(prompt_stack))
 
         for event in result:

--- a/griptape/drivers/prompt/dummy_prompt_driver.py
+++ b/griptape/drivers/prompt/dummy_prompt_driver.py
@@ -20,10 +20,10 @@ class DummyPromptDriver(BasePromptDriver):
     model: None = field(init=False, default=None, kw_only=True)
     tokenizer: DummyTokenizer = field(default=Factory(lambda: DummyTokenizer()), kw_only=True)
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
-        raise DummyError(__class__.__name__, "try_run")
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
+        raise DummyError(__class__.__name__, "run")
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
-        raise DummyError(__class__.__name__, "try_stream")
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+        raise DummyError(__class__.__name__, "stream")

--- a/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
@@ -50,8 +50,8 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
         kw_only=True,
     )
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
         prompt = self.prompt_stack_to_string(prompt_stack)
 
         response = self.client.text_generation(
@@ -69,8 +69,8 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
             usage=Message.Usage(input_tokens=input_tokens, output_tokens=output_tokens),
         )
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         prompt = self.prompt_stack_to_string(prompt_stack)
 
         response = self.client.text_generation(

--- a/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
@@ -47,8 +47,8 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         ),
     )
 
-    @observable
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    @observable(tags=["PromptDriver.run()"])
+    def run(self, prompt_stack: PromptStack) -> Message:
         messages = self._prompt_stack_to_messages(prompt_stack)
 
         result = self.pipe(
@@ -76,8 +76,8 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         else:
             raise Exception("invalid output format")
 
-    @observable
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    @observable(tags=["PromptDriver.stream()"])
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         raise NotImplementedError("streaming is not supported")
 
     def prompt_stack_to_string(self, prompt_stack: PromptStack) -> str:

--- a/griptape/engines/__init__.py
+++ b/griptape/engines/__init__.py
@@ -11,6 +11,7 @@ from .image.outpainting_image_generation_engine import OutpaintingImageGeneratio
 from .image_query.image_query_engine import ImageQueryEngine
 from .audio.text_to_speech_engine import TextToSpeechEngine
 from .audio.audio_transcription_engine import AudioTranscriptionEngine
+from .prompt.prompt_engine import PromptEngine
 
 __all__ = [
     "BaseSummaryEngine",
@@ -26,4 +27,5 @@ __all__ = [
     "ImageQueryEngine",
     "TextToSpeechEngine",
     "AudioTranscriptionEngine",
+    "PromptEngine",
 ]

--- a/griptape/engines/extraction/base_extraction_engine.py
+++ b/griptape/engines/extraction/base_extraction_engine.py
@@ -9,7 +9,7 @@ from griptape.chunkers import BaseChunker, TextChunker
 
 if TYPE_CHECKING:
     from griptape.artifacts import ErrorArtifact, ListArtifact
-    from griptape.drivers import BasePromptDriver
+    from griptape.engines import PromptEngine
     from griptape.rules import Ruleset
 
 
@@ -17,10 +17,10 @@ if TYPE_CHECKING:
 class BaseExtractionEngine(ABC):
     max_token_multiplier: float = field(default=0.5, kw_only=True)
     chunk_joiner: str = field(default="\n\n", kw_only=True)
-    prompt_driver: BasePromptDriver = field(kw_only=True)
+    prompt_engine: PromptEngine = field(kw_only=True)
     chunker: BaseChunker = field(
         default=Factory(
-            lambda self: TextChunker(tokenizer=self.prompt_driver.tokenizer, max_tokens=self.max_chunker_tokens),
+            lambda self: TextChunker(tokenizer=self.prompt_engine.tokenizer, max_tokens=self.max_chunker_tokens),
             takes_self=True,
         ),
         kw_only=True,
@@ -35,13 +35,13 @@ class BaseExtractionEngine(ABC):
 
     @property
     def max_chunker_tokens(self) -> int:
-        return round(self.prompt_driver.tokenizer.max_input_tokens * self.max_token_multiplier)
+        return round(self.prompt_engine.tokenizer.max_input_tokens * self.max_token_multiplier)
 
     @property
     def min_response_tokens(self) -> int:
         return round(
-            self.prompt_driver.tokenizer.max_input_tokens
-            - self.prompt_driver.tokenizer.max_input_tokens * self.max_token_multiplier,
+            self.prompt_engine.tokenizer.max_input_tokens
+            - self.prompt_engine.tokenizer.max_input_tokens * self.max_token_multiplier,
         )
 
     @abstractmethod

--- a/griptape/engines/extraction/csv_extraction_engine.py
+++ b/griptape/engines/extraction/csv_extraction_engine.py
@@ -66,10 +66,10 @@ class CsvExtractionEngine(BaseExtractionEngine):
             rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
         )
 
-        if self.prompt_driver.tokenizer.count_input_tokens_left(full_text) >= self.min_response_tokens:
+        if self.prompt_engine.tokenizer.count_input_tokens_left(full_text) >= self.min_response_tokens:
             rows.extend(
                 self.text_to_csv_rows(
-                    self.prompt_driver.run(PromptStack(messages=[Message(full_text, role=Message.USER_ROLE)])).value,
+                    self.prompt_engine.run(PromptStack(messages=[Message(full_text, role=Message.USER_ROLE)])).value,
                     column_names,
                 ),
             )
@@ -85,7 +85,7 @@ class CsvExtractionEngine(BaseExtractionEngine):
 
             rows.extend(
                 self.text_to_csv_rows(
-                    self.prompt_driver.run(PromptStack(messages=[Message(partial_text, role=Message.USER_ROLE)])).value,
+                    self.prompt_engine.run(PromptStack(messages=[Message(partial_text, role=Message.USER_ROLE)])).value,
                     column_names,
                 ),
             )

--- a/griptape/engines/extraction/json_extraction_engine.py
+++ b/griptape/engines/extraction/json_extraction_engine.py
@@ -61,10 +61,10 @@ class JsonExtractionEngine(BaseExtractionEngine):
             rulesets=J2("rulesets/rulesets.j2").render(rulesets=rulesets),
         )
 
-        if self.prompt_driver.tokenizer.count_input_tokens_left(full_text) >= self.min_response_tokens:
+        if self.prompt_engine.tokenizer.count_input_tokens_left(full_text) >= self.min_response_tokens:
             extractions.extend(
                 self.json_to_text_artifacts(
-                    self.prompt_driver.run(PromptStack(messages=[Message(full_text, role=Message.USER_ROLE)])).value,
+                    self.prompt_engine.run(PromptStack(messages=[Message(full_text, role=Message.USER_ROLE)])).value,
                 ),
             )
 
@@ -79,7 +79,7 @@ class JsonExtractionEngine(BaseExtractionEngine):
 
             extractions.extend(
                 self.json_to_text_artifacts(
-                    self.prompt_driver.run(PromptStack(messages=[Message(partial_text, role=Message.USER_ROLE)])).value,
+                    self.prompt_engine.run(PromptStack(messages=[Message(partial_text, role=Message.USER_ROLE)])).value,
                 ),
             )
 

--- a/griptape/engines/prompt/prompt_engine.py
+++ b/griptape/engines/prompt/prompt_engine.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import TYPE_CHECKING
+
+from attrs import define, field
+
+from griptape.common import (
+    ActionCallDeltaMessageContent,
+    ActionCallMessageContent,
+    BaseDeltaMessageContent,
+    DeltaMessage,
+    Message,
+    PromptStack,
+    TextDeltaMessageContent,
+    TextMessageContent,
+)
+from griptape.events import CompletionChunkEvent, FinishPromptEvent, StartPromptEvent
+from griptape.mixins import EventPublisherMixin, ExponentialBackoffMixin, SerializableMixin
+
+if TYPE_CHECKING:
+    from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
+    from griptape.tokenizers.base_tokenizer import BaseTokenizer
+
+
+@define(kw_only=True)
+class PromptEngine(SerializableMixin, ExponentialBackoffMixin, EventPublisherMixin, ABC):
+    prompt_driver: BasePromptDriver = field(metadata={"serializable": True})
+    stream: bool = field(default=False, kw_only=True, metadata={"serializable": True})
+
+    @property
+    def tokenizer(self) -> BaseTokenizer:
+        return self.prompt_driver.tokenizer
+
+    def before_run(self, prompt_stack: PromptStack) -> None:
+        self.publish_event(StartPromptEvent(model=self.prompt_driver.model, prompt_stack=prompt_stack))
+
+    def after_run(self, result: Message) -> None:
+        self.publish_event(
+            FinishPromptEvent(
+                model=self.prompt_driver.model,
+                result=result.value,
+                input_token_count=result.usage.input_tokens,
+                output_token_count=result.usage.output_tokens,
+            ),
+        )
+
+    def run(self, prompt_stack: PromptStack) -> Message:
+        for attempt in self.retrying():
+            with attempt:
+                self.before_run(prompt_stack)
+
+                result = self.__process_stream(prompt_stack) if self.stream else self.__process_run(prompt_stack)
+
+                self.after_run(result)
+
+                return result
+        else:
+            raise Exception("prompt driver failed after all retry attempts")
+
+    def __process_run(self, prompt_stack: PromptStack) -> Message:
+        return self.prompt_driver.run(prompt_stack)
+
+    def __process_stream(self, prompt_stack: PromptStack) -> Message:
+        delta_contents: dict[int, list[BaseDeltaMessageContent]] = {}
+        usage = DeltaMessage.Usage()
+
+        # Aggregate all content deltas from the stream
+        message_deltas = self.prompt_driver.stream(prompt_stack)
+        for message_delta in message_deltas:
+            usage += message_delta.usage
+            content = message_delta.content
+
+            if content is not None:
+                if content.index in delta_contents:
+                    delta_contents[content.index].append(content)
+                else:
+                    delta_contents[content.index] = [content]
+                if isinstance(content, TextDeltaMessageContent):
+                    self.publish_event(CompletionChunkEvent(token=content.text))
+                elif isinstance(content, ActionCallDeltaMessageContent):
+                    if content.tag is not None and content.name is not None and content.path is not None:
+                        self.publish_event(CompletionChunkEvent(token=str(content)))
+                    elif content.partial_input is not None:
+                        self.publish_event(CompletionChunkEvent(token=content.partial_input))
+
+        # Build a complete content from the content deltas
+        result = self.__build_message(list(delta_contents.values()), usage)
+
+        return result
+
+    def __build_message(
+        self, delta_contents: list[list[BaseDeltaMessageContent]], usage: DeltaMessage.Usage
+    ) -> Message:
+        content = []
+        for delta_content in delta_contents:
+            text_deltas = [delta for delta in delta_content if isinstance(delta, TextDeltaMessageContent)]
+            action_deltas = [delta for delta in delta_content if isinstance(delta, ActionCallDeltaMessageContent)]
+
+            if text_deltas:
+                content.append(TextMessageContent.from_deltas(text_deltas))
+            if action_deltas:
+                content.append(ActionCallMessageContent.from_deltas(action_deltas))
+
+        result = Message(
+            content=content,
+            role=Message.ASSISTANT_ROLE,
+            usage=Message.Usage(input_tokens=usage.input_tokens, output_tokens=usage.output_tokens),
+        )
+
+        return result

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -101,6 +101,8 @@ class Structure(ABC, EventPublisherMixin):
         if self.conversation_memory is not None:
             self.conversation_memory.structure = self
 
+        self.config.structure = self
+
         tasks = self.tasks.copy()
         self.tasks.clear()
         self.add_tasks(*tasks)

--- a/griptape/tasks/csv_extraction_task.py
+++ b/griptape/tasks/csv_extraction_task.py
@@ -14,7 +14,7 @@ class CsvExtractionTask(ExtractionTask):
     def extraction_engine(self) -> CsvExtractionEngine:
         if self._extraction_engine is None:
             if self.structure is not None:
-                self._extraction_engine = CsvExtractionEngine(prompt_driver=self.structure.config.prompt_driver)
+                self._extraction_engine = CsvExtractionEngine(prompt_engine=self.structure.prompt_engine)
             else:
                 raise ValueError("Extraction Engine is not set.")
         return self._extraction_engine

--- a/griptape/tasks/json_extraction_task.py
+++ b/griptape/tasks/json_extraction_task.py
@@ -14,7 +14,7 @@ class JsonExtractionTask(ExtractionTask):
     def extraction_engine(self) -> JsonExtractionEngine:
         if self._extraction_engine is None:
             if self.structure is not None:
-                self._extraction_engine = JsonExtractionEngine(prompt_driver=self.structure.config.prompt_driver)
+                self._extraction_engine = JsonExtractionEngine(prompt_engine=self.structure.prompt_engine)
             else:
                 raise ValueError("Extraction Engine is not set.")
         return self._extraction_engine

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -20,7 +20,7 @@ class TextSummaryTask(BaseTextInputTask):
     def summary_engine(self) -> Optional[BaseSummaryEngine]:
         if self._summary_engine is None:
             if self.structure is not None:
-                self._summary_engine = PromptSummaryEngine(prompt_driver=self.structure.config.prompt_driver)
+                self._summary_engine = PromptSummaryEngine(prompt_engine=self.structure.prompt_engine)
             else:
                 raise ValueError("Summary Engine is not set.")
         return self._summary_engine

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -53,16 +53,16 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
             rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets),
             action_schema=utils.minify_json(json.dumps(self.tool.schema())),
             meta_memory=J2("memory/meta/meta_memory.j2").render(meta_memories=self.meta_memories),
-            use_native_tools=self.prompt_driver.use_native_tools,
+            use_native_tools=self.prompt_engine.prompt_driver.use_native_tools,
         )
 
     def actions_schema(self) -> Schema:
         return self._actions_schema_for_tools([self.tool])
 
     def run(self) -> BaseArtifact:
-        result = self.prompt_driver.run(prompt_stack=self.prompt_stack)
+        result = self.prompt_engine.run(prompt_stack=self.prompt_stack)
 
-        if self.prompt_driver.use_native_tools:
+        if self.prompt_engine.prompt_driver.use_native_tools:
             subtask_input = result.to_artifact()
         else:
             action_matches = re.findall(self.ACTION_PATTERN, result.to_text(), re.DOTALL)

--- a/tests/mocks/mock_failing_prompt_driver.py
+++ b/tests/mocks/mock_failing_prompt_driver.py
@@ -4,41 +4,22 @@ from typing import TYPE_CHECKING
 
 from attrs import define
 
-from griptape.artifacts import TextArtifact
-from griptape.common import DeltaMessage, Message, PromptStack, TextDeltaMessageContent, TextMessageContent
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer, OpenAiTokenizer
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from griptape.common import DeltaMessage, Message, PromptStack
+
 
 @define
 class MockFailingPromptDriver(BasePromptDriver):
-    max_failures: int
-    current_attempt: int = 0
     model: str = "test-model"
     tokenizer: BaseTokenizer = OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL)
 
-    def try_run(self, prompt_stack: PromptStack) -> Message:
-        if self.current_attempt < self.max_failures:
-            self.current_attempt += 1
+    def run(self, prompt_stack: PromptStack) -> Message:
+        raise Exception("failed attempt")
 
-            raise Exception("failed attempt")
-        else:
-            return Message(
-                content=[TextMessageContent(TextArtifact("success"))],
-                role=Message.ASSISTANT_ROLE,
-                usage=Message.Usage(input_tokens=100, output_tokens=100),
-            )
-
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
-        if self.current_attempt < self.max_failures:
-            self.current_attempt += 1
-
-            raise Exception("failed attempt")
-        else:
-            yield DeltaMessage(
-                content=TextDeltaMessageContent("success"),
-                usage=DeltaMessage.Usage(input_tokens=100, output_tokens=100),
-            )
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+        raise Exception("failed attempt")

--- a/tests/mocks/mock_prompt_driver.py
+++ b/tests/mocks/mock_prompt_driver.py
@@ -32,7 +32,7 @@ class MockPromptDriver(BasePromptDriver):
     mock_input: str | Callable[[], str] = field(default="mock input", kw_only=True)
     mock_output: str | Callable[[PromptStack], str] = field(default="mock output", kw_only=True)
 
-    def try_run(self, prompt_stack: PromptStack) -> Message:
+    def run(self, prompt_stack: PromptStack) -> Message:
         output = self.mock_output(prompt_stack) if isinstance(self.mock_output, Callable) else self.mock_output
         if self.use_native_tools and prompt_stack.tools:
             # Hack to simulate CoT. If there are any action messages in the prompt stack, give the answer.
@@ -69,7 +69,7 @@ class MockPromptDriver(BasePromptDriver):
                 usage=Message.Usage(input_tokens=100, output_tokens=100),
             )
 
-    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+    def stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         output = self.mock_output(prompt_stack) if isinstance(self.mock_output, Callable) else self.mock_output
 
         if self.use_native_tools and prompt_stack.tools:

--- a/tests/unit/config/test_amazon_bedrock_structure_config.py
+++ b/tests/unit/config/test_amazon_bedrock_structure_config.py
@@ -49,7 +49,6 @@ class TestAmazonBedrockStructureConfig:
             "prompt_driver": {
                 "max_tokens": None,
                 "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-                "stream": False,
                 "temperature": 0.1,
                 "type": "AmazonBedrockPromptDriver",
                 "tool_choice": {"auto": {}},
@@ -102,7 +101,6 @@ class TestAmazonBedrockStructureConfig:
             "prompt_driver": {
                 "max_tokens": None,
                 "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-                "stream": False,
                 "temperature": 0.1,
                 "type": "AmazonBedrockPromptDriver",
                 "tool_choice": {"auto": {}},

--- a/tests/unit/config/test_anthropic_structure_config.py
+++ b/tests/unit/config/test_anthropic_structure_config.py
@@ -20,7 +20,6 @@ class TestAnthropicStructureConfig:
                 "type": "AnthropicPromptDriver",
                 "temperature": 0.1,
                 "max_tokens": 1000,
-                "stream": False,
                 "model": "claude-3-5-sonnet-20240620",
                 "top_p": 0.999,
                 "top_k": 250,

--- a/tests/unit/config/test_azure_openai_structure_config.py
+++ b/tests/unit/config/test_azure_openai_structure_config.py
@@ -32,7 +32,6 @@ class TestAzureOpenAiStructureConfig:
                 "seed": None,
                 "temperature": 0.1,
                 "max_tokens": None,
-                "stream": False,
                 "user": "",
                 "use_native_tools": True,
             },

--- a/tests/unit/config/test_cohere_structure_config.py
+++ b/tests/unit/config/test_cohere_structure_config.py
@@ -20,7 +20,6 @@ class TestCohereStructureConfig:
                 "type": "CoherePromptDriver",
                 "temperature": 0.1,
                 "max_tokens": None,
-                "stream": False,
                 "model": "command-r",
                 "force_single_step": False,
                 "use_native_tools": True,

--- a/tests/unit/config/test_google_structure_config.py
+++ b/tests/unit/config/test_google_structure_config.py
@@ -19,7 +19,6 @@ class TestGoogleStructureConfig:
                 "type": "GooglePromptDriver",
                 "temperature": 0.1,
                 "max_tokens": None,
-                "stream": False,
                 "model": "gemini-1.5-pro",
                 "top_p": None,
                 "top_k": None,

--- a/tests/unit/config/test_openai_structure_config.py
+++ b/tests/unit/config/test_openai_structure_config.py
@@ -24,7 +24,6 @@ class TestOpenAiStructureConfig:
                 "seed": None,
                 "temperature": 0.1,
                 "max_tokens": None,
-                "stream": False,
                 "user": "",
                 "use_native_tools": True,
             },

--- a/tests/unit/config/test_structure_config.py
+++ b/tests/unit/config/test_structure_config.py
@@ -1,7 +1,6 @@
 import pytest
 
 from griptape.config import StructureConfig
-from griptape.structures import Agent
 
 
 class TestStructureConfig:
@@ -16,7 +15,6 @@ class TestStructureConfig:
                 "type": "DummyPromptDriver",
                 "temperature": 0.1,
                 "max_tokens": None,
-                "stream": False,
                 "use_native_tools": False,
             },
             "conversation_memory_driver": None,
@@ -43,7 +41,6 @@ class TestStructureConfig:
                         "type": "DummyPromptDriver",
                         "temperature": 0.1,
                         "max_tokens": None,
-                        "stream": False,
                     },
                 }
             ).to_dict()
@@ -61,37 +58,3 @@ class TestStructureConfig:
         config.prompt_driver.max_tokens = 10
 
         assert config.prompt_driver.max_tokens == 10
-
-    def test_drivers(self, config):
-        assert config.drivers == [
-            config.prompt_driver,
-            config.image_generation_driver,
-            config.image_query_driver,
-            config.embedding_driver,
-            config.vector_store_driver,
-            config.conversation_memory_driver,
-            config.text_to_speech_driver,
-            config.audio_transcription_driver,
-        ]
-
-    def test_structure(self, config):
-        structure_1 = Agent(
-            config=config,
-        )
-
-        assert config.structure == structure_1
-        assert config._event_listener is not None
-        for driver in config.drivers:
-            if driver is not None:
-                assert config._event_listener in driver.event_listeners
-                assert len(driver.event_listeners) == 1
-
-        structure_2 = Agent(
-            config=config,
-        )
-        assert config.structure == structure_2
-        assert config._event_listener is not None
-        for driver in config.drivers:
-            if driver is not None:
-                assert config._event_listener in driver.event_listeners
-                assert len(driver.event_listeners) == 1

--- a/tests/unit/config/test_structure_config.py
+++ b/tests/unit/config/test_structure_config.py
@@ -51,7 +51,7 @@ class TestStructureConfig:
 
     def test_changed_merge_config(self, config):
         config = config.merge_config(
-            {"prompt_driver": {"type": "DummyPromptDriver", "temperature": 0.1, "max_tokens": None, "stream": False}}
+            {"prompt_driver": {"type": "DummyPromptDriver", "temperature": 0.1, "max_tokens": None}}
         )
 
         assert config.prompt_driver.temperature == 0.1

--- a/tests/unit/config/test_structure_config.py
+++ b/tests/unit/config/test_structure_config.py
@@ -1,6 +1,8 @@
 import pytest
 
 from griptape.config import StructureConfig
+from griptape.mixins import EventPublisherMixin
+from griptape.structures import Agent
 
 
 class TestStructureConfig:
@@ -58,3 +60,37 @@ class TestStructureConfig:
         config.prompt_driver.max_tokens = 10
 
         assert config.prompt_driver.max_tokens == 10
+
+    def test_drivers(self, config):
+        assert config.drivers == [
+            config.prompt_driver,
+            config.image_generation_driver,
+            config.image_query_driver,
+            config.embedding_driver,
+            config.vector_store_driver,
+            config.conversation_memory_driver,
+            config.text_to_speech_driver,
+            config.audio_transcription_driver,
+        ]
+
+    def test_structure(self, config):
+        structure_1 = Agent(
+            config=config,
+        )
+
+        assert config.structure == structure_1
+        assert config._event_listener is not None
+        for driver in config.drivers:
+            if driver is not None and isinstance(driver, EventPublisherMixin):
+                assert config._event_listener in driver.event_listeners
+                assert len(driver.event_listeners) == 1
+
+        structure_2 = Agent(
+            config=config,
+        )
+        assert config.structure == structure_2
+        assert config._event_listener is not None
+        for driver in config.drivers:
+            if driver is not None and isinstance(driver, EventPublisherMixin):
+                assert config._event_listener in driver.event_listeners
+                assert len(driver.event_listeners) == 1

--- a/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
@@ -328,12 +328,12 @@ class TestAmazonBedrockPromptDriver:
         ]
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_converse, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_converse, prompt_stack, messages, use_native_tools):
         # Given
         driver = AmazonBedrockPromptDriver(model="ai21.j2", use_native_tools=use_native_tools)
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_converse.assert_called_once_with(
@@ -359,12 +359,12 @@ class TestAmazonBedrockPromptDriver:
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream_run(self, mock_converse_stream, prompt_stack, messages, use_native_tools):
+    def test_stream(self, mock_converse_stream, prompt_stack, messages, use_native_tools):
         # Given
-        driver = AmazonBedrockPromptDriver(model="ai21.j2", stream=True, use_native_tools=use_native_tools)
+        driver = AmazonBedrockPromptDriver(model="ai21.j2", use_native_tools=use_native_tools)
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then

--- a/tests/unit/drivers/prompt/test_amazon_sagemaker_jumpstart_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_sagemaker_jumpstart_prompt_driver.py
@@ -35,7 +35,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
     def test_init(self):
         assert AmazonSageMakerJumpstartPromptDriver(endpoint="foo", model="bar")
 
-    def test_try_run(self, mock_client):
+    def test_run(self, mock_client):
         # Given
         driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model")
         prompt_stack = PromptStack()
@@ -44,7 +44,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
         # When
         response_body = [{"generated_text": "foobar"}]
         mock_client.invoke_endpoint.return_value = {"Body": to_streaming_body(response_body)}
-        text_artifact = driver.try_run(prompt_stack)
+        text_artifact = driver.run(prompt_stack)
         assert isinstance(driver.tokenizer, HuggingFaceTokenizer)
 
         # Then
@@ -74,7 +74,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
         # When
         response_body = {"generated_text": "foobar"}
         mock_client.invoke_endpoint.return_value = {"Body": to_streaming_body(response_body)}
-        text_artifact = driver.try_run(prompt_stack)
+        text_artifact = driver.run(prompt_stack)
         assert isinstance(driver.tokenizer, HuggingFaceTokenizer)
 
         # Then
@@ -99,7 +99,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
 
         assert text_artifact.value == "foobar"
 
-    def test_try_stream(self, mock_client):
+    def test_stream(self, mock_client):
         # Given
         driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model")
         prompt_stack = PromptStack()
@@ -107,23 +107,12 @@ class TestAmazonSageMakerJumpstartPromptDriver:
 
         # When
         with pytest.raises(NotImplementedError) as e:
-            driver.try_stream(prompt_stack)
+            driver.stream(prompt_stack)
 
         # Then
         assert e.value.args[0] == "streaming is not supported"
 
-    def test_stream_init(self):
-        # Given
-        driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model")
-
-        # When
-        with pytest.raises(ValueError) as e:
-            driver.stream = True
-
-        # Then
-        assert e.value.args[0] == "streaming is not supported"
-
-    def test_try_run_throws_on_empty_response(self, mock_client):
+    def test_run_throws_on_empty_response(self, mock_client):
         # Given
         driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model")
         mock_client.invoke_endpoint.return_value = {"Body": to_streaming_body([])}
@@ -132,7 +121,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
 
         # When
         with pytest.raises(Exception) as e:
-            driver.try_run(prompt_stack)
+            driver.run(prompt_stack)
 
         # Then
         assert e.value.args[0] == "model response is empty"

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -334,12 +334,12 @@ class TestAnthropicPromptDriver:
         assert AnthropicPromptDriver(model="claude-3-haiku", api_key="1234")
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_client, prompt_stack, messages, use_native_tools):
         # Given
         driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", use_native_tools=use_native_tools)
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_client.return_value.messages.create.assert_called_once_with(
@@ -364,14 +364,12 @@ class TestAnthropicPromptDriver:
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream_run(self, mock_stream_client, prompt_stack, messages, use_native_tools):
+    def test_stream(self, mock_stream_client, prompt_stack, messages, use_native_tools):
         # Given
-        driver = AnthropicPromptDriver(
-            model="claude-3-haiku", api_key="api-key", stream=True, use_native_tools=use_native_tools
-        )
+        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", use_native_tools=use_native_tools)
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -67,7 +67,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert AzureOpenAiChatPromptDriver(azure_endpoint="foobar", model="gpt-4").azure_deployment == "gpt-4"
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_chat_completion_create, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_chat_completion_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = AzureOpenAiChatPromptDriver(
             azure_endpoint="endpoint",
@@ -77,7 +77,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_chat_completion_create.assert_called_once_with(
@@ -96,18 +96,17 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert message.value[1].value.input == {"foo": "bar"}
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream_run(self, mock_chat_completion_stream_create, prompt_stack, messages, use_native_tools):
+    def test_stream(self, mock_chat_completion_stream_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = AzureOpenAiChatPromptDriver(
             azure_endpoint="endpoint",
             azure_deployment="deployment-id",
             model="gpt-4",
-            stream=True,
             use_native_tools=use_native_tools,
         )
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then

--- a/tests/unit/drivers/prompt/test_base_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_base_prompt_driver.py
@@ -1,30 +1,21 @@
-from griptape.artifacts import ErrorArtifact, TextArtifact
+from griptape.artifacts import TextArtifact
 from griptape.common import Message, PromptStack
 from griptape.events import FinishPromptEvent, StartPromptEvent
 from griptape.mixins import EventPublisherMixin
 from griptape.structures import Pipeline
 from griptape.tasks import PromptTask, ToolkitTask
-from tests.mocks.mock_failing_prompt_driver import MockFailingPromptDriver
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 from tests.mocks.mock_tool.tool import MockTool
 
 
 class TestBasePromptDriver:
     def test_run_via_pipeline_retries_success(self):
-        driver = MockPromptDriver(max_attempts=1)
+        driver = MockPromptDriver()
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(PromptTask("test"))
 
         assert isinstance(pipeline.run().output_task.output, TextArtifact)
-
-    def test_run_via_pipeline_retries_failure(self):
-        driver = MockFailingPromptDriver(max_failures=2, max_attempts=1)
-        pipeline = Pipeline(prompt_driver=driver)
-
-        pipeline.add_task(PromptTask("test"))
-
-        assert isinstance(pipeline.run().output_task.output, ErrorArtifact)
 
     def test_run_via_pipeline_publishes_events(self, mocker):
         mock_publish_event = mocker.patch.object(EventPublisherMixin, "publish_event")
@@ -42,13 +33,12 @@ class TestBasePromptDriver:
         assert isinstance(MockPromptDriver().run(PromptStack(messages=[])), Message)
 
     def test_run_with_stream(self):
-        pipeline = Pipeline()
-        result = MockPromptDriver(stream=True, event_listeners=pipeline.event_listeners).run(PromptStack(messages=[]))
+        result = MockPromptDriver().run(PromptStack(messages=[]))
         assert isinstance(result, Message)
         assert result.value == "mock output"
 
     def test_run_with_tools(self):
-        driver = MockPromptDriver(max_attempts=1, use_native_tools=True)
+        driver = MockPromptDriver(use_native_tools=True)
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(ToolkitTask(tools=[MockTool()]))
@@ -58,7 +48,7 @@ class TestBasePromptDriver:
         assert output.value == "mock output"
 
     def test_run_with_tools_and_stream(self):
-        driver = MockPromptDriver(max_attempts=1, stream=True, use_native_tools=True)
+        driver = MockPromptDriver(use_native_tools=True)
         pipeline = Pipeline(prompt_driver=driver)
 
         pipeline.add_task(ToolkitTask(tools=[MockTool()]))

--- a/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
@@ -129,12 +129,12 @@ class TestCoherePromptDriver:
         assert CoherePromptDriver(model="command", api_key="foobar")
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_client, prompt_stack, use_native_tools):
+    def test_run(self, mock_client, prompt_stack, use_native_tools):
         # Given
         driver = CoherePromptDriver(model="command", api_key="api-key", use_native_tools=use_native_tools)
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_client.chat.assert_called_once_with(
@@ -180,12 +180,12 @@ class TestCoherePromptDriver:
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream_run(self, mock_stream_client, prompt_stack, use_native_tools):
+    def test_stream(self, mock_stream_client, prompt_stack, use_native_tools):
         # Given
-        driver = CoherePromptDriver(model="command", api_key="api-key", stream=True, use_native_tools=use_native_tools)
+        driver = CoherePromptDriver(model="command", api_key="api-key", use_native_tools=use_native_tools)
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then

--- a/tests/unit/drivers/prompt/test_dummy_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_dummy_prompt_driver.py
@@ -12,10 +12,10 @@ class TestDummyPromptDriver:
     def test_init(self, prompt_driver):
         assert prompt_driver
 
-    def test_try_run(self, prompt_driver):
+    def test_run(self, prompt_driver):
         with pytest.raises(DummyError):
-            prompt_driver.try_run("prompt-stack")
+            prompt_driver.run("prompt-stack")
 
-    def test_try_stream_run(self, prompt_driver):
+    def test_stream(self, prompt_driver):
         with pytest.raises(DummyError):
-            prompt_driver.try_run("prompt-stack")
+            prompt_driver.stream("prompt-stack")

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -148,14 +148,14 @@ class TestGooglePromptDriver:
         assert driver
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_generative_model, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_generative_model, prompt_stack, messages, use_native_tools):
         # Given
         driver = GooglePromptDriver(
             model="gemini-pro", api_key="api-key", top_p=0.5, top_k=50, use_native_tools=use_native_tools
         )
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         if prompt_stack.system_messages:
@@ -185,14 +185,14 @@ class TestGooglePromptDriver:
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream(self, mock_stream_generative_model, prompt_stack, messages, use_native_tools):
+    def test_stream(self, mock_stream_generative_model, prompt_stack, messages, use_native_tools):
         # Given
         driver = GooglePromptDriver(
-            model="gemini-pro", api_key="api-key", stream=True, top_p=0.5, top_k=50, use_native_tools=use_native_tools
+            model="gemini-pro", api_key="api-key", top_p=0.5, top_k=50, use_native_tools=use_native_tools
         )
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
 
         # Then
         event = next(stream)

--- a/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
@@ -45,24 +45,24 @@ class TestHuggingFaceHubPromptDriver:
     def test_init(self):
         assert HuggingFaceHubPromptDriver(api_token="foobar", model="gpt2")
 
-    def test_try_run(self, prompt_stack, mock_client):
+    def test_run(self, prompt_stack, mock_client):
         # Given
         driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         assert message.value == "model-output"
         assert message.usage.input_tokens == 3
         assert message.usage.output_tokens == 3
 
-    def test_try_stream(self, prompt_stack, mock_client_stream):
+    def test_stream(self, prompt_stack, mock_client_stream):
         # Given
-        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id", stream=True)
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then

--- a/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
@@ -37,49 +37,49 @@ class TestHuggingFacePipelinePromptDriver:
     def test_init(self):
         assert HuggingFacePipelinePromptDriver(model="gpt2", max_tokens=42)
 
-    def test_try_run(self, prompt_stack):
+    def test_run(self, prompt_stack):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42)
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         assert message.value == "model-output"
         assert message.usage.input_tokens == 3
         assert message.usage.output_tokens == 3
 
-    def test_try_stream(self, prompt_stack):
+    def test_stream(self, prompt_stack):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42)
 
         # When
         with pytest.raises(Exception) as e:
-            driver.try_stream(prompt_stack)
+            driver.stream(prompt_stack)
 
         assert e.value.args[0] == "streaming is not supported"
 
     @pytest.mark.parametrize("choices", [[], [1, 2]])
-    def test_try_run_throws_when_multiple_choices_returned(self, choices, mock_generator, prompt_stack):
+    def test_run_throws_when_multiple_choices_returned(self, choices, mock_generator, prompt_stack):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42)
         mock_generator.return_value = choices
 
         # When
         with pytest.raises(Exception) as e:
-            driver.try_run(prompt_stack)
+            driver.run(prompt_stack)
 
         # Then
         assert e.value.args[0] == "completion with more than one choice is not supported yet"
 
-    def test_try_run_throws_when_non_list(self, mock_generator, prompt_stack):
+    def test_run_throws_when_non_list(self, mock_generator, prompt_stack):
         # Given
         driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42)
         mock_generator.return_value = {}
 
         # When
         with pytest.raises(Exception) as e:
-            driver.try_run(prompt_stack)
+            driver.run(prompt_stack)
 
         # Then
         assert e.value.args[0] == "invalid output format"

--- a/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
@@ -184,12 +184,12 @@ class TestOllamaPromptDriver:
         assert OllamaPromptDriver(model="llama")
 
     @pytest.mark.parametrize("use_native_tools", [True])
-    def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_client, prompt_stack, messages, use_native_tools):
         # Given
         driver = OllamaPromptDriver(model="llama")
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_client.return_value.chat.assert_called_once_with(
@@ -210,7 +210,7 @@ class TestOllamaPromptDriver:
         assert message.value[1].value.path == "test"
         assert message.value[1].value.input == {"foo": "bar"}
 
-    def test_try_run_bad_response(self, mock_client):
+    def test_run_bad_response(self, mock_client):
         # Given
         prompt_stack = PromptStack()
         driver = OllamaPromptDriver(model="llama")
@@ -218,9 +218,9 @@ class TestOllamaPromptDriver:
 
         # When/Then
         with pytest.raises(Exception, match="invalid model response"):
-            driver.try_run(prompt_stack)
+            driver.run(prompt_stack)
 
-    def test_try_stream_run(self, mock_stream_client):
+    def test_stream(self, mock_stream_client):
         # Given
         prompt_stack = PromptStack()
         prompt_stack.add_system_message("system-input")
@@ -237,10 +237,10 @@ class TestOllamaPromptDriver:
             {"role": "user", "content": "user-input", "images": ["aW1hZ2UtZGF0YQ=="]},
             {"role": "assistant", "content": "assistant-input"},
         ]
-        driver = OllamaPromptDriver(model="llama", stream=True)
+        driver = OllamaPromptDriver(model="llama")
 
         # When
-        text_artifact = next(driver.try_stream(prompt_stack))
+        text_artifact = next(driver.stream(prompt_stack))
 
         # Then
         mock_stream_client.return_value.chat.assert_called_once_with(
@@ -252,12 +252,12 @@ class TestOllamaPromptDriver:
         if isinstance(text_artifact, TextDeltaMessageContent):
             assert text_artifact.text == "model-output"
 
-    def test_try_stream_bad_response(self, mock_stream_client):
+    def test_stream_bad_response(self, mock_stream_client):
         # Given
         prompt_stack = PromptStack()
-        driver = OllamaPromptDriver(model="llama", stream=True)
+        driver = OllamaPromptDriver(model="llama")
         mock_stream_client.return_value.chat.return_value = "bad-response"
 
         # When/Then
         with pytest.raises(Exception, match="invalid model response"):
-            next(driver.try_stream(prompt_stack))
+            next(driver.stream(prompt_stack))

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -312,14 +312,14 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL)
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_run(self, mock_chat_completion_create, prompt_stack, messages, use_native_tools):
+    def test_run(self, mock_chat_completion_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = OpenAiChatPromptDriver(
             model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, use_native_tools=use_native_tools
         )
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_chat_completion_create.assert_called_once_with(
@@ -338,14 +338,14 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert message.value[1].value.path == "test"
         assert message.value[1].value.input == {"foo": "bar"}
 
-    def test_try_run_response_format(self, mock_chat_completion_create, prompt_stack, messages):
+    def test_run_response_format(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
         driver = OpenAiChatPromptDriver(
             model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, response_format="json_object", use_native_tools=False
         )
 
         # When
-        message = driver.try_run(prompt_stack)
+        message = driver.run(prompt_stack)
 
         # Then
         mock_chat_completion_create.assert_called_once_with(
@@ -361,14 +361,14 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    def test_try_stream_run(self, mock_chat_completion_stream_create, prompt_stack, messages, use_native_tools):
+    def test_stream(self, mock_chat_completion_stream_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True, use_native_tools=use_native_tools
+            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, use_native_tools=use_native_tools
         )
 
         # When
-        stream = driver.try_stream(prompt_stack)
+        stream = driver.stream(prompt_stack)
         event = next(stream)
 
         # Then
@@ -403,14 +403,14 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         assert isinstance(event.content, TextDeltaMessageContent)
         assert event.content.text == ""
 
-    def test_try_run_with_max_tokens(self, mock_chat_completion_create, prompt_stack, messages):
+    def test_run_with_max_tokens(self, mock_chat_completion_create, prompt_stack, messages):
         # Given
         driver = OpenAiChatPromptDriver(
             model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, max_tokens=1, use_native_tools=False
         )
 
         # When
-        event = driver.try_run(prompt_stack)
+        event = driver.run(prompt_stack)
 
         # Then
         mock_chat_completion_create.assert_called_once_with(
@@ -423,14 +423,14 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
         assert event.value[0].value == "model-output"
 
-    def test_try_run_throws_when_multiple_choices_returned(self, mock_chat_completion_create, prompt_stack):
+    def test_run_throws_when_multiple_choices_returned(self, mock_chat_completion_create, prompt_stack):
         # Given
         driver = OpenAiChatPromptDriver(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, api_key="api-key")
         mock_chat_completion_create.return_value.choices = [Mock(message=Mock(content="model-output"))] * 10
 
         # When
         with pytest.raises(Exception) as e:
-            driver.try_run(prompt_stack)
+            driver.run(prompt_stack)
 
         # Then
         assert e.value.args[0] == "Completion with more than one choice is not supported yet."
@@ -444,7 +444,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         )
 
         # When
-        event = driver.try_run(prompt_stack)
+        event = driver.run(prompt_stack)
 
         # Then
         mock_chat_completion_create.assert_called_once_with(

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -234,19 +234,25 @@ class TestAgent:
         prompt_driver = MockPromptDriver()
         embedding_driver = MockEmbeddingDriver()
         agent = Agent(prompt_driver=prompt_driver, embedding_driver=embedding_driver)
+        assert agent.prompt_engine.prompt_driver == prompt_driver
 
         storage = list(agent.task_memory.artifact_storages.values())[0]
         assert isinstance(storage, TextArtifactStorage)
 
-        assert storage.rag_engine.response_stage.response_module.prompt_driver == prompt_driver
+        assert storage.rag_engine.response_stage.response_module.prompt_engine.prompt_driver == prompt_driver
         assert (
             storage.rag_engine.retrieval_stage.retrieval_modules[0].vector_store_driver.embedding_driver
             == embedding_driver
         )
         assert isinstance(storage.summary_engine, PromptSummaryEngine)
-        assert storage.summary_engine.prompt_driver == prompt_driver
-        assert storage.csv_extraction_engine.prompt_driver == prompt_driver
-        assert storage.json_extraction_engine.prompt_driver == prompt_driver
+        assert storage.summary_engine.prompt_engine == agent.prompt_engine
+        assert storage.summary_engine.prompt_engine.prompt_driver == prompt_driver
+
+        assert storage.csv_extraction_engine.prompt_engine == agent.prompt_engine
+        assert storage.csv_extraction_engine.prompt_engine.prompt_driver == prompt_driver
+
+        assert storage.json_extraction_engine.prompt_engine == agent.prompt_engine
+        assert storage.json_extraction_engine.prompt_engine.prompt_driver == prompt_driver
 
     def test_deprecation(self):
         with pytest.deprecated_call():


### PR DESCRIPTION
WORK IN PROGRESS

Changes:
- Add a `PromptEngine` class:
  - Has a prompt driver. 
  - Publishes prompt events.
  - Retries when prompt driver fails.
  - Branches `run` logic based on value of `stream` for use in a structure.
- Edit `BasePromptDriver` responsibilities:
  - Remove event publishing.
  - Remove retry logic.
  - Remove `stream` branching logic.
- Edit consumers within the framework to use `PromptEngine` rather than `BasePromptDriver`
  - Required for behavior parity (event publishing + retry logic)
  - TODO: list the consumers, (there weren't that many...)
- Edit `StructureConfig`:
  - Remove references to event listeners and structure.
  - After making the other (non-prompt) drivers "stateless", you'll be able to use the same structure config instance across multiple structures without conflicts. (Though you should still avoid mutating the structure config after doing so, this PR doesn't solve that issue. Making structure config immutable would though)
 
 To summarize the main idea:
 1. Keep drivers "stateless".
 1. Allow engines to be "stateful".
 1. Client framework code should use engines rather than drivers, so that event publishing continues to work by default.

 In our case, this means moving event publishing logic from drivers into engines.
 
> Note: When I say "stateless", I don't actually mean no state; I actually mean "stateless" w.r.t. a specific piece of client code. I think its fine if say a driver has for example an s3 client, just as long as that wouldn't prevent a single instance of the driver from being used simultaneously in multiple contexts, like multiple structures.


> Note: There are some alternative options to this, that I'd like to quickly explore before making any decisions. Publishing this for discussion purposes only.