### PR TITLE
Fix saving results of csv extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure thread safety when publishing events by adding a thread lock to batch operations in `BaseEventListenerDriver`. 
+- `FileManagerTool` failing to save Artifacts created by `ExtractionTool` with a `CsvExtractionEngine`.
 
 ## [0.30.1] - 2024-08-21
 

--- a/griptape/tools/file_manager/tool.py
+++ b/griptape/tools/file_manager/tool.py
@@ -93,7 +93,8 @@ class FileManagerTool(BaseTool):
 
         for artifact in list_artifact.value:
             formatted_file_name = f"{artifact.name}-{file_name}" if len(list_artifact) > 1 else file_name
-            result = self.file_manager_driver.save_file(os.path.join(dir_name, formatted_file_name), artifact.value)
+            value = artifact.value if isinstance(artifact.value, (str, bytes)) else artifact.to_text()
+            result = self.file_manager_driver.save_file(os.path.join(dir_name, formatted_file_name), value)
             if isinstance(result, ErrorArtifact):
                 return result
 

--- a/tests/unit/tools/test_file_manager.py
+++ b/tests/unit/tools/test_file_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from griptape.artifacts import ListArtifact, TextArtifact
+from griptape.artifacts.csv_row_artifact import CsvRowArtifact
 from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.drivers.file_manager.local_file_manager_driver import LocalFileManagerDriver
 from griptape.loaders.text_loader import TextLoader
@@ -106,6 +107,29 @@ class TestFileManager:
 
         assert Path(os.path.join(temp_dir, "test", f"{artifacts[0].name}-{file_name}")).read_text() == "foobar"
         assert Path(os.path.join(temp_dir, "test", f"{artifacts[1].name}-{file_name}")).read_text() == "baz"
+        assert result.value == "Successfully saved memory artifacts to disk"
+
+    def test_save_memory_artifacts_to_disk_for_non_string_artifact(self, temp_dir):
+        memory = defaults.text_task_memory("Memory1")
+        artifact = CsvRowArtifact({"foo": "bar"})
+
+        memory.store_artifact("foobar", artifact)
+
+        file_manager = FileManagerTool(
+            input_memory=[memory], file_manager_driver=LocalFileManagerDriver(workdir=temp_dir)
+        )
+        result = file_manager.save_memory_artifacts_to_disk(
+            {
+                "values": {
+                    "dir_name": "test",
+                    "file_name": "foobar.txt",
+                    "memory_name": memory.name,
+                    "artifact_namespace": "foobar",
+                }
+            }
+        )
+
+        assert Path(os.path.join(temp_dir, "test", "foobar.txt")).read_text() == "bar"
         assert result.value == "Successfully saved memory artifacts to disk"
 
     def test_save_content_to_file(self, temp_dir):


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Fixed
- `FileManagerTool` failing to save Artifacts created by `ExtractionTool` with a `CsvExtractionEngine`.

## Issue ticket number and link
Offline issue.