### PR TITLE
Drivers Config Context Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AzureOpenAiTextToSpeechDriver`.
 - Ability to use Event Listeners as Context Managers for temporarily setting the Event Bus listeners.
 - `JsonSchemaRule` for instructing the LLM to output a JSON object that conforms to a schema.
+- Ability to use Drivers Configs as Context Managers for temporarily setting the default Drivers.
 
 ### Changed
 - **BREAKING**: Drivers, Loaders, and Engines now raise exceptions rather than returning `ErrorArtifacts`.

--- a/docs/griptape-framework/structures/configs.md
+++ b/docs/griptape-framework/structures/configs.md
@@ -5,13 +5,26 @@ search:
 
 ## Overview
 
-Griptape exposes global configuration options to easily customize different parts of the framework.
+Griptape exposes a global singleton, [Defaults](../../reference/griptape/configs/defaults_config.md), which can be used to access and modify the default configurations of the framework.
+
+To update the default configurations, simply update the fields on the `Defaults` object. 
+Framework objects will be created with the currently set default configurations, but you can always override at the individual class level.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/config_defaults.py"
+```
 
 ### Drivers Configs
 
 The [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md) class allows for the customization of Structures within Griptape, enabling specific settings such as Drivers to be defined for Tasks. 
 
 Griptape provides predefined [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md)'s for widely used services that provide APIs for most Driver types Griptape offers.
+
+`DriversConfig`s can be used as a Python Context Manager using the `with` statement to temporarily change the default configurations for a block of code.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_with.py"
+```
 
 #### OpenAI
 

--- a/docs/griptape-framework/structures/src/config_defaults.py
+++ b/docs/griptape-framework/structures/src/config_defaults.py
@@ -1,0 +1,12 @@
+from griptape.configs import Defaults
+from griptape.configs.drivers import AnthropicDriversConfig, OpenAiDriversConfig
+from griptape.drivers.prompt.anthropic_prompt_driver import AnthropicPromptDriver
+from griptape.structures import Agent
+
+Defaults.drivers_config = OpenAiDriversConfig()  # Default
+openai_agent = Agent()
+
+Defaults.drivers_config = AnthropicDriversConfig()
+anthropic_agent = Agent(
+    prompt_driver=AnthropicPromptDriver(model="claude-3-5-sonnet-20240620"),  # Override the default prompt driver
+)

--- a/docs/griptape-framework/structures/src/drivers_config_with.py
+++ b/docs/griptape-framework/structures/src/drivers_config_with.py
@@ -1,0 +1,31 @@
+import schema
+
+from griptape.configs.drivers import AnthropicDriversConfig, OpenAiDriversConfig
+from griptape.drivers import AnthropicPromptDriver, OpenAiChatPromptDriver
+from griptape.engines import JsonExtractionEngine
+from griptape.structures import Agent
+from griptape.tasks import ToolTask
+from griptape.tools import ExtractionTool
+
+with OpenAiDriversConfig():  # Agent will be created with OpenAi Drivers
+    openai_agent = Agent()
+
+with AnthropicDriversConfig():  # Agent will be created with Anthropic Drivers
+    anthropic_agent = Agent(
+        tasks=[
+            ToolTask(
+                "Extract sentiment from this text: {{ args[0] }}",
+                prompt_driver=OpenAiChatPromptDriver(model="gpt-4o"),  # Override this particular Task's prompt driver
+                tool=ExtractionTool(
+                    extraction_engine=JsonExtractionEngine(
+                        prompt_driver=AnthropicPromptDriver(  # Override this particular Engine's prompt driver
+                            model="claude-3-opus-20240229"
+                        ),
+                        template_schema=schema.Schema({"sentiment": str}).json_schema("Output"),
+                    ),
+                ),
+            )
+        ]
+    )
+
+anthropic_agent.run("Hello, I am happy!")

--- a/griptape/configs/drivers/base_drivers_config.py
+++ b/griptape/configs/drivers/base_drivers_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
 
@@ -47,6 +47,25 @@ class BaseDriversConfig(ABC, SerializableMixin):
     _audio_transcription_driver: BaseAudioTranscriptionDriver = field(
         default=None, kw_only=True, metadata={"serializable": True}, alias="audio_transcription_driver"
     )
+
+    _last_drivers_config: Optional[BaseDriversConfig] = field(default=None)
+
+    def __enter__(self) -> BaseDriversConfig:
+        from griptape.configs import Defaults
+
+        self._last_drivers_config = Defaults.drivers_config
+
+        Defaults.drivers_config = self
+
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:  # noqa: ANN001, A002
+        from griptape.configs import Defaults
+
+        if self._last_drivers_config is not None:
+            Defaults.drivers_config = self._last_drivers_config
+
+        self._last_drivers_config = None
 
     @lazy_property()
     @abstractmethod

--- a/tests/unit/configs/drivers/test_drivers_config.py
+++ b/tests/unit/configs/drivers/test_drivers_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from griptape.configs.drivers import DriversConfig
+from tests.mocks.mock_drivers_config import MockDriversConfig
 
 
 class TestDriversConfig:
@@ -40,6 +41,16 @@ class TestDriversConfig:
         config.prompt_driver.max_tokens = 10
 
         assert config.prompt_driver.max_tokens == 10
+
+    def test_context_manager(self):
+        from griptape.configs import Defaults
+
+        old_drivers_config = Defaults.drivers_config
+
+        with MockDriversConfig() as config:
+            assert Defaults.drivers_config == config
+
+        assert Defaults.drivers_config == old_drivers_config
 
     @pytest.mark.skip_mock_config()
     def test_lazy_init(self):


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Added ability to use Drivers Configs as Context Managers for temporarily setting the default Drivers.
## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1162.org.readthedocs.build//1162/

<!-- readthedocs-preview griptape end -->