### PR TITLE
Migrate GriptapeCloudStructureRunDriver to use `env_var` over `env` field

### DIFF
--- a/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
+++ b/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
@@ -28,9 +28,11 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
 
         url = urljoin(self.base_url.strip("/"), f"/api/structures/{self.structure_id}/runs")
 
+        env_vars = [{"name": key, "value": value, "source": "manual"} for key, value in self.env.items()]
+
         response: Response = post(
             url,
-            json={"args": [arg.value for arg in args], "env": self.env},
+            json={"args": [arg.value for arg in args], "env_vars": env_vars},
             headers=self.headers,
         )
         response.raise_for_status()


### PR DESCRIPTION
- [X] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Use the updated `env_vars` field for Griptape Cloud Structure Runs

## Issue ticket number and link
