### PR TITLE
Set logger level in Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QueryTool` for having the LLM query text.
 - Support for bitshift composition in `BaseTask` for adding parent/child tasks.
 - `JsonArtifact` for handling de/seralization of values.
+- `Chat.logger_level` for setting what the `Chat` utility sets the logger level to. 
 
 ### Changed
 - **BREAKING**: Removed all uses of `EventPublisherMixin` in favor of `event_bus`.
@@ -46,11 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Changed `JsonExtractionEngine.template_schema` from a `run` argument to a class attribute. 
 - **BREAKING**: Changed `CsvExtractionEngine.column_names` from a `run` argument to a class attribute. 
 - **BREAKING**: Removed `JsonExtractionTask`, and `CsvExtractionTask` use `ExtractionTask` instead.
-- **BREAKING**: Removed `TaskMemoryClient`, use `RagClient`, `ExtractionTool`, or `PromptSummaryTool` instead.
+- **BREAKING**: Removed `TaskMemoryClient`, use `QueryClient`, `ExtractionTool`, or `PromptSummaryTool` instead.
 - **BREAKING**: `BaseTask.add_parent/child` now take a `BaseTask` instead of `str | BaseTask`.
 - Engines that previously required Drivers now pull from `griptape.config.config.drivers` by default.
 - `BaseTask.add_parent/child` will now call `self.structure.add_task` if possible.
 - `BaseTask.add_parent/child` now returns `self`, allowing for chaining.
+- `Chat` now sets the `griptape` logger level to `logging.ERROR`, suppressing all logs except for errors.
 
 ### Fixed
 - `JsonExtractionEngine` failing to parse json when the LLM outputs more than just the json.

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -1,3 +1,7 @@
+import logging
+from unittest.mock import patch
+
+from griptape.config import config
 from griptape.memory.structure import ConversationMemory
 from griptape.structures import Agent
 from griptape.utils import Chat
@@ -5,8 +9,6 @@ from griptape.utils import Chat
 
 class TestConversation:
     def test_init(self):
-        import logging
-
         agent = Agent(conversation_memory=ConversationMemory())
 
         chat = Chat(
@@ -18,6 +20,7 @@ class TestConversation:
             prompt_prefix="Question: ",
             response_prefix="Answer: ",
             output_fn=logging.info,
+            logger_level=logging.INFO,
         )
         assert chat.structure == agent
         assert chat.exiting_text == "foo..."
@@ -26,3 +29,20 @@ class TestConversation:
         assert chat.prompt_prefix == "Question: "
         assert chat.response_prefix == "Answer: "
         assert callable(chat.output_fn)
+        assert chat.logger_level == logging.INFO
+
+    @patch("builtins.input", side_effect=["exit"])
+    def test_chat_logger_level(self, mock_input):
+        agent = Agent(conversation_memory=ConversationMemory())
+
+        chat = Chat(agent)
+
+        logger = logging.getLogger(config.logging.logger_name)
+        logger.setLevel(logging.DEBUG)
+
+        assert logger.getEffectiveLevel() == logging.DEBUG
+
+        chat.start()
+
+        assert logger.getEffectiveLevel() == logging.DEBUG
+        assert mock_input.call_count == 1


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `Chat.logger_level` for setting what the `Chat` utility sets the logger level to. 
### Changed
- `Chat` now sets the `griptape` logger level to `logging.ERROR`, suppressing all logs except for errors.

Most of the time when users are using `Chat` they disable log output so that Griptape's logging does not interfere with the output. This change does it automatically.
## Issue ticket number and link
NA