### PR TITLE
Fix docs type check in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check/lint:
 
 .PHONY: check/types
 check/types:
-	@poetry run pyright griptape/ docs/**/src/**
+	@poetry run pyright griptape $(shell find docs -type f -path "*/src/*")
 	
 .PHONY: check/spell
 check/spell:


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Makefile wildcard expansion works different than you'd think.
## Issue ticket number and link
NA