### PR TITLE
Remove many instances of catching exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseConversationMemory.prompt_driver` for use with autopruning. 
 - Parameter `meta: dict` on `BaseEvent`.
 
+### Changed
+- **BREAKING**: Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.
+
 ### Fixed
 - Parsing streaming response with some OpenAi compatible services.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseConversationMemory.prompt_driver` for use with autopruning. 
 - Parameter `meta: dict` on `BaseEvent`.
 
-### Changed
-- **BREAKING**: Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.
-
 ### Fixed
 - Parsing streaming response with some OpenAi compatible services.
 
-**Note**: This release includes breaking changes. Please refer to the [Migration Guide](MIGRATION.md#0.31.0) for details.
+**Note**: This release includes breaking changes. Please refer to the [Migration Guide](./MIGRATION.md#030x-to-031x) for details.
 
 ## [0.30.1] - 2024-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Parsing streaming response with some OpenAi compatible services.
 
-**Note**: This release includes breaking changes. Please refer to the [Migration Guide](./MIGRATION.md#030x-to-031x) for details.
+**Note**: This release includes breaking changes. Please refer to the [Migration Guide](MIGRATION.md#0.31.0) for details.
 
 ## [0.30.1] - 2024-08-21
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,4 +2,4 @@
 
 This document provides instructions for migrating your codebase to accommodate breaking changes introduced in new versions of Griptape.
 
-## 0.30.X to 0.31.X
+## 0.30.X -> 0.31.X

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,4 +2,23 @@
 
 This document provides instructions for migrating your codebase to accommodate breaking changes introduced in new versions of Griptape.
 
-## 0.30.X -> 0.31.X
+## 0.30.X to 0.31.X
+
+### Exceptions Over `ErrorArtifact`s
+
+Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.
+Update any logic that expects `ErrorArtifact` to handle exceptions instead.
+
+```python
+# Before
+artifacts = WebLoader().load("https://www.griptape.ai")
+
+if isinstance(artifacts, ErrorArtifact):
+    raise Exception(artifacts.value)
+
+# After
+try:
+    artifacts = WebLoader().load("https://www.griptape.ai")
+except Exception as e:
+    raise e
+```

--- a/docs/examples/src/load_query_and_chat_marqo_1.py
+++ b/docs/examples/src/load_query_and_chat_marqo_1.py
@@ -1,7 +1,6 @@
 import os
 
 from griptape import utils
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import MarqoVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 from griptape.structures import Agent
@@ -26,9 +25,6 @@ vector_store_tool = VectorStoreTool(
 
 # Load artifacts from the web
 artifacts = WebLoader().load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert the artifacts into the vector store
 vector_store.upsert_text_artifacts(

--- a/docs/examples/src/query_webpage_1.py
+++ b/docs/examples/src/query_webpage_1.py
@@ -1,14 +1,11 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
 vector_store = LocalVectorStoreDriver(embedding_driver=OpenAiEmbeddingDriver(api_key=os.environ["OPENAI_API_KEY"]))
 
 artifacts = WebLoader(max_tokens=100).load("https://www.griptape.ai")
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 for a in artifacts:
     vector_store.upsert_text_artifact(a, namespace="griptape")

--- a/docs/examples/src/query_webpage_astra_db_1.py
+++ b/docs/examples/src/query_webpage_astra_db_1.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts import ErrorArtifact
 from griptape.drivers import (
     AstraDbVectorStoreDriver,
     OpenAiChatPromptDriver,
@@ -45,8 +44,7 @@ engine = RagEngine(
 )
 
 artifacts = WebLoader(max_tokens=256).load(input_blogpost)
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
+
 vector_store_driver.upsert_text_artifacts({namespace: artifacts})
 
 rag_tool = RagTool(

--- a/docs/examples/src/talk_to_a_pdf_1.py
+++ b/docs/examples/src/talk_to_a_pdf_1.py
@@ -1,6 +1,5 @@
 import requests
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiChatPromptDriver, OpenAiEmbeddingDriver
 from griptape.engines.rag import RagEngine
 from griptape.engines.rag.modules import PromptResponseRagModule, VectorStoreRetrievalRagModule
@@ -32,8 +31,6 @@ rag_tool = RagTool(
 )
 
 artifacts = PdfLoader().load(response.content)
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 vector_store.upsert_text_artifacts({namespace: artifacts})
 

--- a/docs/examples/src/talk_to_a_webpage_1.py
+++ b/docs/examples/src/talk_to_a_webpage_1.py
@@ -1,4 +1,3 @@
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiChatPromptDriver, OpenAiEmbeddingDriver
 from griptape.engines.rag import RagEngine
 from griptape.engines.rag.modules import PromptResponseRagModule, VectorStoreRetrievalRagModule
@@ -27,9 +26,6 @@ engine = RagEngine(
 )
 
 artifacts = WebLoader().load("https://en.wikipedia.org/wiki/Physics")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 vector_store_driver.upsert_text_artifacts({namespace: artifacts})
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_1.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_1.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -12,8 +11,6 @@ vector_store_driver = LocalVectorStoreDriver(embedding_driver=embedding_driver)
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=100).load("https://www.griptape.ai")
 
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 # Upsert Artifacts into the Vector Store Driver
 [vector_store_driver.upsert_text_artifact(a, namespace="griptape") for a in artifacts]
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_10.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_10.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import OpenAiEmbeddingDriver, QdrantVectorStoreDriver
 from griptape.loaders import WebLoader
 
@@ -21,9 +20,6 @@ vector_store_driver = QdrantVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader().load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Recreate Qdrant collection
 vector_store_driver.client.recreate_collection(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_11.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_11.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import AstraDbVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -22,9 +21,6 @@ vector_store_driver = AstraDbVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader().load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 [vector_store_driver.upsert_text_artifact(a, namespace="griptape") for a in artifacts]

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_3.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_3.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts import ErrorArtifact
 from griptape.drivers import OpenAiEmbeddingDriver, PineconeVectorStoreDriver
 from griptape.loaders import WebLoader
 
@@ -16,9 +15,6 @@ vector_store_driver = PineconeVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=100).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 [vector_store_driver.upsert_text_artifact(a, namespace="griptape") for a in artifacts]

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_4.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_4.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts import ErrorArtifact
 from griptape.drivers import MarqoVectorStoreDriver, OpenAiChatPromptDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -21,9 +20,6 @@ vector_store_driver = MarqoVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=200).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_5.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_5.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import MongoDbAtlasVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -27,9 +26,6 @@ vector_store_driver = MongoDbAtlasVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=200).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_6.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_6.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import AzureMongoDbVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -27,9 +26,6 @@ vector_store_driver = AzureMongoDbVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=200).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_7.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_7.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import OpenAiEmbeddingDriver, RedisVectorStoreDriver
 from griptape.loaders import WebLoader
 
@@ -17,9 +16,6 @@ vector_store_driver = RedisVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=200).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_8.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_8.py
@@ -2,7 +2,6 @@ import os
 
 import boto3
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import AmazonOpenSearchVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 
@@ -18,9 +17,6 @@ vector_store_driver = AmazonOpenSearchVectorStoreDriver(
 
 # Load Artifacts from the web
 artifacts = WebLoader(max_tokens=200).load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_9.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_9.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import OpenAiEmbeddingDriver, PgVectorVectorStoreDriver
 from griptape.loaders import WebLoader
 
@@ -24,9 +23,6 @@ vector_store_driver.setup()
 
 # Load Artifacts from the web
 artifacts = WebLoader().load("https://www.griptape.ai")
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 # Upsert Artifacts into the Vector Store Driver
 vector_store_driver.upsert_text_artifacts(

--- a/docs/griptape-framework/engines/src/rag_engines_1.py
+++ b/docs/griptape-framework/engines/src/rag_engines_1.py
@@ -1,4 +1,3 @@
-from griptape.artifacts import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiChatPromptDriver, OpenAiEmbeddingDriver
 from griptape.engines.rag import RagContext, RagEngine
 from griptape.engines.rag.modules import PromptResponseRagModule, TranslateQueryRagModule, VectorStoreRetrievalRagModule
@@ -11,8 +10,6 @@ prompt_driver = OpenAiChatPromptDriver(model="gpt-4o", temperature=0)
 vector_store = LocalVectorStoreDriver(embedding_driver=OpenAiEmbeddingDriver())
 artifacts = WebLoader(max_tokens=500).load("https://www.griptape.ai")
 
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 vector_store.upsert_text_artifacts(
     {

--- a/docs/griptape-framework/engines/src/summary_engines_1.py
+++ b/docs/griptape-framework/engines/src/summary_engines_1.py
@@ -1,6 +1,5 @@
 import requests
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import OpenAiChatPromptDriver
 from griptape.engines import PromptSummaryEngine
 from griptape.loaders import PdfLoader
@@ -11,9 +10,6 @@ engine = PromptSummaryEngine(
 )
 
 artifacts = PdfLoader().load(response.content)
-
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 text = "\n\n".join([a.value for a in artifacts])
 

--- a/docs/griptape-tools/official-tools/src/vector_store_tool_1.py
+++ b/docs/griptape-tools/official-tools/src/vector_store_tool_1.py
@@ -1,4 +1,3 @@
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import LocalVectorStoreDriver, OpenAiEmbeddingDriver
 from griptape.loaders import WebLoader
 from griptape.structures import Agent
@@ -9,8 +8,6 @@ vector_store_driver = LocalVectorStoreDriver(
 )
 
 artifacts = WebLoader().load("https://www.griptape.ai")
-if isinstance(artifacts, ErrorArtifact):
-    raise Exception(artifacts.value)
 
 vector_store_driver.upsert_text_artifacts({"griptape": artifacts})
 vector_db = VectorStoreTool(

--- a/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
+++ b/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 from attrs import Factory, define, field
 
-from griptape.artifacts import BaseArtifact, ErrorArtifact, InfoArtifact
+from griptape.artifacts import BaseArtifact, InfoArtifact
 from griptape.drivers.structure_run.base_structure_run_driver import BaseStructureRunDriver
 
 
@@ -23,28 +23,25 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
     structure_run_max_wait_time_attempts: int = field(default=20, kw_only=True)
     async_run: bool = field(default=False, kw_only=True)
 
-    def try_run(self, *args: BaseArtifact) -> BaseArtifact:
-        from requests import HTTPError, Response, exceptions, post
+    def try_run(self, *args: BaseArtifact) -> BaseArtifact | InfoArtifact:
+        from requests import Response, post
 
         url = urljoin(self.base_url.strip("/"), f"/api/structures/{self.structure_id}/runs")
 
-        try:
-            response: Response = post(
-                url,
-                json={"args": [arg.value for arg in args], "env": self.env},
-                headers=self.headers,
-            )
-            response.raise_for_status()
-            response_json = response.json()
+        response: Response = post(
+            url,
+            json={"args": [arg.value for arg in args], "env": self.env},
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        response_json = response.json()
 
-            if self.async_run:
-                return InfoArtifact("Run started successfully")
-            else:
-                return self._get_structure_run_result(response_json["structure_run_id"])
-        except (exceptions.RequestException, HTTPError) as err:
-            return ErrorArtifact(str(err))
+        if self.async_run:
+            return InfoArtifact("Run started successfully")
+        else:
+            return self._get_structure_run_result(response_json["structure_run_id"])
 
-    def _get_structure_run_result(self, structure_run_id: str) -> InfoArtifact | BaseArtifact | ErrorArtifact:
+    def _get_structure_run_result(self, structure_run_id: str) -> BaseArtifact | InfoArtifact:
         url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{structure_run_id}")
 
         result = self._get_structure_run_result_attempt(url)
@@ -59,12 +56,10 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
             status = result["status"]
 
         if wait_attempts >= self.structure_run_max_wait_time_attempts:
-            return ErrorArtifact(
-                f"Failed to get Run result after {self.structure_run_max_wait_time_attempts} attempts.",
-            )
+            raise Exception(f"Failed to get Run result after {self.structure_run_max_wait_time_attempts} attempts.")
 
         if status != "SUCCEEDED":
-            return ErrorArtifact(result)
+            raise Exception(f"Run failed with status: {status}")
 
         if "output" in result:
             return BaseArtifact.from_dict(result["output"])

--- a/griptape/engines/extraction/base_extraction_engine.py
+++ b/griptape/engines/extraction/base_extraction_engine.py
@@ -9,7 +9,7 @@ from griptape.chunkers import BaseChunker, TextChunker
 from griptape.configs import Defaults
 
 if TYPE_CHECKING:
-    from griptape.artifacts import ErrorArtifact, ListArtifact
+    from griptape.artifacts import ListArtifact
     from griptape.drivers import BasePromptDriver
     from griptape.rules import Ruleset
 
@@ -54,4 +54,4 @@ class BaseExtractionEngine(ABC):
         *,
         rulesets: Optional[list[Ruleset]] = None,
         **kwargs,
-    ) -> ListArtifact | ErrorArtifact: ...
+    ) -> ListArtifact: ...

--- a/griptape/engines/extraction/csv_extraction_engine.py
+++ b/griptape/engines/extraction/csv_extraction_engine.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, cast
 
 from attrs import Factory, define, field
 
-from griptape.artifacts import CsvRowArtifact, ErrorArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import CsvRowArtifact, ListArtifact, TextArtifact
 from griptape.common import Message, PromptStack
 from griptape.engines import BaseExtractionEngine
 from griptape.utils import J2
@@ -27,17 +27,14 @@ class CsvExtractionEngine(BaseExtractionEngine):
         *,
         rulesets: Optional[list[Ruleset]] = None,
         **kwargs,
-    ) -> ListArtifact | ErrorArtifact:
-        try:
-            return ListArtifact(
-                self._extract_rec(
-                    cast(list[TextArtifact], text.value) if isinstance(text, ListArtifact) else [TextArtifact(text)],
-                    [],
-                ),
-                item_separator="\n",
-            )
-        except Exception as e:
-            return ErrorArtifact(f"error extracting CSV rows: {e}")
+    ) -> ListArtifact:
+        return ListArtifact(
+            self._extract_rec(
+                cast(list[TextArtifact], text.value) if isinstance(text, ListArtifact) else [TextArtifact(text)],
+                [],
+            ),
+            item_separator="\n",
+        )
 
     def text_to_csv_rows(self, text: str, column_names: list[str]) -> list[CsvRowArtifact]:
         rows = []

--- a/griptape/engines/extraction/json_extraction_engine.py
+++ b/griptape/engines/extraction/json_extraction_engine.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, cast
 
 from attrs import Factory, define, field
 
-from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import ListArtifact, TextArtifact
 from griptape.common import PromptStack
 from griptape.common.prompt_stack.messages.message import Message
 from griptape.engines import BaseExtractionEngine
@@ -32,18 +32,15 @@ class JsonExtractionEngine(BaseExtractionEngine):
         *,
         rulesets: Optional[list[Ruleset]] = None,
         **kwargs,
-    ) -> ListArtifact | ErrorArtifact:
-        try:
-            return ListArtifact(
-                self._extract_rec(
-                    cast(list[TextArtifact], text.value) if isinstance(text, ListArtifact) else [TextArtifact(text)],
-                    [],
-                    rulesets=rulesets,
-                ),
-                item_separator="\n",
-            )
-        except Exception as e:
-            return ErrorArtifact(f"error extracting JSON: {e}")
+    ) -> ListArtifact:
+        return ListArtifact(
+            self._extract_rec(
+                cast(list[TextArtifact], text.value) if isinstance(text, ListArtifact) else [TextArtifact(text)],
+                [],
+                rulesets=rulesets,
+            ),
+            item_separator="\n",
+        )
 
     def json_to_text_artifacts(self, json_input: str) -> list[TextArtifact]:
         json_matches = re.findall(self.JSON_PATTERN, json_input, re.DOTALL)

--- a/griptape/engines/rag/modules/retrieval/text_loader_retrieval_rag_module.py
+++ b/griptape/engines/rag/modules/retrieval/text_loader_retrieval_rag_module.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Any, Callable
 from attrs import Factory, define, field
 
 from griptape import utils
-from griptape.artifacts import ErrorArtifact, TextArtifact
 from griptape.engines.rag.modules import BaseRetrievalRagModule
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from griptape.artifacts import TextArtifact
     from griptape.drivers import BaseVectorStoreDriver
     from griptape.engines.rag import RagContext
     from griptape.loaders import BaseTextLoader
@@ -38,8 +38,6 @@ class TextLoaderRetrievalRagModule(BaseRetrievalRagModule):
 
         loader_output = self.loader.load(source)
 
-        if isinstance(loader_output, ErrorArtifact):
-            raise Exception(loader_output.to_text() if loader_output.exception is None else loader_output.exception)
         self.vector_store_driver.upsert_text_artifacts({namespace: loader_output})
 
         return self.process_query_output_fn(self.vector_store_driver.query(context.query, **query_params))

--- a/griptape/loaders/base_text_loader.py
+++ b/griptape/loaders/base_text_loader.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from attrs import Factory, define, field
 
 from griptape.artifacts import TextArtifact
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.chunkers import BaseChunker, TextChunker
 from griptape.loaders import BaseLoader
 from griptape.tokenizers import OpenAiTokenizer
@@ -40,11 +39,11 @@ class BaseTextLoader(BaseLoader, ABC):
     reference: Optional[Reference] = field(default=None, kw_only=True)
 
     @abstractmethod
-    def load(self, source: Any, *args, **kwargs) -> ErrorArtifact | list[TextArtifact]: ...
+    def load(self, source: Any, *args, **kwargs) -> list[TextArtifact]: ...
 
-    def load_collection(self, sources: list[Any], *args, **kwargs) -> dict[str, ErrorArtifact | list[TextArtifact]]:
+    def load_collection(self, sources: list[Any], *args, **kwargs) -> dict[str, list[TextArtifact]]:
         return cast(
-            dict[str, Union[ErrorArtifact, list[TextArtifact]]],
+            dict[str, list[TextArtifact]],
             super().load_collection(sources, *args, **kwargs),
         )
 

--- a/griptape/loaders/blob_loader.py
+++ b/griptape/loaders/blob_loader.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from attrs import define
 
-from griptape.artifacts import BlobArtifact, ErrorArtifact
+from griptape.artifacts import BlobArtifact
 from griptape.loaders import BaseLoader
 
 
 @define
 class BlobLoader(BaseLoader):
-    def load(self, source: Any, *args, **kwargs) -> BlobArtifact | ErrorArtifact:
+    def load(self, source: Any, *args, **kwargs) -> BlobArtifact:
         if self.encoding is None:
             return BlobArtifact(source)
         else:
             return BlobArtifact(source, encoding=self.encoding)
 
-    def load_collection(self, sources: list[bytes | str], *args, **kwargs) -> dict[str, BlobArtifact | ErrorArtifact]:
-        return cast(dict[str, Union[BlobArtifact, ErrorArtifact]], super().load_collection(sources, *args, **kwargs))
+    def load_collection(self, sources: list[bytes | str], *args, **kwargs) -> dict[str, BlobArtifact]:
+        return cast(dict[str, BlobArtifact], super().load_collection(sources, *args, **kwargs))

--- a/griptape/loaders/csv_loader.py
+++ b/griptape/loaders/csv_loader.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import csv
 from io import StringIO
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from attrs import define, field
 
-from griptape.artifacts import CsvRowArtifact, ErrorArtifact
+from griptape.artifacts import CsvRowArtifact
 from griptape.loaders import BaseLoader
 
 if TYPE_CHECKING:
@@ -19,16 +19,13 @@ class CsvLoader(BaseLoader):
     delimiter: str = field(default=",", kw_only=True)
     encoding: str = field(default="utf-8", kw_only=True)
 
-    def load(self, source: bytes | str, *args, **kwargs) -> ErrorArtifact | list[CsvRowArtifact]:
+    def load(self, source: bytes | str, *args, **kwargs) -> list[CsvRowArtifact]:
         artifacts = []
 
         if isinstance(source, bytes):
-            try:
-                source = source.decode(encoding=self.encoding)
-            except UnicodeDecodeError:
-                return ErrorArtifact(f"Failed to decode bytes to string using encoding: {self.encoding}")
+            source = source.decode(encoding=self.encoding)
         elif isinstance(source, (bytearray, memoryview)):
-            return ErrorArtifact(f"Unsupported source type: {type(source)}")
+            raise ValueError(f"Unsupported source type: {type(source)}")
 
         reader = csv.DictReader(StringIO(source), delimiter=self.delimiter)
         chunks = [CsvRowArtifact(row) for row in reader]
@@ -47,8 +44,8 @@ class CsvLoader(BaseLoader):
         sources: list[bytes | str],
         *args,
         **kwargs,
-    ) -> dict[str, ErrorArtifact | list[CsvRowArtifact]]:
+    ) -> dict[str, list[CsvRowArtifact]]:
         return cast(
-            dict[str, Union[ErrorArtifact, list[CsvRowArtifact]]],
+            dict[str, list[CsvRowArtifact]],
             super().load_collection(sources, *args, **kwargs),
         )

--- a/griptape/loaders/email_loader.py
+++ b/griptape/loaders/email_loader.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import imaplib
-import logging
-from typing import Optional, Union, cast
+from typing import Optional, cast
 
 from attrs import astuple, define, field
 
-from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import ListArtifact, TextArtifact
 from griptape.loaders import BaseLoader
 from griptape.utils import import_optional_dependency
 
@@ -33,50 +32,46 @@ class EmailLoader(BaseLoader):
     username: str = field(kw_only=True)
     password: str = field(kw_only=True)
 
-    def load(self, source: EmailQuery, *args, **kwargs) -> ListArtifact | ErrorArtifact:
+    def load(self, source: EmailQuery, *args, **kwargs) -> ListArtifact:
         mailparser = import_optional_dependency("mailparser")
         label, key, search_criteria, max_count = astuple(source)
 
         artifacts = []
-        try:
-            with imaplib.IMAP4_SSL(self.imap_url) as client:
-                client.login(self.username, self.password)
+        with imaplib.IMAP4_SSL(self.imap_url) as client:
+            client.login(self.username, self.password)
 
-                mailbox = client.select(f'"{label}"', readonly=True)
-                if mailbox[0] != "OK":
-                    raise Exception(mailbox[1][0].decode())
+            mailbox = client.select(f'"{label}"', readonly=True)
+            if mailbox[0] != "OK":
+                raise Exception(mailbox[1][0].decode())
 
-                if key and search_criteria:
-                    _typ, [message_numbers] = client.search(None, key, f'"{search_criteria}"')
-                    messages_count = self._count_messages(message_numbers)
-                elif len(mailbox) > 1 and mailbox[1] and mailbox[1][0] is not None:
-                    messages_count = int(mailbox[1][0])
-                else:
-                    raise Exception("unable to parse number of messages")
+            if key and search_criteria:
+                _typ, [message_numbers] = client.search(None, key, f'"{search_criteria}"')
+                messages_count = self._count_messages(message_numbers)
+            elif len(mailbox) > 1 and mailbox[1] and mailbox[1][0] is not None:
+                messages_count = int(mailbox[1][0])
+            else:
+                raise Exception("unable to parse number of messages")
 
-                top_n = max(0, messages_count - max_count) if max_count else 0
-                for i in range(messages_count, top_n, -1):
-                    _result, data = client.fetch(str(i), "(RFC822)")
+            top_n = max(0, messages_count - max_count) if max_count else 0
+            for i in range(messages_count, top_n, -1):
+                _result, data = client.fetch(str(i), "(RFC822)")
 
-                    if data is None or not data or data[0] is None:
-                        continue
+                if data is None or not data or data[0] is None:
+                    continue
 
-                    message = mailparser.parse_from_bytes(data[0][1])
+                message = mailparser.parse_from_bytes(data[0][1])
 
-                    # Note: mailparser only populates the text_plain field
-                    # if the message content type is explicitly set to 'text/plain'.
-                    if message.text_plain:
-                        artifacts.append(TextArtifact("\n".join(message.text_plain)))
+                # Note: mailparser only populates the text_plain field
+                # if the message content type is explicitly set to 'text/plain'.
+                if message.text_plain:
+                    artifacts.append(TextArtifact("\n".join(message.text_plain)))
 
-                client.close()
+            client.close()
 
-                return ListArtifact(artifacts)
-        except Exception as e:
-            logging.error(e)
-            return ErrorArtifact(f"error retrieving email: {e}")
+            return ListArtifact(artifacts)
 
     def _count_messages(self, message_numbers: bytes) -> int:
         return len(list(filter(None, message_numbers.decode().split(" "))))
 
-    def load_collection(self, sources: list[EmailQuery], *args, **kwargs) -> dict[str, ListArtifact | ErrorArtifact]:
-        return cast(dict[str, Union[ListArtifact, ErrorArtifact]], super().load_collection(sources, *args, **kwargs))
+    def load_collection(self, sources: list[EmailQuery], *args, **kwargs) -> dict[str, ListArtifact]:
+        return cast(dict[str, ListArtifact], super().load_collection(sources, *args, **kwargs))

--- a/griptape/loaders/pdf_loader.py
+++ b/griptape/loaders/pdf_loader.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from io import BytesIO
-from typing import Optional, Union, cast
+from typing import Optional, cast
 
 from attrs import Factory, define, field
 
 from griptape.artifacts import TextArtifact
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.chunkers import PdfChunker
 from griptape.loaders import BaseTextLoader
 from griptape.utils import import_optional_dependency
@@ -26,13 +25,13 @@ class PdfLoader(BaseTextLoader):
         password: Optional[str] = None,
         *args,
         **kwargs,
-    ) -> ErrorArtifact | list[TextArtifact]:
+    ) -> list[TextArtifact]:
         pypdf = import_optional_dependency("pypdf")
         reader = pypdf.PdfReader(BytesIO(source), strict=True, password=password)
         return self._text_to_artifacts("\n".join([p.extract_text() for p in reader.pages]))
 
