### PR TITLE
Refactor Conversation Memory class and drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Added
-- `BaseConversationMemory.prompt_driver` for use with autopruning. 
 - Parameter `meta: dict` on `BaseEvent`.
+
+### Changed
+- **BREAKING**: Parameter `driver` on `BaseConversationMemory` renamed to `conversation_memory_driver`.
+- **BREAKING**: `BaseConversationMemory.add_to_prompt_stack` now takes a `prompt_driver` parameter.
+- **BREAKING**: `BaseConversationMemoryDriver.load` now returns `tuple[list[Run], Optional[dict]]`.
+- **BREAKING**: `BaseConversationMemoryDriver.store` now takes `runs: list[Run]` and `metadata: Optional[dict]` as input.
+- **BREAKING**: Parameter `file_path` on `LocalConversationMemoryDriver` renamed to `persist_file` and is now type `Optional[str]`.
+- `Defaults.drivers_config.conversation_memory_driver` now defaults to `LocalConversationMemoryDriver` instead of `None`.
 
 ### Fixed
 - Parsing streaming response with some OpenAi compatible services.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ This document provides instructions for migrating your codebase to accommodate b
 Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.
 Update any logic that expects `ErrorArtifact` to handle exceptions instead.
 
-#### 0.30.X
+#### Before
 ```python
 artifacts = WebLoader().load("https://www.griptape.ai")
 
@@ -17,7 +17,7 @@ if isinstance(artifacts, ErrorArtifact):
     raise Exception(artifacts.value)
 ```
 
-#### 0.31.X
+#### After
 ```python
 try:
     artifacts = WebLoader().load("https://www.griptape.ai")
@@ -25,11 +25,39 @@ except Exception as e:
     raise e
 ```
 
+### LocalConversationMemoryDriver `file_path` renamed to `persist_file`
+
+`LocalConversationMemoryDriver.file_path` has been renamed to `persist_file` and is now `Optional[str]`. If `persist_file` is not passed as a parameter, nothing will be persisted and no errors will be raised. `LocalConversationMemoryDriver` is now the default driver in the global `Defaults` object.
+
+#### Before
+```python
+local_driver_with_file = LocalConversationMemoryDriver(
+    file_path="my_file.json"
+)
+
+local_driver = LocalConversationMemoryDriver()
+
+assert local_driver_with_file.file_path == "my_file.json"
+assert local_driver.file_path == "griptape_memory.json"
+```
+
+#### After
+```python
+local_driver_with_file = LocalConversationMemoryDriver(
+    persist_file="my_file.json"
+)
+
+local_driver = LocalConversationMemoryDriver()
+
+assert local_driver_with_file.persist_file == "my_file.json"
+assert local_driver.persist_file is None
+```
+
 ### Changes to BaseConversationMemoryDriver
 
-`BaseConversationMemoryDriver` has updated parameter names and different method signatures for `.store` and `.load`.
+`BaseConversationMemoryDriver.driver` has been renamed to `conversation_memory_driver`. Method signatures for `.store` and `.load` have been changed.
 
-#### 0.30.X
+#### Before
 ```python
 memory_driver = LocalConversationMemoryDriver()
 
@@ -42,7 +70,7 @@ load_result: BaseConversationMemory = memory_driver.load()
 memory_driver.store(conversation_memory)
 ```
 
-#### 0.31.X
+#### After
 ```python
 memory_driver = LocalConversationMemoryDriver()
 
@@ -56,32 +84,4 @@ memory_driver.store(
     conversation_memory.runs,
     conversation_memory.meta
 )
-```
-
-### LocalConversationMemoryDriver `file_path` renamed to `persist_file`
-
-`LocalConversationMemoryDriver.file_path` has been renamed to `persist_file` and is now `Optional[str]`. If `persist_file` is not passed as a parameter, nothing will be persisted and no errors will be raised. `LocalConversationMemoryDriver` is now the default driver in the global `Defaults` object.
-
-#### 0.30.X
-```python
-local_driver_with_file = LocalConversationMemoryDriver(
-    file_path="my_file.json"
-)
-
-local_driver = LocalConversationMemoryDriver()
-
-assert local_driver_with_file.file_path == "my_file.json"
-assert local_driver.file_path == "griptape_memory.json"
-```
-
-#### 0.31.X
-```python
-local_driver_with_file = LocalConversationMemoryDriver(
-    persist_file="my_file.json"
-)
-
-local_driver = LocalConversationMemoryDriver()
-
-assert local_driver_with_file.persist_file == "my_file.json"
-assert local_driver.persist_file is None
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,16 +9,79 @@ This document provides instructions for migrating your codebase to accommodate b
 Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.
 Update any logic that expects `ErrorArtifact` to handle exceptions instead.
 
+#### 0.30.X
 ```python
-# Before
 artifacts = WebLoader().load("https://www.griptape.ai")
 
 if isinstance(artifacts, ErrorArtifact):
     raise Exception(artifacts.value)
