### PR TITLE
Use subtask output if no action output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Workflow` threads not being properly cleaned up after completion.
+- Crash when `ToolAction`s were missing output due to an `ActionsSubtask` exception.
 
 ## [0.29.1] - 2024-08-02
 

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -83,7 +83,12 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
                         for action in s.actions
                     ]
                     action_results = [
-                        ToolAction(name=action.name, path=action.path, tag=action.tag, output=action.output)
+                        ToolAction(
+                            name=action.name,
+                            path=action.path,
+                            tag=action.tag,
+                            output=action.output if action.output is not None else s.output,
+                        )
                         for action in s.actions
                     ]
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
If an `ActionsSubtask` crashes before any of its `ToolAction`'s have an output, that output should be used as the `ToolAction` output when building `ActionArtifact`s.

This fixes `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages`. 
## Issue ticket number and link
Offline discussion.