-    def load_collection(self, sources: list[bytes], *args, **kwargs) -> dict[str, ErrorArtifact | list[TextArtifact]]:
+    def load_collection(self, sources: list[bytes], *args, **kwargs) -> dict[str, list[TextArtifact]]:
         return cast(
-            dict[str, Union[ErrorArtifact, list[TextArtifact]]],
+            dict[str, list[TextArtifact]],
             super().load_collection(sources, *args, **kwargs),
         )

--- a/griptape/loaders/text_loader.py
+++ b/griptape/loaders/text_loader.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from attrs import Factory, define, field
 
 from griptape.artifacts import TextArtifact
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.chunkers import TextChunker
 from griptape.loaders import BaseTextLoader
 from griptape.tokenizers import OpenAiTokenizer
@@ -36,14 +35,11 @@ class TextLoader(BaseTextLoader):
     embedding_driver: Optional[BaseEmbeddingDriver] = field(default=None, kw_only=True)
     encoding: str = field(default="utf-8", kw_only=True)
 
-    def load(self, source: bytes | str, *args, **kwargs) -> ErrorArtifact | list[TextArtifact]:
+    def load(self, source: bytes | str, *args, **kwargs) -> list[TextArtifact]:
         if isinstance(source, bytes):
-            try:
-                source = source.decode(encoding=self.encoding)
-            except UnicodeDecodeError:
-                return ErrorArtifact(f"Failed to decode bytes to string using encoding: {self.encoding}")
+            source = source.decode(encoding=self.encoding)
         elif isinstance(source, (bytearray, memoryview)):