+```
 
-# After
+#### 0.31.X
+```python
 try:
     artifacts = WebLoader().load("https://www.griptape.ai")
 except Exception as e:
     raise e
+```
+
+### Changes to BaseConversationMemoryDriver
+
+`BaseConversationMemoryDriver` has updated parameter names and different method signatures for `.store` and `.load`.
+
+#### 0.30.X
+```python
+memory_driver = LocalConversationMemoryDriver()
+
+conversation_memory = ConversationMemory(
+    driver=memory_driver
+)
+
+load_result: BaseConversationMemory = memory_driver.load()
+
+memory_driver.store(conversation_memory)
+```
+
+#### 0.31.X
+```python
+memory_driver = LocalConversationMemoryDriver()
+
+conversation_memory = ConversationMemory(
+    conversation_memory_driver=memory_driver
+)
+
+load_result: tuple[list[Run], dict[str, Any]] = memory_driver.load()
+
+memory_driver.store(
+    conversation_memory.runs,
+    conversation_memory.meta
+)
+```
+
+### LocalConversationMemoryDriver `file_path` renamed to `persist_file`
+
+`LocalConversationMemoryDriver.file_path` has been renamed to `persist_file` and is now `Optional[str]`. If `persist_file` is not passed as a parameter, nothing will be persisted and no errors will be raised. `LocalConversationMemoryDriver` is now the default driver in the global `Defaults` object.
+
+#### 0.30.X
+```python
+local_driver_with_file = LocalConversationMemoryDriver(
+    file_path="my_file.json"
+)
+
+local_driver = LocalConversationMemoryDriver()
+
+assert local_driver_with_file.file_path == "my_file.json"
+assert local_driver.file_path == "griptape_memory.json"
+```
+
+#### 0.31.X
+```python
+local_driver_with_file = LocalConversationMemoryDriver(
+    persist_file="my_file.json"
+)
+
+local_driver = LocalConversationMemoryDriver()
+
+assert local_driver_with_file.persist_file == "my_file.json"
+assert local_driver.persist_file is None
 ```

--- a/docs/examples/src/amazon_dynamodb_sessions_1.py
+++ b/docs/examples/src/amazon_dynamodb_sessions_1.py
@@ -18,7 +18,7 @@ else:
 
 structure = Agent(
     conversation_memory=ConversationMemory(
-        driver=AmazonDynamoDbConversationMemoryDriver(
+        conversation_memory_driver=AmazonDynamoDbConversationMemoryDriver(
             session=boto3.Session(
                 aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
                 aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_1.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_1.py
@@ -2,8 +2,8 @@ from griptape.drivers import LocalConversationMemoryDriver
 from griptape.memory.structure import ConversationMemory
 from griptape.structures import Agent
 
-local_driver = LocalConversationMemoryDriver(file_path="memory.json")
-agent = Agent(conversation_memory=ConversationMemory(driver=local_driver))
+local_driver = LocalConversationMemoryDriver(persist_file="memory.json")
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=local_driver))
 
 agent.run("Surfing is my favorite sport.")
 agent.run("What is my favorite sport?")

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_2.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_2.py
@@ -13,7 +13,7 @@ dynamodb_driver = AmazonDynamoDbConversationMemoryDriver(
     partition_key_value=conversation_id,
 )
 
-agent = Agent(conversation_memory=ConversationMemory(driver=dynamodb_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=dynamodb_driver))
 
 agent.run("My name is Jeff.")
 agent.run("What is my name?")

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_3.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_3.py
@@ -14,7 +14,7 @@ redis_conversation_driver = RedisConversationMemoryDriver(
     conversation_id=conversation_id,
 )
 
-agent = Agent(conversation_memory=ConversationMemory(driver=redis_conversation_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=redis_conversation_driver))
 
 agent.run("My name is Jeff.")
 agent.run("What is my name?")

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_griptape_cloud.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_griptape_cloud.py
@@ -9,7 +9,7 @@ conversation_id = uuid.uuid4().hex
 cloud_conversation_driver = GriptapeCloudConversationMemoryDriver(
     api_key=os.environ["GT_CLOUD_API_KEY"],
 )
-agent = Agent(conversation_memory=ConversationMemory(driver=cloud_conversation_driver))
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=cloud_conversation_driver))
 
 agent.run("My name is Jeff.")
 agent.run("What is my name?")

--- a/griptape/configs/drivers/base_drivers_config.py
+++ b/griptape/configs/drivers/base_drivers_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attrs import define, field
 
@@ -38,7 +38,7 @@ class BaseDriversConfig(ABC, SerializableMixin):
     _vector_store_driver: BaseVectorStoreDriver = field(
         default=None, kw_only=True, metadata={"serializable": True}, alias="vector_store_driver"
     )
-    _conversation_memory_driver: Optional[BaseConversationMemoryDriver] = field(
+    _conversation_memory_driver: BaseConversationMemoryDriver = field(
         default=None, kw_only=True, metadata={"serializable": True}, alias="conversation_memory_driver"
     )
     _text_to_speech_driver: BaseTextToSpeechDriver = field(
@@ -70,7 +70,7 @@ class BaseDriversConfig(ABC, SerializableMixin):
 
     @lazy_property()
     @abstractmethod
-    def conversation_memory_driver(self) -> Optional[BaseConversationMemoryDriver]: ...
+    def conversation_memory_driver(self) -> BaseConversationMemoryDriver: ...
 
     @lazy_property()
     @abstractmethod

--- a/griptape/configs/drivers/drivers_config.py
+++ b/griptape/configs/drivers/drivers_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attrs import define
 
@@ -13,6 +13,7 @@ from griptape.drivers import (
     DummyPromptDriver,
     DummyTextToSpeechDriver,
     DummyVectorStoreDriver,
+    LocalConversationMemoryDriver,
 )
 from griptape.utils.decorators import lazy_property
 
@@ -52,8 +53,8 @@ class DriversConfig(BaseDriversConfig):
         return DummyVectorStoreDriver(embedding_driver=self.embedding_driver)
 
     @lazy_property()
-    def conversation_memory_driver(self) -> Optional[BaseConversationMemoryDriver]:
-        return None
+    def conversation_memory_driver(self) -> BaseConversationMemoryDriver:
+        return LocalConversationMemoryDriver()
 
     @lazy_property()
     def text_to_speech_driver(self) -> BaseTextToSpeechDriver:

--- a/griptape/drivers/memory/conversation/base_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/base_conversation_memory_driver.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any
 
 from griptape.mixins import SerializableMixin
 
 if TYPE_CHECKING:
-    from griptape.memory.structure import BaseConversationMemory
+    from griptape.memory.structure import Run
 
 
 class BaseConversationMemoryDriver(SerializableMixin, ABC):
     @abstractmethod
-    def store(self, memory: BaseConversationMemory) -> None: ...
+    def store(self, runs: list[Run], metadata: dict[str, Any]) -> None: ...
 
     @abstractmethod
-    def load(self) -> Optional[BaseConversationMemory]: ...
+    def load(self) -> tuple[list[Run], dict[str, Any]]: ...
+
+    def _to_params_dict(self, runs: list[Run], metadata: dict[str, Any]) -> dict:
+        return {"runs": [run.to_dict() for run in runs], "metadata": metadata}
+
+    def _from_params_dict(self, params_dict: dict[str, Any]) -> tuple[list[Run], dict[str, Any]]:
+        from griptape.memory.structure import Run
+
+        return [Run.from_dict(run) for run in params_dict.get("runs", [])], params_dict.get("metadata", {})

--- a/griptape/drivers/memory/conversation/local_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/local_conversation_memory_driver.py
@@ -3,34 +3,33 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import define, field
 
 from griptape.drivers import BaseConversationMemoryDriver
 
 if TYPE_CHECKING:
-    from griptape.memory.structure import BaseConversationMemory
+    from griptape.memory.structure import Run
 
 
-@define
+@define(kw_only=True)
 class LocalConversationMemoryDriver(BaseConversationMemoryDriver):
-    file_path: str = field(default="griptape_memory.json", kw_only=True, metadata={"serializable": True})
+    persist_file: Optional[str] = field(default=None, metadata={"serializable": True})
 
-    def store(self, memory: BaseConversationMemory) -> None:
-        Path(self.file_path).write_text(memory.to_json())
+    def store(self, runs: list[Run], metadata: dict[str, Any]) -> None:
+        if self.persist_file is not None:
+            Path(self.persist_file).write_text(json.dumps(self._to_params_dict(runs, metadata)))
 
-    def load(self) -> Optional[BaseConversationMemory]:
-        from griptape.memory.structure import BaseConversationMemory
+    def load(self) -> tuple[list[Run], dict[str, Any]]:
+        if (
+            self.persist_file is not None
+            and os.path.exists(self.persist_file)
+            and (loaded_str := Path(self.persist_file).read_text()) is not None
+        ):
+            try:
+                return self._from_params_dict(json.loads(loaded_str))
+            except Exception as e:
+                raise ValueError(f"Unable to load data from {self.persist_file}") from e
 
-        if not os.path.exists(self.file_path):
-            return None
-
-        memory_dict = json.loads(Path(self.file_path).read_text())
-        # needed to avoid recursive method calls
-        memory_dict["autoload"] = False
-        memory = BaseConversationMemory.from_dict(memory_dict)
-
-        memory.driver = self
-
-        return memory
+        return [], {}

--- a/griptape/memory/structure/base_conversation_memory.py
+++ b/griptape/memory/structure/base_conversation_memory.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import Factory, define, field
 
 from griptape.common import PromptStack
 from griptape.configs import Defaults
 from griptape.mixins import SerializableMixin
+from griptape.utils import dict_merge
 
 if TYPE_CHECKING:
     from griptape.drivers import BaseConversationMemoryDriver, BasePromptDriver
@@ -16,22 +17,20 @@ if TYPE_CHECKING:
 
 @define
 class BaseConversationMemory(SerializableMixin, ABC):
-    driver: Optional[BaseConversationMemoryDriver] = field(
+    conversation_memory_driver: BaseConversationMemoryDriver = field(
         default=Factory(lambda: Defaults.drivers_config.conversation_memory_driver), kw_only=True
     )
-    prompt_driver: BasePromptDriver = field(
-        default=Factory(lambda: Defaults.drivers_config.prompt_driver), kw_only=True
-    )
     runs: list[Run] = field(factory=list, kw_only=True, metadata={"serializable": True})
+    meta: dict[str, Any] = field(factory=dict, kw_only=True, metadata={"serializable": True})
     autoload: bool = field(default=True, kw_only=True)
     autoprune: bool = field(default=True, kw_only=True)
     max_runs: Optional[int] = field(default=None, kw_only=True, metadata={"serializable": True})
 
     def __attrs_post_init__(self) -> None:
-        if self.driver and self.autoload:
-            memory = self.driver.load()
-            if memory is not None:
-                [self.add_run(r) for r in memory.runs]
+        if self.autoload:
+            runs, meta = self.conversation_memory_driver.load()
+            self.runs.extend(runs)
+            self.meta = dict_merge(self.meta, meta)
 
     def before_add_run(self) -> None:
         pass
@@ -44,8 +43,7 @@ class BaseConversationMemory(SerializableMixin, ABC):
         return self
 
     def after_add_run(self) -> None:
-        if self.driver:
-            self.driver.store(self)
+        self.conversation_memory_driver.store(self.runs, self.meta)
 
     @abstractmethod
     def try_add_run(self, run: Run) -> None: ...
@@ -53,13 +51,16 @@ class BaseConversationMemory(SerializableMixin, ABC):
     @abstractmethod
     def to_prompt_stack(self, last_n: Optional[int] = None) -> PromptStack: ...
 
-    def add_to_prompt_stack(self, prompt_stack: PromptStack, index: Optional[int] = None) -> PromptStack:
+    def add_to_prompt_stack(
+        self, prompt_driver: BasePromptDriver, prompt_stack: PromptStack, index: Optional[int] = None
+    ) -> PromptStack:
         """Add the Conversation Memory runs to the Prompt Stack by modifying the messages in place.
 
         If autoprune is enabled, this will fit as many Conversation Memory runs into the Prompt Stack
         as possible without exceeding the token limit.
 
         Args:
+            prompt_driver: The Prompt Driver to use for token counting.
             prompt_stack: The Prompt Stack to add the Conversation Memory to.
             index: Optional index to insert the Conversation Memory runs at.
                    Defaults to appending to the end of the Prompt Stack.
@@ -82,8 +83,8 @@ class BaseConversationMemory(SerializableMixin, ABC):
                 temp_stack.messages.extend(memory_inputs)
 
                 # Convert the Prompt Stack into tokens left.
-                tokens_left = self.prompt_driver.tokenizer.count_input_tokens_left(
-                    self.prompt_driver.prompt_stack_to_string(temp_stack),
+                tokens_left = prompt_driver.tokenizer.count_input_tokens_left(
+                    prompt_driver.prompt_stack_to_string(temp_stack),
                 )
                 if tokens_left > 0:
                     # There are still tokens left, no need to prune.

--- a/griptape/memory/structure/run.py
+++ b/griptape/memory/structure/run.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import uuid
+from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
 
-from griptape.artifacts.base_artifact import BaseArtifact
 from griptape.mixins import SerializableMixin
 
+if TYPE_CHECKING:
+    from griptape.artifacts import BaseArtifact
 
-@define
+
+@define(kw_only=True)
 class Run(SerializableMixin):
-    id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True, metadata={"serializable": True})
-    input: BaseArtifact = field(kw_only=True, metadata={"serializable": True})
-    output: BaseArtifact = field(kw_only=True, metadata={"serializable": True})
+    id: str = field(default=Factory(lambda: uuid.uuid4().hex), metadata={"serializable": True})
+    meta: Optional[dict] = field(default=None, metadata={"serializable": True})
+    input: BaseArtifact = field(metadata={"serializable": True})
+    output: BaseArtifact = field(metadata={"serializable": True})

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -58,7 +58,7 @@ class PromptTask(RuleMixin, BaseTask):
 
         if memory is not None:
             # insert memory into the stack right before the user messages
-            memory.add_to_prompt_stack(stack, 1 if system_template else 0)
+            memory.add_to_prompt_stack(self.prompt_driver, stack, 1 if system_template else 0)
 
         return stack
 

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -115,7 +115,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
 
         if memory:
             # inserting at index 1 to place memory right after system prompt
-            memory.add_to_prompt_stack(stack, 1)
+            memory.add_to_prompt_stack(self.prompt_driver, stack, 1)
 
         return stack
 

--- a/griptape/utils/__init__.py
+++ b/griptape/utils/__init__.py
@@ -7,11 +7,7 @@ from .command_runner import CommandRunner
 from .chat import Chat
 from .futures import execute_futures_dict, execute_futures_list, execute_futures_list_dict
 from .token_counter import TokenCounter
-from .dict_utils import (
-    remove_null_values_in_dict_recursively,
-    dict_merge,
-    remove_key_in_dict_recursively,
-)
+from .dict_utils import remove_null_values_in_dict_recursively, dict_merge, remove_key_in_dict_recursively
 from .file_utils import load_file, load_files
 from .hash import str_to_hash
 from .import_utils import import_optional_dependency

--- a/griptape/utils/__init__.py
+++ b/griptape/utils/__init__.py
@@ -7,7 +7,11 @@ from .command_runner import CommandRunner
 from .chat import Chat
 from .futures import execute_futures_dict, execute_futures_list, execute_futures_list_dict
 from .token_counter import TokenCounter
-from .dict_utils import remove_null_values_in_dict_recursively, dict_merge, remove_key_in_dict_recursively
+from .dict_utils import (
+    remove_null_values_in_dict_recursively,
+    dict_merge,
+    remove_key_in_dict_recursively,
+)
 from .file_utils import load_file, load_files
 from .hash import str_to_hash
 from .import_utils import import_optional_dependency

--- a/tests/unit/configs/drivers/test_amazon_bedrock_drivers_config.py
+++ b/tests/unit/configs/drivers/test_amazon_bedrock_drivers_config.py
@@ -25,7 +25,10 @@ class TestAmazonBedrockDriversConfig:
 
     def test_to_dict(self, config):
         assert config.to_dict() == {
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "embedding_driver": {"model": "amazon.titan-embed-text-v1", "type": "AmazonBedrockTitanEmbeddingDriver"},
             "image_generation_driver": {
                 "image_generation_model_driver": {
@@ -77,7 +80,10 @@ class TestAmazonBedrockDriversConfig:
 
     def test_to_dict_with_values(self, config_with_values):
         assert config_with_values.to_dict() == {
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "embedding_driver": {"model": "amazon.titan-embed-text-v1", "type": "AmazonBedrockTitanEmbeddingDriver"},
             "image_generation_driver": {
                 "image_generation_model_driver": {

--- a/tests/unit/configs/drivers/test_anthropic_drivers_config.py
+++ b/tests/unit/configs/drivers/test_anthropic_drivers_config.py
@@ -45,7 +45,10 @@ class TestAnthropicDriversConfig:
                     "input_type": "document",
                 },
             },
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "text_to_speech_driver": {"type": "DummyTextToSpeechDriver"},
             "audio_transcription_driver": {"type": "DummyAudioTranscriptionDriver"},
         }

--- a/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
+++ b/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
@@ -36,7 +36,10 @@ class TestAzureOpenAiDriversConfig:
                 "user": "",
                 "use_native_tools": True,
             },
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "embedding_driver": {
                 "base_url": None,
                 "model": "text-embedding-3-small",

--- a/tests/unit/configs/drivers/test_cohere_drivers_config.py
+++ b/tests/unit/configs/drivers/test_cohere_drivers_config.py
@@ -13,7 +13,10 @@ class TestCohereDriversConfig:
             "type": "CohereDriversConfig",
             "image_generation_driver": {"type": "DummyImageGenerationDriver"},
             "image_query_driver": {"type": "DummyImageQueryDriver"},
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "text_to_speech_driver": {"type": "DummyTextToSpeechDriver"},
             "audio_transcription_driver": {"type": "DummyAudioTranscriptionDriver"},
             "prompt_driver": {

--- a/tests/unit/configs/drivers/test_drivers_config.py
+++ b/tests/unit/configs/drivers/test_drivers_config.py
@@ -18,7 +18,10 @@ class TestDriversConfig:
                 "stream": False,
                 "use_native_tools": False,
             },
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "embedding_driver": {"type": "DummyEmbeddingDriver"},
             "image_generation_driver": {"type": "DummyImageGenerationDriver"},
             "image_query_driver": {"type": "DummyImageQueryDriver"},
@@ -56,7 +59,7 @@ class TestDriversConfig:
         assert Defaults.drivers_config.image_query_driver is not None
         assert Defaults.drivers_config.embedding_driver is not None
         assert Defaults.drivers_config.vector_store_driver is not None
-        assert Defaults.drivers_config.conversation_memory_driver is None
+        assert Defaults.drivers_config.conversation_memory_driver is not None
         assert Defaults.drivers_config.text_to_speech_driver is not None
         assert Defaults.drivers_config.audio_transcription_driver is not None
 
@@ -65,6 +68,6 @@ class TestDriversConfig:
         assert Defaults.drivers_config._image_query_driver is not None
         assert Defaults.drivers_config._embedding_driver is not None
         assert Defaults.drivers_config._vector_store_driver is not None
-        assert Defaults.drivers_config._conversation_memory_driver is None
+        assert Defaults.drivers_config._conversation_memory_driver is not None
         assert Defaults.drivers_config._text_to_speech_driver is not None
         assert Defaults.drivers_config._audio_transcription_driver is not None

--- a/tests/unit/configs/drivers/test_google_drivers_config.py
+++ b/tests/unit/configs/drivers/test_google_drivers_config.py
@@ -43,7 +43,10 @@ class TestGoogleDriversConfig:
                     "title": None,
                 },
             },
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "text_to_speech_driver": {"type": "DummyTextToSpeechDriver"},
             "audio_transcription_driver": {"type": "DummyAudioTranscriptionDriver"},
         }

--- a/tests/unit/configs/drivers/test_openai_driver_config.py
+++ b/tests/unit/configs/drivers/test_openai_driver_config.py
@@ -28,7 +28,10 @@ class TestOpenAiDriversConfig:
                 "user": "",
                 "use_native_tools": True,
             },
-            "conversation_memory_driver": None,
+            "conversation_memory_driver": {
+                "type": "LocalConversationMemoryDriver",
+                "persist_file": None,
+            },
             "embedding_driver": {
                 "base_url": None,
                 "model": "text-embedding-3-small",

--- a/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_dynamodb_conversation_memory_driver.py
@@ -46,7 +46,7 @@ class TestDynamoDbConversationMemoryDriver:
             value_attribute_key=self.VALUE_ATTRIBUTE_KEY,
             partition_key_value=self.PARTITION_KEY_VALUE,
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -72,7 +72,7 @@ class TestDynamoDbConversationMemoryDriver:
             sort_key="sortKey",
             sort_key_value="foo",
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver)
         pipeline = Pipeline(conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -93,7 +93,7 @@ class TestDynamoDbConversationMemoryDriver:
             value_attribute_key=self.VALUE_ATTRIBUTE_KEY,
             partition_key_value=self.PARTITION_KEY_VALUE,
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver, meta={"foo": "bar"})
         pipeline = Pipeline(conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -101,12 +101,10 @@ class TestDynamoDbConversationMemoryDriver:
         pipeline.run()
         pipeline.run()
 
-        new_memory = memory_driver.load()
+        runs, metadata = memory_driver.load()
 
-        assert new_memory.type == "ConversationMemory"
-        assert len(new_memory.runs) == 2
-        assert new_memory.runs[0].input.value == "test"
-        assert new_memory.runs[0].output.value == "mock output"
+        assert len(runs) == 2
+        assert metadata == {"foo": "bar"}
 
     def test_load_with_sort_key(self):
         memory_driver = AmazonDynamoDbConversationMemoryDriver(
@@ -118,7 +116,7 @@ class TestDynamoDbConversationMemoryDriver:
             sort_key="sortKey",
             sort_key_value="foo",
         )
-        memory = ConversationMemory(driver=memory_driver)
+        memory = ConversationMemory(conversation_memory_driver=memory_driver, meta={"foo": "bar"})
         pipeline = Pipeline(conversation_memory=memory)
 
         pipeline.add_task(PromptTask("test"))
@@ -126,9 +124,7 @@ class TestDynamoDbConversationMemoryDriver:
         pipeline.run()
         pipeline.run()
 
-        new_memory = memory_driver.load()
+        runs, metadata = memory_driver.load()
 
-        assert new_memory.type == "ConversationMemory"
-        assert len(new_memory.runs) == 2
-        assert new_memory.runs[0].input.value == "test"
-        assert new_memory.runs[0].output.value == "mock output"
+        assert len(runs) == 2
+        assert metadata == {"foo": "bar"}

--- a/tests/unit/drivers/memory/conversation/test_griptape_cloud_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_griptape_cloud_conversation_memory_driver.py
@@ -1,10 +1,11 @@
 import json
+import os
 
 import pytest
 
 from griptape.artifacts import BaseArtifact
 from griptape.drivers import GriptapeCloudConversationMemoryDriver
-from griptape.memory.structure import BaseConversationMemory, ConversationMemory, Run, SummaryConversationMemory
+from griptape.memory.structure import Run
 
 TEST_CONVERSATION = '{"type": "SummaryConversationMemory", "runs": [{"type": "Run", "id": "729ca6be5d79433d9762eb06dfd677e2", "input": {"type": "TextArtifact", "id": "1234", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "id": "123", "value": "Hello! How can I assist you today?"}}], "max_runs": 2}'
 
@@ -23,6 +24,7 @@ class TestGriptapeCloudConversationMemoryDriver:
                                 "input": '{"type": "TextArtifact", "id": "1234", "value": "Hi There, Hello"}',
                                 "output": '{"type": "TextArtifact", "id": "123", "value": "Hello! How can I assist you today?"}',
                                 "index": 0,
+                                "metadata": {"run_id": "1234"},
                             }
                         ]
                     },
@@ -32,7 +34,7 @@ class TestGriptapeCloudConversationMemoryDriver:
                 return mocker.Mock(
                     raise_for_status=lambda: None,
                     json=lambda: {
-                        "metadata": json.loads(TEST_CONVERSATION),
+                        "metadata": {"foo": "bar"},
                         "name": "test",
                         "thread_id": "test_metadata",
                     }
@@ -44,12 +46,22 @@ class TestGriptapeCloudConversationMemoryDriver:
             "requests.get",
             side_effect=get,
         )
+
+        def post(*args, **kwargs):
+            if str(args[0]).endswith("/threads"):
+                return mocker.Mock(
+                    raise_for_status=lambda: None,
+                    json=lambda: {"thread_id": "test", "name": "test"},
+                )
+            else:
+                return mocker.Mock(
+                    raise_for_status=lambda: None,
+                    json=lambda: {"message_id": "test"},
+                )
+
         mocker.patch(
             "requests.post",
-            return_value=mocker.Mock(
-                raise_for_status=lambda: None,
-                json=lambda: {"thread_id": "test", "name": "test"},
-            ),
+            side_effect=post,
         )
         mocker.patch(
             "requests.patch",
@@ -66,26 +78,28 @@ class TestGriptapeCloudConversationMemoryDriver:
         with pytest.raises(ValueError):
             GriptapeCloudConversationMemoryDriver(api_key=None, thread_id="test")
 
-    def test_no_thread_id(self):
+    def test_thread_id(self):
         driver = GriptapeCloudConversationMemoryDriver(api_key="test")
         assert driver.thread_id == "test"
+        os.environ["GT_CLOUD_THREAD_ID"] = "test_env"
+        driver = GriptapeCloudConversationMemoryDriver(api_key="test")
+        assert driver.thread_id == "test_env"
+        driver = GriptapeCloudConversationMemoryDriver(api_key="test", thread_id="test_init")
+        assert driver.thread_id == "test_init"
 
-    def test_store(self, driver):
-        memory = ConversationMemory(
-            runs=[
-                Run(input=BaseArtifact.from_dict(run["input"]), output=BaseArtifact.from_dict(run["output"]))
-                for run in json.loads(TEST_CONVERSATION)["runs"]
-            ],
-        )
-        assert driver.store(memory) is None
+    def test_store(self, driver: GriptapeCloudConversationMemoryDriver):
+        runs = [
+            Run(input=BaseArtifact.from_dict(run["input"]), output=BaseArtifact.from_dict(run["output"]))
+            for run in json.loads(TEST_CONVERSATION)["runs"]
+        ]
+        assert driver.store(runs, {}) is None
 
     def test_load(self, driver):
-        memory = driver.load()
-        assert isinstance(memory, BaseConversationMemory)
-        assert len(memory.runs) == 1
-
-    def test_load_metadata(self, driver):
+        runs, metadata = driver.load()
+        assert len(runs) == 1
+        assert runs[0].id == "1234"
+        assert metadata == {}
         driver.thread_id = "test_metadata"
-        memory = driver.load()
-        assert isinstance(memory, SummaryConversationMemory)
-        assert len(memory.runs) == 1
+        runs, metadata = driver.load()
+        assert len(runs) == 1
+        assert metadata == {"foo": "bar"}

--- a/tests/unit/drivers/memory/conversation/test_redis_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_redis_conversation_memory_driver.py
@@ -4,7 +4,8 @@ import redis
 from griptape.drivers.memory.conversation.redis_conversation_memory_driver import RedisConversationMemoryDriver
 from griptape.memory.structure.base_conversation_memory import BaseConversationMemory
 
-TEST_CONVERSATION = '{"type": "ConversationMemory", "runs": [{"type": "Run", "id": "729ca6be5d79433d9762eb06dfd677e2", "input": {"type": "TextArtifact", "id": "1234", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "id": "123", "value": "Hello! How can I assist you today?"}}], "max_runs": 2}'
+TEST_DATA = '{"runs": [{"input": {"type": "TextArtifact", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "value": "Hello! How can I assist you today?"}}], "metadata": {"foo": "bar"}}'
+TEST_MEMORY = '{"type": "ConversationMemory", "runs": [{"type": "Run", "id": "729ca6be5d79433d9762eb06dfd677e2", "input": {"type": "TextArtifact", "id": "1234", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "id": "123", "value": "Hello! How can I assist you today?"}}], "max_runs": 2}'
 CONVERSATION_ID = "117151897f344ff684b553d0655d8f39"
 INDEX = "griptape_conversation"
 HOST = "127.0.0.1"
@@ -17,7 +18,7 @@ class TestRedisConversationMemoryDriver:
     def _mock_redis(self, mocker):
         mocker.patch.object(redis.StrictRedis, "hset", return_value=None)
         mocker.patch.object(redis.StrictRedis, "keys", return_value=[b"test"])
-        mocker.patch.object(redis.StrictRedis, "hget", return_value=TEST_CONVERSATION)
+        mocker.patch.object(redis.StrictRedis, "hget", return_value=TEST_DATA)
 
         fake_redisearch = mocker.MagicMock()
         fake_redisearch.search = mocker.MagicMock(return_value=mocker.MagicMock(docs=[]))
@@ -31,11 +32,16 @@ class TestRedisConversationMemoryDriver:
         return RedisConversationMemoryDriver(host=HOST, port=PORT, db=0, index=INDEX, conversation_id=CONVERSATION_ID)
 
     def test_store(self, driver):
-        memory = BaseConversationMemory.from_json(TEST_CONVERSATION)
-        assert driver.store(memory) is None
+        memory = BaseConversationMemory.from_json(TEST_MEMORY)
+        assert driver.store(memory.runs, memory.meta) is None
 
     def test_load(self, driver):
-        memory = driver.load()
-        assert memory.type == "ConversationMemory"
-        assert memory.max_runs == 2
-        assert memory.runs == BaseConversationMemory.from_json(TEST_CONVERSATION).runs
+        runs, metadata = driver.load()
+        assert len(runs) == 1
+        assert metadata == {"foo": "bar"}
+
+    def test_load_empty(self, mocker, driver):
+        mocker.patch.object(redis.StrictRedis, "hget", return_value=None)
+        runs, metadata = driver.load()
+        assert len(runs) == 0
+        assert metadata == {}

--- a/tests/unit/memory/structure/test_conversation_memory.py
+++ b/tests/unit/memory/structure/test_conversation_memory.py
@@ -90,7 +90,7 @@ class TestConversationMemory:
         prompt_stack = PromptStack()
         prompt_stack.add_user_message(TextArtifact("foo"))
         prompt_stack.add_assistant_message("bar")
-        memory.add_to_prompt_stack(prompt_stack)
+        memory.add_to_prompt_stack(agent.prompt_driver, prompt_stack)
 
         assert len(prompt_stack.messages) == 12
 
@@ -116,7 +116,7 @@ class TestConversationMemory:
         prompt_stack.add_system_message("fizz")
         prompt_stack.add_user_message("foo")
         prompt_stack.add_assistant_message("bar")
-        memory.add_to_prompt_stack(prompt_stack)
+        memory.add_to_prompt_stack(agent.prompt_driver, prompt_stack)
 
         assert len(prompt_stack.messages) == 3
 
@@ -140,7 +140,7 @@ class TestConversationMemory:
         prompt_stack.add_system_message("fizz")
         prompt_stack.add_user_message("foo")
         prompt_stack.add_assistant_message("bar")
-        memory.add_to_prompt_stack(prompt_stack)
+        memory.add_to_prompt_stack(agent.prompt_driver, prompt_stack)
 
         assert len(prompt_stack.messages) == 13
 
@@ -168,7 +168,7 @@ class TestConversationMemory:
         prompt_stack.add_system_message("fizz")
         prompt_stack.add_user_message("foo")
         prompt_stack.add_assistant_message("bar")
-        memory.add_to_prompt_stack(prompt_stack, 1)
+        memory.add_to_prompt_stack(agent.prompt_driver, prompt_stack, 1)
 
         # We expect one run (2 Prompt Stack inputs) to be pruned.
         assert len(prompt_stack.messages) == 11

--- a/tests/unit/utils/test_dict_utils.py
+++ b/tests/unit/utils/test_dict_utils.py
@@ -1,10 +1,6 @@
 import pytest
 
-from griptape.utils import (
-    dict_merge,
-    remove_key_in_dict_recursively,
-    remove_null_values_in_dict_recursively,
-)
+from griptape.utils import dict_merge, remove_key_in_dict_recursively, remove_null_values_in_dict_recursively
 
 
 class TestDictUtils:

--- a/tests/unit/utils/test_dict_utils.py
+++ b/tests/unit/utils/test_dict_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from griptape.utils import dict_merge, remove_key_in_dict_recursively, remove_null_values_in_dict_recursively
+from griptape.utils import (
+    dict_merge,
+    remove_key_in_dict_recursively,
+    remove_null_values_in_dict_recursively,
+)
 
 
 class TestDictUtils:


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
- Update `LocalConversationMemory` with an optional `persist_file`, consistent with `LocalVectorStoreDriver`
-  update return value of `load` to a tuple instead of instance
- update `BaseConversationMemory.to_prompt_stack` to take a prompt driver.

## Issue ticket number and link
