### PR TITLE
Fix adding ErrorArtifacts to Prompt Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `JsonExtractionEngine` failing to parse json when the LLM outputs more than just the json.
+- Exception when adding `ErrorArtifact`'s to the Prompt Stack.
+
 ## [0.29.2] - 2024-08-16
 
 ### Fixed

--- a/griptape/common/prompt_stack/prompt_stack.py
+++ b/griptape/common/prompt_stack/prompt_stack.py
@@ -4,7 +4,15 @@ from typing import TYPE_CHECKING
 
 from attrs import define, field
 
-from griptape.artifacts import ActionArtifact, BaseArtifact, GenericArtifact, ImageArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import (
+    ActionArtifact,
+    BaseArtifact,
+    ErrorArtifact,
+    GenericArtifact,
+    ImageArtifact,
+    ListArtifact,
+    TextArtifact,
+)
 from griptape.common import (
     ActionCallMessageContent,
     ActionResultMessageContent,
@@ -62,6 +70,8 @@ class PromptStack(SerializableMixin):
             return [ImageMessageContent(artifact)]
         elif isinstance(artifact, GenericArtifact):
             return [GenericMessageContent(artifact)]
+        elif isinstance(artifact, ErrorArtifact):
+            return [TextMessageContent(TextArtifact(artifact.to_text()))]
         elif isinstance(artifact, ActionArtifact):
             action = artifact.value
             output = action.output
@@ -72,6 +82,5 @@ class PromptStack(SerializableMixin):
         elif isinstance(artifact, ListArtifact):
             processed_contents = [self.__to_message_content(artifact) for artifact in artifact.value]
             return [sub_content for processed_content in processed_contents for sub_content in processed_content]
-
         else:
             raise ValueError(f"Unsupported artifact type: {type(artifact)}")

--- a/tests/unit/common/test_prompt_stack.py
+++ b/tests/unit/common/test_prompt_stack.py
@@ -1,6 +1,7 @@
 import pytest
 
 from griptape.artifacts import ActionArtifact, GenericArtifact, ImageArtifact, ListArtifact, TextArtifact
+from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.common import (
     ActionCallMessageContent,
     ActionResultMessageContent,
@@ -45,6 +46,8 @@ class TestPromptStack:
             "role",
         )
 
+        prompt_stack.add_message(ErrorArtifact("foo"), "role")
+
         assert prompt_stack.messages[0].role == "role"
         assert isinstance(prompt_stack.messages[0].content[0], TextMessageContent)
         assert prompt_stack.messages[0].content[0].artifact.value == "foo"
@@ -84,6 +87,9 @@ class TestPromptStack:
         assert prompt_stack.messages[6].role == "role"
         assert isinstance(prompt_stack.messages[6].content[0], GenericMessageContent)
         assert prompt_stack.messages[6].content[0].artifact.value == "foo"
+
+        assert prompt_stack.messages[7].role == "role"
+        assert isinstance(prompt_stack.messages[7].content[0], TextMessageContent)
 
     def test_add_system_message(self, prompt_stack):
         prompt_stack.add_system_message("foo")


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Adds support for adding `ErrorArtifact`'s to the Prompt Stack.
## Issue ticket number and link
Closes #1071 