-            return ErrorArtifact(f"Unsupported source type: {type(source)}")
+            raise ValueError(f"Unsupported source type: {type(source)}")
 
         return self._text_to_artifacts(source)
 
@@ -52,8 +48,8 @@ class TextLoader(BaseTextLoader):
         sources: list[bytes | str],
         *args,
         **kwargs,
-    ) -> dict[str, ErrorArtifact | list[TextArtifact]]:
+    ) -> dict[str, list[TextArtifact]]:
         return cast(
-            dict[str, Union[ErrorArtifact, list[TextArtifact]]],
+            dict[str, list[TextArtifact]],
             super().load_collection(sources, *args, **kwargs),
         )

--- a/griptape/loaders/web_loader.py
+++ b/griptape/loaders/web_loader.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers import BaseWebScraperDriver, TrafilaturaWebScraperDriver
 from griptape.loaders import BaseTextLoader
 
@@ -19,9 +18,6 @@ class WebLoader(BaseTextLoader):
         kw_only=True,
     )
 
-    def load(self, source: str, *args, **kwargs) -> ErrorArtifact | list[TextArtifact]:
-        try:
-            single_chunk_text_artifact = self.web_scraper_driver.scrape_url(source)
-            return self._text_to_artifacts(single_chunk_text_artifact.value)
-        except Exception as e:
-            return ErrorArtifact(f"Error loading from source: {source}", exception=e)
+    def load(self, source: str, *args, **kwargs) -> list[TextArtifact]:
+        single_chunk_text_artifact = self.web_scraper_driver.scrape_url(source)
+        return self._text_to_artifacts(single_chunk_text_artifact.value)

