### PR TITLE
Revert "Filter out cohere's pydantic warning (#1081)"

### DIFF
--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from attrs import Factory, define, field
@@ -24,9 +23,6 @@ from griptape.common.prompt_stack.contents.action_call_delta_message_content imp
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer, CohereTokenizer
 from griptape.utils import import_optional_dependency
-
-# TODO Remove once https://github.com/cohere-ai/cohere-python/issues/559 is resolved
-warnings.filterwarnings("ignore", module="pydantic")
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/poetry.lock
+++ b/poetry.lock
@@ -1107,13 +1107,13 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cohere"
-version = "5.9.0"
+version = "5.9.1"
 description = ""
 optional = true
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "cohere-5.9.0-py3-none-any.whl", hash = "sha256:7c70cc9e6ade3355e00aa4a77fcb5662b32261a3237e00975d92b97bb5f3c0c9"},
-    {file = "cohere-5.9.0.tar.gz", hash = "sha256:74e5b6e1fed0f617c26dfb8ef1cfccf8334321a51cc886c37374047916d71568"},
+    {file = "cohere-5.9.1-py3-none-any.whl", hash = "sha256:8e1e1dde0e1a5ee5a3f22b890e0c927989f9326bab57b6b4be812a40e2565c3a"},
+    {file = "cohere-5.9.1.tar.gz", hash = "sha256:de9a828b91481882bf554e94a61ccc52843a09fbc58f53b8e1fa940b17ce1dc9"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
This reverts commit ade80a500df7c90a8efa0ec89879fa62521eb2d9 #1081 .

- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

This is fixed in the latest cohere sdk.

## Issue ticket number and link
