### PR TITLE
Add and integrate `FuturesExecutorMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for bitshift composition in `BaseTask` for adding parent/child tasks.
 - `JsonArtifact` for handling de/seralization of values.
 - `Chat.logger_level` for setting what the `Chat` utility sets the logger level to. 
+- `FuturesExecutorMixin` to DRY up and optimize concurrent code across multiple classes.
 
 ### Changed
 - **BREAKING**: Removed all uses of `EventPublisherMixin` in favor of `event_bus`.

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from concurrent import futures
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
+
+from griptape.mixins import FuturesExecutorMixin
 
 if TYPE_CHECKING:
     from griptape.events import BaseEvent
@@ -14,11 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @define
-class BaseEventListenerDriver(ABC):
-    futures_executor_fn: Callable[[], futures.Executor] = field(
-        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
-        kw_only=True,
-    )
+class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
     batched: bool = field(default=True, kw_only=True)
     batch_size: int = field(default=10, kw_only=True)
 
@@ -29,8 +26,7 @@ class BaseEventListenerDriver(ABC):
         return self._batch
 
     def publish_event(self, event: BaseEvent | dict, *, flush: bool = False) -> None:
-        with self.futures_executor_fn() as executor:
-            executor.submit(self._safe_try_publish_event, event, flush=flush)
+        self.futures_executor.submit(self._safe_try_publish_event, event, flush=flush)
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -2,22 +2,21 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from concurrent import futures
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape import utils
 from griptape.artifacts import BaseArtifact, ListArtifact, TextArtifact
-from griptape.mixins import SerializableMixin
+from griptape.mixins import FuturesExecutorMixin, SerializableMixin
 
 if TYPE_CHECKING:
     from griptape.drivers import BaseEmbeddingDriver
 
 
 @define
-class BaseVectorStoreDriver(SerializableMixin, ABC):
+class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
     DEFAULT_QUERY_COUNT = 5
 
     @dataclass
@@ -36,10 +35,6 @@ class BaseVectorStoreDriver(SerializableMixin, ABC):
             return BaseArtifact.from_json(self.meta["artifact"])  # pyright: ignore[reportOptionalSubscript]
 
     embedding_driver: BaseEmbeddingDriver = field(kw_only=True, metadata={"serializable": True})
-    futures_executor_fn: Callable[[], futures.Executor] = field(
-        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
-        kw_only=True,
-    )
 
     def upsert_text_artifacts(
         self,
@@ -48,24 +43,23 @@ class BaseVectorStoreDriver(SerializableMixin, ABC):
         meta: Optional[dict] = None,
         **kwargs,
     ) -> None:
-        with self.futures_executor_fn() as executor:
-            if isinstance(artifacts, list):
-                utils.execute_futures_list(
-                    [
-                        executor.submit(self.upsert_text_artifact, a, namespace=None, meta=meta, **kwargs)
-                        for a in artifacts
-                    ],
-                )
-            else:
-                utils.execute_futures_dict(
-                    {
-                        namespace: executor.submit(
-                            self.upsert_text_artifact, a, namespace=namespace, meta=meta, **kwargs
-                        )
-                        for namespace, artifact_list in artifacts.items()
-                        for a in artifact_list
-                    },
-                )
+        if isinstance(artifacts, list):
+            utils.execute_futures_list(
+                [
+                    self.futures_executor.submit(self.upsert_text_artifact, a, namespace=None, meta=meta, **kwargs)
+                    for a in artifacts
+                ],
+            )
+        else:
+            utils.execute_futures_dict(
+                {
+                    namespace: self.futures_executor.submit(
+                        self.upsert_text_artifact, a, namespace=namespace, meta=meta, **kwargs
+                    )
+                    for namespace, artifact_list in artifacts.items()
+                    for a in artifact_list
+                },
+            )
 
     def upsert_text_artifact(
         self,

--- a/griptape/engines/rag/modules/base_rag_module.py
+++ b/griptape/engines/rag/modules/base_rag_module.py
@@ -2,24 +2,21 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC
-from concurrent import futures
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import Factory, define, field
 
 from griptape.common import Message, PromptStack
+from griptape.mixins import FuturesExecutorMixin
 
 if TYPE_CHECKING:
     from griptape.engines.rag import RagContext
 
 
 @define(kw_only=True)
-class BaseRagModule(ABC):
+class BaseRagModule(FuturesExecutorMixin, ABC):
     name: str = field(
         default=Factory(lambda self: f"{self.__class__.__name__}-{uuid.uuid4().hex}", takes_self=True), kw_only=True
-    )
-    futures_executor_fn: Callable[[], futures.Executor] = field(
-        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
     )
 
     def generate_prompt_stack(self, system_prompt: Optional[str], query: str) -> PromptStack:

--- a/griptape/engines/rag/stages/base_rag_stage.py
+++ b/griptape/engines/rag/stages/base_rag_stage.py
@@ -1,20 +1,15 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from concurrent import futures
-from typing import Callable
 
-from attrs import Factory, define, field
+from attrs import define
 
 from griptape.engines.rag import RagContext
 from griptape.engines.rag.modules import BaseRagModule
+from griptape.mixins import FuturesExecutorMixin
 
 
 @define(kw_only=True)
-class BaseRagStage(ABC):
-    futures_executor_fn: Callable[[], futures.Executor] = field(
-        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
-    )
-
+class BaseRagStage(FuturesExecutorMixin, ABC):
     @abstractmethod
     def run(self, context: RagContext) -> RagContext: ...
 

--- a/griptape/engines/rag/stages/response_rag_stage.py
+++ b/griptape/engines/rag/stages/response_rag_stage.py
@@ -31,8 +31,9 @@ class ResponseRagStage(BaseRagStage):
     def run(self, context: RagContext) -> RagContext:
         logging.info("ResponseRagStage: running %s retrieval modules in parallel", len(self.response_modules))
 
-        with self.futures_executor_fn() as executor:
-            results = utils.execute_futures_list([executor.submit(r.run, context) for r in self.response_modules])
+        results = utils.execute_futures_list(
+            [self.futures_executor.submit(r.run, context) for r in self.response_modules]
+        )
 
         context.outputs = results
 

--- a/griptape/engines/rag/stages/retrieval_rag_stage.py
+++ b/griptape/engines/rag/stages/retrieval_rag_stage.py
@@ -35,8 +35,9 @@ class RetrievalRagStage(BaseRagStage):
     def run(self, context: RagContext) -> RagContext:
         logging.info("RetrievalRagStage: running %s retrieval modules in parallel", len(self.retrieval_modules))
 
-        with self.futures_executor_fn() as executor:
-            results = utils.execute_futures_list([executor.submit(r.run, context) for r in self.retrieval_modules])
+        results = utils.execute_futures_list(
+            [self.futures_executor.submit(r.run, context) for r in self.retrieval_modules]
+        )
 
         # flatten the list of lists
         results = list(itertools.chain.from_iterable(results))

--- a/griptape/mixins/__init__.py
+++ b/griptape/mixins/__init__.py
@@ -4,6 +4,7 @@ from .actions_subtask_origin_mixin import ActionsSubtaskOriginMixin
 from .rule_mixin import RuleMixin
 from .serializable_mixin import SerializableMixin
 from .media_artifact_file_output_mixin import BlobArtifactFileOutputMixin
+from .futures_executor_mixin import FuturesExecutorMixin
 
 __all__ = [
     "ActivityMixin",
@@ -12,4 +13,5 @@ __all__ = [
     "RuleMixin",
     "BlobArtifactFileOutputMixin",
     "SerializableMixin",
+    "FuturesExecutorMixin",
 ]

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -8,15 +8,14 @@ from typing import Callable, Optional
 from attrs import Factory, define, field
 
 
-@define(slots=False)
+@define(slots=False, kw_only=True)
 class FuturesExecutorMixin(ABC):
     futures_executor_fn: Callable[[], futures.Executor] = field(
         default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
-        kw_only=True,
     )
+    thread_lock: threading.Lock = field(default=Factory(lambda: threading.Lock()))
 
     _futures_executor: Optional[futures.Executor] = field(init=False, default=None)
-    thread_lock: threading.Lock = field(default=Factory(lambda: threading.Lock()))
 
     @property
     def futures_executor(self) -> futures.Executor:

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from concurrent import futures
+from threading import Lock
 from typing import Callable, Optional
 
 from attrs import Factory, define, field
@@ -15,15 +16,25 @@ class FuturesExecutorMixin(ABC):
     )
 
     _futures_executor: Optional[futures.Executor] = field(init=False, default=None)
+    _executor_lock: Lock = field(init=False, factory=Lock)
 
     @property
     def futures_executor(self) -> futures.Executor:
         if self._futures_executor is None:
-            self._futures_executor = self.futures_executor_fn()
+            with self._executor_lock:
+                if self._futures_executor is None:
+                    try:
+                        self._futures_executor = self.futures_executor_fn()
+                    except Exception as e:
+                        raise RuntimeError(f"Failed to initialize futures executor: {e}")
 
         return self._futures_executor
 
+    def __shutdown_executor(self, wait: bool = True) -> None:
+        with self._executor_lock:
+            if self._futures_executor:
+                self._futures_executor.shutdown(wait=wait)
+                self._futures_executor = None
+
     def __del__(self) -> None:
-        if self._futures_executor:
-            self._futures_executor.shutdown()
-            self._futures_executor = None
+        self.__shutdown_executor(wait=False)

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -20,10 +20,9 @@ class FuturesExecutorMixin(ABC):
 
     @property
     def futures_executor(self) -> futures.Executor:
-        if self._futures_executor is None:
-            with self._executor_lock:
-                if self._futures_executor is None:
-                    self._futures_executor = self.futures_executor_fn()
+        with self._executor_lock:
+            if self._futures_executor is None:
+                self._futures_executor = self.futures_executor_fn()
 
         return self._futures_executor
 

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -23,18 +23,12 @@ class FuturesExecutorMixin(ABC):
         if self._futures_executor is None:
             with self._executor_lock:
                 if self._futures_executor is None:
-                    try:
-                        self._futures_executor = self.futures_executor_fn()
-                    except Exception as e:
-                        raise RuntimeError(f"Failed to initialize futures executor: {e}")
+                    self._futures_executor = self.futures_executor_fn()
 
         return self._futures_executor
 
-    def __shutdown_executor(self, wait: bool = True) -> None:
+    def __del__(self) -> None:
         with self._executor_lock:
             if self._futures_executor:
-                self._futures_executor.shutdown(wait=wait)
+                self._futures_executor.shutdown(True)
                 self._futures_executor = None
-
-    def __del__(self) -> None:
-        self.__shutdown_executor(wait=False)

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -30,5 +30,5 @@ class FuturesExecutorMixin(ABC):
     def __del__(self) -> None:
         with self._executor_lock:
             if self._futures_executor:
-                self._futures_executor.shutdown(True)
+                self._futures_executor.shutdown(wait=True)
                 self._futures_executor = None

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -23,7 +23,7 @@ class FuturesExecutorMixin(ABC):
 
         return self._futures_executor
 
-    def __exit__(self, *args) -> None:
+    def __del__(self) -> None:
         if self._futures_executor:
             self._futures_executor.shutdown()
             self._futures_executor = None

--- a/griptape/mixins/futures_executor_mixin.py
+++ b/griptape/mixins/futures_executor_mixin.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abc import ABC
+from concurrent import futures
+from typing import Callable, Optional
+
+from attrs import Factory, define, field
+
+
+@define(slots=False)
+class FuturesExecutorMixin(ABC):
+    futures_executor_fn: Callable[[], futures.Executor] = field(
+        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
+        kw_only=True,
+    )
+
+    _futures_executor: Optional[futures.Executor] = field(init=False, default=None)
+
+    @property
+    def futures_executor(self) -> futures.Executor:
+        if self._futures_executor is None:
+            self._futures_executor = self.futures_executor_fn()
+
+        return self._futures_executor
+
+    def __exit__(self, *args) -> None:
+        if self._futures_executor:
+            self._futures_executor.shutdown()
+            self._futures_executor = None

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -96,7 +96,7 @@ class Workflow(Structure, FuturesExecutorMixin):
 
             for task in ordered_tasks:
                 if task.can_execute():
-                    future = self.futures_executor_fn().submit(task.execute)
+                    future = self.futures_executor.submit(task.execute)
                     futures_list[future] = task
 
             # Wait for all tasks to complete

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import concurrent.futures as futures
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from attrs import Factory, define, field
+from attrs import define
 from graphlib import TopologicalSorter
 
 from griptape.artifacts import ErrorArtifact
 from griptape.common import observable
 from griptape.memory.structure import Run
+from griptape.mixins import FuturesExecutorMixin
 from griptape.structures import Structure
 
 if TYPE_CHECKING:
@@ -16,12 +17,7 @@ if TYPE_CHECKING:
 
 
 @define
-class Workflow(Structure):
-    futures_executor_fn: Callable[[], futures.Executor] = field(
-        default=Factory(lambda: lambda: futures.ThreadPoolExecutor()),
-        kw_only=True,
-    )
-
+class Workflow(Structure, FuturesExecutorMixin):
     @property
     def input_task(self) -> Optional[BaseTask]:
         return self.order_tasks()[0] if self.tasks else None

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -139,8 +139,9 @@ class ActionsSubtask(BaseTask):
             return ErrorArtifact("no tool output")
 
     def execute_actions(self, actions: list[ToolAction]) -> list[tuple[str, BaseArtifact]]:
-        with self.futures_executor_fn() as executor:
-            results = utils.execute_futures_dict({a.tag: executor.submit(self.execute_action, a) for a in actions})
+        results = utils.execute_futures_dict(
+            {a.tag: self.futures_executor.submit(self.execute_action, a) for a in actions}
+        )
 
         return list(results.values())
 

--- a/tests/mocks/mock_futures_executor.py
+++ b/tests/mocks/mock_futures_executor.py
@@ -1,0 +1,4 @@
+from griptape.mixins import FuturesExecutorMixin
+
+
+class MockFuturesExecutor(FuturesExecutorMixin): ...

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -12,9 +12,7 @@ class TestBaseEventListenerDriver:
 
         driver.publish_event(MockEvent().to_dict())
 
-        executor.__enter__.assert_called_once()
         executor.submit.assert_called_once()
-        executor.__exit__.assert_called_once()
 
     def test__safe_try_publish_event(self):
         driver = MockEventListenerDriver(batched=False)

--- a/tests/unit/mixins/test_futures_executor_mixin.py
+++ b/tests/unit/mixins/test_futures_executor_mixin.py
@@ -1,0 +1,10 @@
+from concurrent import futures
+
+from tests.mocks.mock_futures_executor import MockFuturesExecutor
+
+
+class TestFuturesExecutorMixin:
+    def test_futures_executor(self):
+        executor = futures.ThreadPoolExecutor()
+
+        assert MockFuturesExecutor(futures_executor_fn=lambda: executor).futures_executor == executor


### PR DESCRIPTION
- [X] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

* Added and integrated `FuturesExecutorMixin` to DRY up and optimize futures execution across the framework.