--- a/griptape/tasks/code_execution_task.py
+++ b/griptape/tasks/code_execution_task.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from attrs import define, field
 
-from griptape.artifacts import BaseArtifact, ErrorArtifact
 from griptape.tasks import BaseTextInputTask
+
+if TYPE_CHECKING:
+    from griptape.artifacts import BaseArtifact
 
 
 @define
@@ -13,7 +15,4 @@ class CodeExecutionTask(BaseTextInputTask):
     run_fn: Callable[[CodeExecutionTask], BaseArtifact] = field(kw_only=True)
 
     def run(self) -> BaseArtifact:
-        try:
-            return self.run_fn(self)
-        except Exception as e:
-            return ErrorArtifact(f"error during Code Execution Task: {e}")
+        return self.run_fn(self)

--- a/griptape/tools/file_manager/tool.py
+++ b/griptape/tools/file_manager/tool.py
@@ -93,9 +93,16 @@ class FileManagerTool(BaseTool):
 
         for artifact in list_artifact.value:
             formatted_file_name = f"{artifact.name}-{file_name}" if len(list_artifact) > 1 else file_name
-            result = self.file_manager_driver.save_file(os.path.join(dir_name, formatted_file_name), artifact.value)
-            if isinstance(result, ErrorArtifact):
-                return result
+            try:
+                self.file_manager_driver.save_file(os.path.join(dir_name, formatted_file_name), artifact.value)
+            except FileNotFoundError:
+                return ErrorArtifact("Path not found")
+            except IsADirectoryError:
+                return ErrorArtifact("Path is a directory")
+            except NotADirectoryError:
+                return ErrorArtifact("Not a directory")
+            except Exception as e:
+                return ErrorArtifact(f"Failed to load file: {str(e)}")
 
         return InfoArtifact("Successfully saved memory artifacts to disk")
 

