### PR TITLE
Fix parsing response with openai-compatible endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Parsing streaming response with some OpenAi compatible services.
+
 ## [0.30.0] - 2024-08-20
 
 ### Added

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -119,14 +119,11 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                         output_tokens=chunk.usage.completion_tokens,
                     ),
                 )
-            elif chunk.choices is not None:
-                if len(chunk.choices) == 1:
-                    choice = chunk.choices[0]
-                    delta = choice.delta
+            if chunk.choices:
+                choice = chunk.choices[0]
+                delta = choice.delta
 
-                    yield DeltaMessage(content=self.__to_prompt_stack_delta_message_content(delta))
-                else:
-                    raise Exception("Completion with more than one choice is not supported yet.")
+                yield DeltaMessage(content=self.__to_prompt_stack_delta_message_content(delta))
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         params = {


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Some openai-compatible services respond with usage _and_ choices, unlike OpenAi itself. 
```python
import os

from griptape.configs import Defaults
from griptape.configs.drivers import OpenAiDriversConfig
from griptape.drivers import OpenAiChatPromptDriver
from griptape.structures import Agent

Defaults.drivers_config = OpenAiDriversConfig(
    prompt_driver=OpenAiChatPromptDriver(
        base_url="https://integrate.api.nvidia.com/v1",
        api_key=os.getenv("NVIDIA_API_KEY"),
        model="meta/llama-3.1-405b-instruct",
    )
)
agent = Agent(stream=True)


agent.run("What is the capital of France?")
```
## Issue ticket number and link
Offline discussion