### PR TITLE
Fix missing maxTokens in AmazonBedrockPromptDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing streaming response with some OpenAi compatible services.
 - Issue in `PromptSummaryEngine` if there are no artifacts during recursive summarization.
 - Issue in `GooglePromptDriver` using Tools with no schema.
+- Missing `maxTokens` inference parameter in `AmazonBedrockPromptDriver`.
 
 **Note**: This release includes breaking changes. Please refer to the [Migration Guide](./MIGRATION.md#030x-to-031x) for details.
 

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -98,7 +98,7 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
             "modelId": self.model,
             "messages": messages,
             "system": system_messages,
-            "inferenceConfig": {"temperature": self.temperature},
+            "inferenceConfig": {"temperature": self.temperature, "maxTokens": self.max_tokens},
             "additionalModelRequestFields": self.additional_model_request_fields,
             **(
                 {"toolConfig": {"tools": self.__to_bedrock_tools(prompt_stack.tools), "toolChoice": self.tool_choice}}

--- a/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
@@ -344,7 +344,7 @@ class TestAmazonBedrockPromptDriver:
         mock_converse.assert_called_once_with(
             modelId=driver.model,
             messages=messages,
-            inferenceConfig={"temperature": driver.temperature},
+            inferenceConfig={"temperature": driver.temperature, "maxTokens": driver.max_tokens},
             additionalModelRequestFields={},
             **({"system": [{"text": "system-input"}]} if prompt_stack.system_messages else {"system": []}),
             **(
@@ -376,7 +376,7 @@ class TestAmazonBedrockPromptDriver:
         mock_converse_stream.assert_called_once_with(
             modelId=driver.model,
             messages=messages,
-            inferenceConfig={"temperature": driver.temperature},
+            inferenceConfig={"temperature": driver.temperature, "maxTokens": driver.max_tokens},
             additionalModelRequestFields={},
             **({"system": [{"text": "system-input"}]} if prompt_stack.system_messages else {"system": []}),
             **(


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Fixed
- Missing `maxTokens` inference parameter in `AmazonBedrockPromptDriver`.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1120