--- a/griptape/tools/variation_image_generation/tool.py
+++ b/griptape/tools/variation_image_generation/tool.py
@@ -51,9 +51,6 @@ class VariationImageGenerationTool(BaseImageGenerationTool):
 
         image_artifact = self.image_loader.load(Path(image_file).read_bytes())
 
-        if isinstance(image_artifact, ErrorArtifact):
-            return image_artifact
-
         return self._generate_variation(prompt, negative_prompt, image_artifact)
 
     @activity(

--- a/griptape/tools/web_scraper/tool.py
+++ b/griptape/tools/web_scraper/tool.py
@@ -24,9 +24,6 @@ class WebScraperTool(BaseTool):
 
         try:
             result = self.web_loader.load(url)
-            if isinstance(result, ErrorArtifact):
-                return result
-            else:
-                return ListArtifact(result)
+            return ListArtifact(result)
         except Exception as e:
             return ErrorArtifact("Error getting page content: " + str(e))

--- a/tests/unit/engines/extraction/test_json_extraction_engine.py
+++ b/tests/unit/engines/extraction/test_json_extraction_engine.py
@@ -1,7 +1,6 @@
 import pytest
 from schema import Schema
 
-from griptape.artifacts import ErrorArtifact
 from griptape.engines import JsonExtractionEngine
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 
@@ -25,7 +24,9 @@ class TestJsonExtractionEngine:
 
     def test_extract_error(self, engine):
         engine.template_schema = lambda: "non serializable"
-        assert isinstance(engine.extract("foo"), ErrorArtifact)
+
+        with pytest.raises(TypeError):
+            engine.extract("foo")
 
     def test_json_to_text_artifacts(self, engine):
         assert [

--- a/tests/unit/loaders/test_email_loader.py
+++ b/tests/unit/loaders/test_email_loader.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import pytest
 
-from griptape.artifacts import ErrorArtifact, ListArtifact
+from griptape.artifacts import ListArtifact
 from griptape.loaders import EmailLoader
 
 
@@ -79,20 +79,16 @@ class TestEmailLoader:
         mock_select.return_value = (None, [b"NOT-OK"])
 
         # When
-        artifact = loader.load(EmailLoader.EmailQuery(label="INBOX"))
-
-        # Then
-        assert isinstance(artifact, ErrorArtifact)
+        with pytest.raises(Exception, match="NOT-OK"):
+            loader.load(EmailLoader.EmailQuery(label="INBOX"))
 
     def test_load_returns_error_artifact_when_login_throws(self, loader, mock_login):
         # Given
         mock_login.side_effect = Exception("login-failed")
 
         # When
-        artifact = loader.load(EmailLoader.EmailQuery(label="INBOX"))
-
-        # Then
-        assert isinstance(artifact, ErrorArtifact)
+        with pytest.raises(Exception, match="login-failed"):
+            loader.load(EmailLoader.EmailQuery(label="INBOX"))
 
     def test_load_collection(self, loader, mock_fetch):
         # Given

--- a/tests/unit/loaders/test_web_loader.py
+++ b/tests/unit/loaders/test_web_loader.py
@@ -1,6 +1,5 @@
 import pytest
 
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.loaders import WebLoader
 from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
@@ -27,10 +26,8 @@ class TestWebLoader:
     def test_load_exception(self, mocker, loader):
         mocker.patch("trafilatura.fetch_url", side_effect=Exception("error"))
         source = "https://github.com/griptape-ai/griptape"
-        artifact = loader.load(source)
-
-        assert isinstance(artifact, ErrorArtifact)
-        assert f"Error loading from source: {source}" == artifact.value
+        with pytest.raises(Exception, match="error"):
+            loader.load(source)
 
     def test_load_collection(self, loader):
         artifacts = loader.load_collection(
@@ -48,13 +45,11 @@ class TestWebLoader:
     def test_empty_page_string_response(self, loader, mocker):
         mocker.patch("trafilatura.extract", return_value="")
 
-        artifact = loader.load("https://example.com/")
-        assert isinstance(artifact, ErrorArtifact)
-        assert str(artifact.exception) == "can't extract page"
+        with pytest.raises(Exception, match="can't extract page"):
+            loader.load("https://example.com/")
 
     def test_empty_page_none_response(self, loader, mocker):
         mocker.patch("trafilatura.extract", return_value=None)
 
-        artifact = loader.load("https://example.com/")
-        assert isinstance(artifact, ErrorArtifact)
-        assert str(artifact.exception) == "can't extract page"
+        with pytest.raises(Exception, match="can't extract page"):
+            loader.load("https://example.com/")

--- a/tests/unit/tasks/test_code_execution_task.py
+++ b/tests/unit/tasks/test_code_execution_task.py
@@ -1,4 +1,6 @@
-from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact
+import pytest
+
+from griptape.artifacts import BaseArtifact, TextArtifact
 from griptape.structures import Pipeline
 from griptape.tasks import CodeExecutionTask
 
@@ -35,7 +37,5 @@ class TestCodeExecutionTask:
     def test_error_fn(self):
         task = CodeExecutionTask(run_fn=deliberate_exception)
 
-        result = task.run()
-
-        assert isinstance(result, ErrorArtifact)
-        assert result.value == "error during Code Execution Task: Intentional Error"
+        with pytest.raises(ValueError):
+            task.run()

--- a/tests/unit/tools/test_file_manager.py
+++ b/tests/unit/tools/test_file_manager.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 
 from griptape.artifacts import ListArtifact, TextArtifact
-from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers.file_manager.local_file_manager_driver import LocalFileManagerDriver
 from griptape.loaders.text_loader import TextLoader
 from griptape.tools import FileManagerTool
@@ -55,9 +54,8 @@ class TestFileManager:
             )
         )
 
-        result = file_manager.load_files_from_disk({"values": {"paths": ["../../resources/bitcoin.pdf"]}})
-
-        assert isinstance(result.value[0], ErrorArtifact)
+        with pytest.raises(UnicodeDecodeError):
+            file_manager.load_files_from_disk({"values": {"paths": ["../../resources/bitcoin.pdf"]}})
 
     def test_save_memory_artifacts_to_disk_for_one_artifact(self, temp_dir):
         memory = defaults.text_task_memory("Memory1")


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- **BREAKING**: Drivers, Loaders, and Engines will now raises exceptions rather than returning `ErrorArtifact`s.

Note that this change was not made to Tools, Tasks, or Structures for the following reasons:
- Tools: Tool output always goes to the LLM, therefore if a Tool errors out we want to convey that to the LLM so that it can course correct. A Tool does not need to return `ErrorArtifact`s on its own, it can raise an exception which will be [caught and converted](https://github.com/griptape-ai/griptape/blob/be18083838eb5dc3c5db780ec43eb966b4e0ac52/griptape/tools/base_tool.py#L120-L129) in BaseTool.
- Tasks & Structures: it is useful for Tasks and Structures to have an output value even if they errored. If [fail_fast](https://github.com/griptape-ai/griptape/blob/be18083838eb5dc3c5db780ec43eb966b4e0ac52/griptape/structures/structure.py#L37) is disabled, the Structure will continue running and you can inspect the output of all Tasks (successful or not) afterwards.

## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1101.org.readthedocs.build//1101/

<!-- readthedocs-preview griptape end -->