### PR TITLE
Add ability to use EventListener as Context Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Parameter `meta: dict` on `BaseEvent`.
 - `AzureOpenAiTextToSpeechDriver`.
+- Ability to use Event Listeners as Context Managers for temporarily setting the Event Bus listeners.
 
 ### Changed
 - **BREAKING**: Drivers, Loaders, and Engines now raise exceptions rather than returning `ErrorArtifacts`.

--- a/docs/griptape-framework/misc/events.md
+++ b/docs/griptape-framework/misc/events.md
@@ -73,6 +73,15 @@ Handler 1 <class 'griptape.events.finish_structure_run_event.FinishStructureRunE
 Handler 2 <class 'griptape.events.finish_structure_run_event.FinishStructureRunEvent'>
 ```
 
+## Context Managers
+
+You can also use [EventListener](../../reference/griptape/events/event_listener.md)s as a Python Context Manager.
+The `EventListener` will automatically be added and removed from the [EventBus](../../reference/griptape/events/event_bus.md) when entering and exiting the context.
+
+```python
+--8<-- "docs/griptape-framework/misc/src/events_context.py"
+```
+
 ## Streaming
 
 

--- a/docs/griptape-framework/misc/src/events_context.py
+++ b/docs/griptape-framework/misc/src/events_context.py
@@ -1,0 +1,13 @@
+from griptape.events import EventBus, EventListener, FinishStructureRunEvent, StartPromptEvent
+from griptape.structures import Agent
+
+EventBus.add_event_listeners(
+    [EventListener(lambda e: print(f"Out of context: {e.type}"), event_types=[StartPromptEvent])]
+)
+
+agent = Agent(input="Hello!")
+
+with EventListener(lambda e: print(f"In context: {e.type}"), event_types=[FinishStructureRunEvent]):
+    agent.run()
+
+agent.run()

--- a/griptape/events/event_bus.py
+++ b/griptape/events/event_bus.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
-from attrs import define, field
+from attrs import Factory, define, field
 
 from griptape.mixins.singleton_mixin import SingletonMixin
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 @define
 class _EventBus(SingletonMixin):
     _event_listeners: list[EventListener] = field(factory=list, kw_only=True, alias="_event_listeners")
+    _thread_lock: threading.Lock = field(default=Factory(lambda: threading.Lock()), alias="_thread_lock")
 
     @property
     def event_listeners(self) -> list[EventListener]:
@@ -26,26 +28,24 @@ class _EventBus(SingletonMixin):
             self.remove_event_listener(event_listener)
 
     def add_event_listener(self, event_listener: EventListener) -> EventListener:
-        if event_listener not in self._event_listeners:
-            self._event_listeners.append(event_listener)
+        with self._thread_lock:
+            if event_listener not in self._event_listeners:
+                self._event_listeners.append(event_listener)
 
         return event_listener
 
-    def set_event_listeners(self, event_listeners: list[EventListener]) -> list[EventListener]:
-        self._event_listeners = event_listeners
-
-        return self._event_listeners
-
     def remove_event_listener(self, event_listener: EventListener) -> None:
-        if event_listener in self._event_listeners:
-            self._event_listeners.remove(event_listener)
+        with self._thread_lock:
+            if event_listener in self._event_listeners:
+                self._event_listeners.remove(event_listener)
 
     def publish_event(self, event: BaseEvent, *, flush: bool = False) -> None:
         for event_listener in self._event_listeners:
             event_listener.publish_event(event, flush=flush)
 
     def clear_event_listeners(self) -> None:
-        self._event_listeners.clear()
+        with self._thread_lock:
+            self._event_listeners.clear()
 
 
 EventBus = _EventBus()

--- a/griptape/events/event_bus.py
+++ b/griptape/events/event_bus.py
@@ -31,6 +31,11 @@ class _EventBus(SingletonMixin):
 
         return event_listener
 
+    def set_event_listeners(self, event_listeners: list[EventListener]) -> list[EventListener]:
+        self._event_listeners = event_listeners
+
+        return self._event_listeners
+
     def remove_event_listener(self, event_listener: EventListener) -> None:
         if event_listener in self._event_listeners:
             self._event_listeners.remove(event_listener)

--- a/griptape/events/event_listener.py
+++ b/griptape/events/event_listener.py
@@ -21,17 +21,14 @@ class EventListener:
     def __enter__(self) -> EventListener:
         from griptape.events import EventBus
 
-        self._last_event_listeners = [*EventBus.event_listeners]
-
-        EventBus.set_event_listeners([self])
+        EventBus.add_event_listener(self)
 
         return self
 
     def __exit__(self, type, value, traceback) -> None:  # noqa: ANN001, A002
         from griptape.events import EventBus
 
-        if self._last_event_listeners is not None:
-            EventBus.set_event_listeners(self._last_event_listeners)
+        EventBus.remove_event_listener(self)
 
         self._last_event_listeners = None
 

--- a/griptape/events/event_listener.py
+++ b/griptape/events/event_listener.py
@@ -16,6 +16,25 @@ class EventListener:
     event_types: Optional[list[type[BaseEvent]]] = field(default=None, kw_only=True)
     driver: Optional[BaseEventListenerDriver] = field(default=None, kw_only=True)
 
+    _last_event_listeners: Optional[list[EventListener]] = field(default=None)
+
+    def __enter__(self) -> EventListener:
+        from griptape.events import EventBus
+
+        self._last_event_listeners = [*EventBus.event_listeners]
+
+        EventBus.set_event_listeners([self])
+
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:  # noqa: ANN001, A002
+        from griptape.events import EventBus
+
+        if self._last_event_listeners is not None:
+            EventBus.set_event_listeners(self._last_event_listeners)
+
+        self._last_event_listeners = None
+
     def publish_event(self, event: BaseEvent, *, flush: bool = False) -> None:
         event_types = self.event_types
 

--- a/tests/unit/events/test_event_bus.py
+++ b/tests/unit/events/test_event_bus.py
@@ -33,11 +33,6 @@ class TestEventBus:
 
         assert len(EventBus.event_listeners) == 0
 
-    def test_set_event_listeners(self):
-        listeners = [EventListener(), EventListener()]
-        EventBus.set_event_listeners(listeners)
-        assert EventBus.event_listeners == listeners
-
     def test_remove_unknown_event_listener(self):
         EventBus.remove_event_listener(EventListener())
 

--- a/tests/unit/events/test_event_bus.py
+++ b/tests/unit/events/test_event_bus.py
@@ -33,6 +33,11 @@ class TestEventBus:
 
         assert len(EventBus.event_listeners) == 0
 
+    def test_set_event_listeners(self):
+        listeners = [EventListener(), EventListener()]
+        EventBus.set_event_listeners(listeners)
+        assert EventBus.event_listeners == listeners
+
     def test_remove_unknown_event_listener(self):
         EventBus.remove_event_listener(EventListener())
 

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -137,10 +137,19 @@ class TestEventListener:
         mock_event_listener_driver.publish_event.assert_called_once_with({"event": mock_event.to_dict()}, flush=False)
 
     def test_context_manager(self):
-        EventBus.add_event_listeners([EventListener()])
-        last_event_listeners = EventBus.event_listeners
+        e1 = EventListener()
+        EventBus.add_event_listeners([e1])
 
-        with EventListener() as e:
-            assert EventBus.event_listeners == [e]
+        with EventListener() as e2:
+            assert EventBus.event_listeners == [e1, e2]
 
-        assert EventBus.event_listeners == last_event_listeners
+        assert EventBus.event_listeners == [e1]
+
+    def test_context_manager_multiple(self):
+        e1 = EventListener()
+        EventBus.add_event_listener(e1)
+
+        with EventListener() as e2, EventListener() as e3:
+            assert EventBus.event_listeners == [e1, e2, e3]
+
+        assert EventBus.event_listeners == [e1]

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -135,3 +135,12 @@ class TestEventListener:
         event_listener.publish_event(mock_event)
 
         mock_event_listener_driver.publish_event.assert_called_once_with({"event": mock_event.to_dict()}, flush=False)
+
+    def test_context_manager(self):
+        EventBus.add_event_listeners([EventListener()])
+        last_event_listeners = EventBus.event_listeners
+
+        with EventListener() as e:
+            assert EventBus.event_listeners == [e]
+
+        assert EventBus.event_listeners == last_event_listeners


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- Ability to use Event Listeners as Context Managers for temporarily setting the Event Bus listeners.
## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1163.org.readthedocs.build//1163/

<!-- readthedocs-preview griptape end -->