### PR TITLE
Don't send empty properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Parsing streaming response with some OpenAi compatible services.
 - Issue in `PromptSummaryEngine` if there are no artifacts during recursive summarization.
+- Issue in `GooglePromptDriver` using Tools with no schema.
 
 **Note**: This release includes breaking changes. Please refer to the [Migration Guide](./MIGRATION.md#030x-to-031x) for details.
 

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -187,11 +187,17 @@ class GooglePromptDriver(BasePromptDriver):
                 tool_declaration = types.FunctionDeclaration(
                     name=tool.to_native_tool_name(activity),
                     description=tool.activity_description(activity),
-                    parameters={
-                        "type": schema["type"],
-                        "properties": schema["properties"],
-                        "required": schema.get("required", []),
-                    },
+                    **(
+                        {
+                            "parameters": {
+                                "type": schema["type"],
+                                "properties": schema["properties"],
+                                "required": schema.get("required", []),
+                            }
+                        }
+                        if schema.get("properties")
+                        else {}
+                    ),
                 )
 
                 tool_declarations.append(tool_declaration)

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -29,8 +29,8 @@ class TestGooglePromptDriver:
             "description": "test description: foo",
             "parameters": {"type": "OBJECT", "properties": {"test": {"type": "STRING"}}, "required": ["test"]},
         },
-        {"name": "MockTool_test_list_output", "description": "test description", "parameters": {"type": "OBJECT"}},
-        {"name": "MockTool_test_no_schema", "description": "test description", "parameters": {"type": "OBJECT"}},
+        {"name": "MockTool_test_list_output", "description": "test description"},
+        {"name": "MockTool_test_no_schema", "description": "test description"},
         {
             "name": "MockTool_test_str_output",
             "description": "test description: foo",


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Fixes this:
```python
from griptape.configs import Defaults
from griptape.configs.drivers import GoogleDriversConfig
from griptape.structures import Agent
from griptape.tools import DateTimeTool

Defaults.drivers_config = GoogleDriversConfig()
agent = Agent(tools=[DateTimeTool()])

agent.run("Hi, what day is it?")
```

```
[08/28/24 06:20:10] INFO     ToolkitTask c2b5dbb40ba34d6d88a3ed29ec5c7058
                             Input: Hi, what day is it?
WARNING:root:<RetryCallState 2611478496784: attempt #1; slept for 0.0; last result: failed (InvalidArgument 400 * GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type
)>
```
## Issue ticket number and link
Offline discussion.