### PR TITLE
Normalize `client` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sagemaker_client` on `AmazonSageMakerJumpstartEmbeddingDriver`.
   - `sagemaker_client` on `AmazonSageMakerJumpstartPromptDriver`.
   - `sqs_client` on `AmazonSqsEventListenerDriver`.
-  - `AwsIotCoreEventListenerDriver`.
+  - `iotdata_client` on `AwsIotCoreEventListenerDriver`.
   - `s3_client` on `AmazonS3FileManagerDriver`.
   - `s3_client` on `AwsS3Tool`.
   - `pusher_client` on `PusherEventListenerDriver`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockCohereEmbeddingDriver` to `client`.
+- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockTitanEmbeddingDriver` to `client`.
+- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockImageGenerationDriver` to `client`.
+- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockImageQueryDriver` to `client`.
+- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockPromptDriver` to `client`.
+- **BREAKING**: Renamed parameter `sagemaker_client` on `AmazonSageMakerJumpstartEmbeddingDriver` to `client`.
+- **BREAKING**: Renamed parameter `sagemaker_client` on `AmazonSageMakerJumpstartPromptDriver` to `client`.
+- **BREAKING**: Renamed parameter `sqs_client` on `AmazonSqsEventListenerDriver` to `client`.
+- **BREAKING**: Renamed parameter `iotdata_client` on `AwsIotCoreEventListenerDriver` to `client`.
+- **BREAKING**: Renamed parameter `s3_client` on `AmazonS3FileManagerDriver` to `client`.
+- **BREAKING**: Renamed parameter `s3_client` on `AwsS3Tool` to `client`.
+- **BREAKING**: Renamed parameter `pusher_client` on `PusherEventListenerDriver` to `client`.
+- **BREAKING**: Renamed parameter `mq` on `MarqoVectorStoreDriver` to `client`.
+- **BREAKING**: Renamed parameter `model_client` on `GooglePromptDriver` to `client`.
+- **BREAKING**: Renamed parameter `model_client` on `GoogleTokenizer` to `client`.
+- **BREAKING**: Renamed parameter `pipe` on `HuggingFacePipelinePromptDriver` to `text_generation_pipeline`.
+- **BREAKING**: Renamed parameter `engine` on `PgVectorVectorStoreDriver` to `sqlalchemy_engine`.
+- Several places where API clients are initialized are now lazy loaded.
+
+
 ## [0.32.0] - 2024-09-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockCohereEmbeddingDriver` to `client`.
-- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockTitanEmbeddingDriver` to `client`.
-- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockImageGenerationDriver` to `client`.
-- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockImageQueryDriver` to `client`.
-- **BREAKING**: Renamed parameter `bedrock_client` on `AmazonBedrockPromptDriver` to `client`.
-- **BREAKING**: Renamed parameter `sagemaker_client` on `AmazonSageMakerJumpstartEmbeddingDriver` to `client`.
-- **BREAKING**: Renamed parameter `sagemaker_client` on `AmazonSageMakerJumpstartPromptDriver` to `client`.
-- **BREAKING**: Renamed parameter `sqs_client` on `AmazonSqsEventListenerDriver` to `client`.
-- **BREAKING**: Renamed parameter `iotdata_client` on `AwsIotCoreEventListenerDriver` to `client`.
-- **BREAKING**: Renamed parameter `s3_client` on `AmazonS3FileManagerDriver` to `client`.
-- **BREAKING**: Renamed parameter `s3_client` on `AwsS3Tool` to `client`.
-- **BREAKING**: Renamed parameter `pusher_client` on `PusherEventListenerDriver` to `client`.
-- **BREAKING**: Renamed parameter `mq` on `MarqoVectorStoreDriver` to `client`.
-- **BREAKING**: Renamed parameter `model_client` on `GooglePromptDriver` to `client`.
-- **BREAKING**: Renamed parameter `model_client` on `GoogleTokenizer` to `client`.
-- **BREAKING**: Renamed parameter `pipe` on `HuggingFacePipelinePromptDriver` to `text_generation_pipeline`.
-- **BREAKING**: Renamed parameter `engine` on `PgVectorVectorStoreDriver` to `sqlalchemy_engine`.
+- **BREAKING**: Renamed parameters on several classes to `client`:
+  - `bedrock_client` on `AmazonBedrockCohereEmbeddingDriver`.
+  - `bedrock_client` on `AmazonBedrockCohereEmbeddingDriver`.
+  - `bedrock_client` on `AmazonBedrockTitanEmbeddingDriver`.
+  - `bedrock_client` on `AmazonBedrockImageGenerationDriver`.
+  - `bedrock_client` on `AmazonBedrockImageQueryDriver`.
+  - `bedrock_client` on `AmazonBedrockPromptDriver`.
+  - `sagemaker_client` on `AmazonSageMakerJumpstartEmbeddingDriver`.
+  - `sagemaker_client` on `AmazonSageMakerJumpstartPromptDriver`.
+  - `sqs_client` on `AmazonSqsEventListenerDriver`.
+  - `AwsIotCoreEventListenerDriver`.
+  - `s3_client` on `AmazonS3FileManagerDriver`.
+  - `s3_client` on `AwsS3Tool`.
+  - `pusher_client` on `PusherEventListenerDriver`.
+  - `mq` on `MarqoVectorStoreDriver`.
+  - `model_client` on `GooglePromptDriver`.
+  - `model_client` on `GoogleTokenizer`.
+- **BREAKING**: Renamed parameter `pipe` on `HuggingFacePipelinePromptDriver` to `pipeline`.
 - Several places where API clients are initialized are now lazy loaded.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+- Parameter `pipeline_task` on `HuggingFacePipelinePromptDriver` for creating different types of `Pipeline`s.
+
 ### Changed
 - **BREAKING**: Renamed parameters on several classes to `client`:
   - `bedrock_client` on `AmazonBedrockCohereEmbeddingDriver`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `iotdata_client` on `AwsIotCoreEventListenerDriver`.
   - `s3_client` on `AmazonS3FileManagerDriver`.
   - `s3_client` on `AwsS3Tool`.
+  - `iam_client` on `AwsIamTool`.
   - `pusher_client` on `PusherEventListenerDriver`.
   - `mq` on `MarqoVectorStoreDriver`.
   - `model_client` on `GooglePromptDriver`.

--- a/griptape/drivers/embedding/amazon_bedrock_cohere_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_bedrock_cohere_embedding_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
@@ -12,6 +12,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_bedrock import BedrockClient
 
     from griptape.tokenizers.base_tokenizer import BaseTokenizer
 
@@ -39,10 +40,10 @@ class AmazonBedrockCohereEmbeddingDriver(BaseEmbeddingDriver):
         default=Factory(lambda self: AmazonBedrockTokenizer(model=self.model), takes_self=True),
         kw_only=True,
     )
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: BedrockClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> BedrockClient:
         return self.session.client("bedrock-runtime")
 
     def try_embed_chunk(self, chunk: str) -> list[float]:

--- a/griptape/drivers/embedding/amazon_bedrock_cohere_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_bedrock_cohere_embedding_driver.py
@@ -8,6 +8,7 @@ from attrs import Factory, define, field
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.tokenizers.amazon_bedrock_tokenizer import AmazonBedrockTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
@@ -26,7 +27,7 @@ class AmazonBedrockCohereEmbeddingDriver(BaseEmbeddingDriver):
             `search_query` when querying your vector DB to find relevant documents.
         session: Optionally provide custom `boto3.Session`.
         tokenizer: Optionally provide custom `BedrockCohereTokenizer`.
-        bedrock_client: Optionally provide custom `bedrock-runtime` client.
+        client: Optionally provide custom `bedrock-runtime` client.
     """
 
     DEFAULT_MODEL = "cohere.embed-english-v3"
@@ -38,15 +39,16 @@ class AmazonBedrockCohereEmbeddingDriver(BaseEmbeddingDriver):
         default=Factory(lambda self: AmazonBedrockTokenizer(model=self.model), takes_self=True),
         kw_only=True,
     )
-    bedrock_client: Any = field(
-        default=Factory(lambda self: self.session.client("bedrock-runtime"), takes_self=True),
-        kw_only=True,
-    )
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("bedrock-runtime")
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         payload = {"input_type": self.input_type, "texts": [chunk]}
 
-        response = self.bedrock_client.invoke_model(
+        response = self.client.invoke_model(
             body=json.dumps(payload),
             modelId=self.model,
             accept="*/*",

--- a/griptape/drivers/embedding/amazon_bedrock_titan_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_bedrock_titan_embedding_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
@@ -12,6 +12,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_bedrock import BedrockClient
 
     from griptape.tokenizers.base_tokenizer import BaseTokenizer
 
@@ -35,10 +36,10 @@ class AmazonBedrockTitanEmbeddingDriver(BaseEmbeddingDriver):
         default=Factory(lambda self: AmazonBedrockTokenizer(model=self.model), takes_self=True),
         kw_only=True,
     )
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: BedrockClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> BedrockClient:
         return self.session.client("bedrock-runtime")
 
     def try_embed_chunk(self, chunk: str) -> list[float]:

--- a/griptape/drivers/embedding/amazon_sagemaker_jumpstart_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_sagemaker_jumpstart_embedding_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
 
@@ -11,6 +11,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_sagemaker import SageMakerClient
 
 
 @define
@@ -19,10 +20,10 @@ class AmazonSageMakerJumpstartEmbeddingDriver(BaseEmbeddingDriver):
     endpoint: str = field(kw_only=True, metadata={"serializable": True})
     custom_attributes: str = field(default="accept_eula=true", kw_only=True, metadata={"serializable": True})
     inference_component_name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: SageMakerClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> SageMakerClient:
         return self.session.client("sagemaker-runtime")
 
     def try_embed_chunk(self, chunk: str) -> list[float]:

--- a/griptape/drivers/embedding/amazon_sagemaker_jumpstart_embedding_driver.py
+++ b/griptape/drivers/embedding/amazon_sagemaker_jumpstart_embedding_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
@@ -15,18 +16,19 @@ if TYPE_CHECKING:
 @define
 class AmazonSageMakerJumpstartEmbeddingDriver(BaseEmbeddingDriver):
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    sagemaker_client: Any = field(
-        default=Factory(lambda self: self.session.client("sagemaker-runtime"), takes_self=True),
-        kw_only=True,
-    )
     endpoint: str = field(kw_only=True, metadata={"serializable": True})
     custom_attributes: str = field(default="accept_eula=true", kw_only=True, metadata={"serializable": True})
     inference_component_name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("sagemaker-runtime")
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         payload = {"text_inputs": chunk, "mode": "embedding"}
 
-        endpoint_response = self.sagemaker_client.invoke_endpoint(
+        endpoint_response = self.client.invoke_endpoint(
             EndpointName=self.endpoint,
             ContentType="application/json",
             Body=json.dumps(payload).encode("utf-8"),

--- a/griptape/drivers/embedding/azure_openai_embedding_driver.py
+++ b/griptape/drivers/embedding/azure_openai_embedding_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 
 from griptape.drivers import OpenAiEmbeddingDriver
 from griptape.tokenizers import OpenAiTokenizer
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -40,17 +41,16 @@ class AzureOpenAiEmbeddingDriver(OpenAiEmbeddingDriver):
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True),
         kw_only=True,
     )
-    client: openai.AzureOpenAI = field(
-        default=Factory(
-            lambda self: openai.AzureOpenAI(
-                organization=self.organization,
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_deployment,
-                azure_ad_token=self.azure_ad_token,
-                azure_ad_token_provider=self.azure_ad_token_provider,
-            ),
-            takes_self=True,
-        ),
-    )
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(
+            organization=self.organization,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_deployment,
+            azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider=self.azure_ad_token_provider,
+        )

--- a/griptape/drivers/embedding/azure_openai_embedding_driver.py
+++ b/griptape/drivers/embedding/azure_openai_embedding_driver.py
@@ -41,7 +41,7 @@ class AzureOpenAiEmbeddingDriver(OpenAiEmbeddingDriver):
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True),
         kw_only=True,
     )
-    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.AzureOpenAI:

--- a/griptape/drivers/embedding/cohere_embedding_driver.py
+++ b/griptape/drivers/embedding/cohere_embedding_driver.py
@@ -29,7 +29,7 @@ class CohereEmbeddingDriver(BaseEmbeddingDriver):
 
     api_key: str = field(kw_only=True, metadata={"serializable": False})
     input_type: str = field(kw_only=True, metadata={"serializable": True})
-    _client: Client = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
     tokenizer: CohereTokenizer = field(
         default=Factory(lambda self: CohereTokenizer(model=self.model, client=self.client), takes_self=True),
         kw_only=True,

--- a/griptape/drivers/embedding/cohere_embedding_driver.py
+++ b/griptape/drivers/embedding/cohere_embedding_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.tokenizers import CohereTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from cohere import Client
@@ -27,16 +28,16 @@ class CohereEmbeddingDriver(BaseEmbeddingDriver):
     DEFAULT_MODEL = "models/embedding-001"
 
     api_key: str = field(kw_only=True, metadata={"serializable": False})
-    client: Client = field(
-        default=Factory(lambda self: import_optional_dependency("cohere").Client(self.api_key), takes_self=True),
-        kw_only=True,
-    )
+    input_type: str = field(kw_only=True, metadata={"serializable": True})
+    _client: Client = field(default=None, kw_only=True, metadata={"serializable": False})
     tokenizer: CohereTokenizer = field(
         default=Factory(lambda self: CohereTokenizer(model=self.model, client=self.client), takes_self=True),
         kw_only=True,
     )
 
-    input_type: str = field(kw_only=True, metadata={"serializable": True})
+    @lazy_property()
+    def client(self) -> Client:
+        return import_optional_dependency("cohere").Client(self.api_key)
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         result = self.client.embed(texts=[chunk], model=self.model, input_type=self.input_type)

--- a/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
+++ b/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from huggingface_hub import InferenceClient
@@ -22,16 +23,14 @@ class HuggingFaceHubEmbeddingDriver(BaseEmbeddingDriver):
     """
 
     api_token: str = field(kw_only=True, metadata={"serializable": True})
-    client: InferenceClient = field(
-        default=Factory(
-            lambda self: import_optional_dependency("huggingface_hub").InferenceClient(
-                model=self.model,
-                token=self.api_token,
-            ),
-            takes_self=True,
-        ),
-        kw_only=True,
-    )
+    _client: InferenceClient = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> InferenceClient:
+        return import_optional_dependency("huggingface_hub").InferenceClient(
+            model=self.model,
+            token=self.api_token,
+        )
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         response = self.client.feature_extraction(chunk)

--- a/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
+++ b/griptape/drivers/embedding/huggingface_hub_embedding_driver.py
@@ -23,7 +23,7 @@ class HuggingFaceHubEmbeddingDriver(BaseEmbeddingDriver):
     """
 
     api_token: str = field(kw_only=True, metadata={"serializable": True})
-    _client: InferenceClient = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: InferenceClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> InferenceClient:

--- a/griptape/drivers/embedding/ollama_embedding_driver.py
+++ b/griptape/drivers/embedding/ollama_embedding_driver.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from ollama import Client
@@ -23,10 +24,11 @@ class OllamaEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(kw_only=True, metadata={"serializable": True})
     host: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    client: Client = field(
-        default=Factory(lambda self: import_optional_dependency("ollama").Client(host=self.host), takes_self=True),
-        kw_only=True,
-    )
+    _client: Client = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Client:
+        return import_optional_dependency("ollama").Client(host=self.host)
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         return list(self.client.embeddings(model=self.model, prompt=chunk)["embedding"])

--- a/griptape/drivers/embedding/ollama_embedding_driver.py
+++ b/griptape/drivers/embedding/ollama_embedding_driver.py
@@ -24,7 +24,7 @@ class OllamaEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(kw_only=True, metadata={"serializable": True})
     host: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    _client: Client = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Client:

--- a/griptape/drivers/embedding/voyageai_embedding_driver.py
+++ b/griptape/drivers/embedding/voyageai_embedding_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import Factory, define, field
 
@@ -8,6 +8,9 @@ from griptape.drivers import BaseEmbeddingDriver
 from griptape.tokenizers import VoyageAiTokenizer
 from griptape.utils import import_optional_dependency
 from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    import voyageai
 
 
 @define
@@ -31,7 +34,7 @@ class VoyageAiEmbeddingDriver(BaseEmbeddingDriver):
         kw_only=True,
     )
     input_type: str = field(default="document", kw_only=True, metadata={"serializable": True})
-    _client: Any = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: voyageai.Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Any:

--- a/griptape/drivers/embedding/voyageai_embedding_driver.py
+++ b/griptape/drivers/embedding/voyageai_embedding_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 from griptape.drivers import BaseEmbeddingDriver
 from griptape.tokenizers import VoyageAiTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -25,17 +26,16 @@ class VoyageAiEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(default=DEFAULT_MODEL, kw_only=True, metadata={"serializable": True})
     api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
-    client: Any = field(
-        default=Factory(
-            lambda self: import_optional_dependency("voyageai").Client(api_key=self.api_key),
-            takes_self=True,
-        ),
-    )
     tokenizer: VoyageAiTokenizer = field(
         default=Factory(lambda self: VoyageAiTokenizer(model=self.model, api_key=self.api_key), takes_self=True),
         kw_only=True,
     )
     input_type: str = field(default="document", kw_only=True, metadata={"serializable": True})
+    _client: Any = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return import_optional_dependency("voyageai").Client(api_key=self.api_key)
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         return self.client.embed([chunk], model=self.model, input_type=self.input_type).embeddings[0]

--- a/griptape/drivers/event_listener/amazon_sqs_event_listener_driver.py
+++ b/griptape/drivers/event_listener/amazon_sqs_event_listener_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
@@ -11,16 +11,17 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_sqs import SQSClient
 
 
 @define
 class AmazonSqsEventListenerDriver(BaseEventListenerDriver):
     queue_url: str = field(kw_only=True)
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: SQSClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> SQSClient:
         return self.session.client("sqs")
 
     def try_publish_event_payload(self, event_payload: dict) -> None:

--- a/griptape/drivers/event_listener/amazon_sqs_event_listener_driver.py
+++ b/griptape/drivers/event_listener/amazon_sqs_event_listener_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 
 from griptape.drivers.event_listener.base_event_listener_driver import BaseEventListenerDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
@@ -16,10 +17,14 @@ if TYPE_CHECKING:
 class AmazonSqsEventListenerDriver(BaseEventListenerDriver):
     queue_url: str = field(kw_only=True)
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    sqs_client: Any = field(default=Factory(lambda self: self.session.client("sqs"), takes_self=True))
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("sqs")
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
-        self.sqs_client.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(event_payload))
+        self.client.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(event_payload))
 
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
         entries = [
@@ -27,4 +32,4 @@ class AmazonSqsEventListenerDriver(BaseEventListenerDriver):
             for event_payload in event_payload_batch
         ]
 
-        self.sqs_client.send_message_batch(QueueUrl=self.queue_url, Entries=entries)
+        self.client.send_message_batch(QueueUrl=self.queue_url, Entries=entries)

--- a/griptape/drivers/event_listener/aws_iot_core_event_listener_driver.py
+++ b/griptape/drivers/event_listener/aws_iot_core_event_listener_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
@@ -11,6 +11,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_iot_data import IoTDataPlaneClient
 
 
 @define
@@ -18,10 +19,10 @@ class AwsIotCoreEventListenerDriver(BaseEventListenerDriver):
     iot_endpoint: str = field(kw_only=True)
     topic: str = field(kw_only=True)
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: IoTDataPlaneClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> IoTDataPlaneClient:
         return self.session.client("iot-data")
 
     def try_publish_event_payload(self, event_payload: dict) -> None:

--- a/griptape/drivers/event_listener/aws_iot_core_event_listener_driver.py
+++ b/griptape/drivers/event_listener/aws_iot_core_event_listener_driver.py
@@ -7,6 +7,7 @@ from attrs import Factory, define, field
 
 from griptape.drivers.event_listener.base_event_listener_driver import BaseEventListenerDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
@@ -17,10 +18,14 @@ class AwsIotCoreEventListenerDriver(BaseEventListenerDriver):
     iot_endpoint: str = field(kw_only=True)
     topic: str = field(kw_only=True)
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    iotdata_client: Any = field(default=Factory(lambda self: self.session.client("iot-data"), takes_self=True))
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("iot-data")
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
-        self.iotdata_client.publish(topic=self.topic, payload=json.dumps(event_payload))
+        self.client.publish(topic=self.topic, payload=json.dumps(event_payload))
 
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
-        self.iotdata_client.publish(topic=self.topic, payload=json.dumps(event_payload_batch))
+        self.client.publish(topic=self.topic, payload=json.dumps(event_payload_batch))

--- a/griptape/drivers/event_listener/pusher_event_listener_driver.py
+++ b/griptape/drivers/event_listener/pusher_event_listener_driver.py
@@ -21,7 +21,7 @@ class PusherEventListenerDriver(BaseEventListenerDriver):
     channel: str = field(kw_only=True, metadata={"serializable": True})
     event_name: str = field(kw_only=True, metadata={"serializable": True})
     ssl: bool = field(default=True, kw_only=True, metadata={"serializable": True})
-    _client: Pusher = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Pusher = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Pusher:

--- a/griptape/drivers/event_listener/pusher_event_listener_driver.py
+++ b/griptape/drivers/event_listener/pusher_event_listener_driver.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.drivers import BaseEventListenerDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from pusher import Pusher
@@ -13,25 +14,24 @@ if TYPE_CHECKING:
 
 @define
 class PusherEventListenerDriver(BaseEventListenerDriver):
-    app_id: str = field(kw_only=True)
-    key: str = field(kw_only=True)
-    secret: str = field(kw_only=True)
-    cluster: str = field(kw_only=True)
-    channel: str = field(kw_only=True)
-    event_name: str = field(kw_only=True)
-    pusher_client: Pusher = field(
-        default=Factory(
-            lambda self: import_optional_dependency("pusher").Pusher(
-                app_id=self.app_id,
-                key=self.key,
-                secret=self.secret,
-                cluster=self.cluster,
-                ssl=True,
-            ),
-            takes_self=True,
-        ),
-        kw_only=True,
-    )
+    app_id: str = field(kw_only=True, metadata={"serializable": True})
+    key: str = field(kw_only=True, metadata={"serializable": True})
+    secret: str = field(kw_only=True, metadata={"serializable": False})
+    cluster: str = field(kw_only=True, metadata={"serializable": True})
+    channel: str = field(kw_only=True, metadata={"serializable": True})
+    event_name: str = field(kw_only=True, metadata={"serializable": True})
+    ssl: bool = field(default=True, kw_only=True, metadata={"serializable": True})
+    _client: Pusher = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Pusher:
+        return import_optional_dependency("pusher").Pusher(
+            app_id=self.app_id,
+            key=self.key,
+            secret=self.secret,
+            cluster=self.cluster,
+            ssl=self.ssl,
+        )
 
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
         data = [
@@ -39,7 +39,7 @@ class PusherEventListenerDriver(BaseEventListenerDriver):
             for event_payload in event_payload_batch
         ]
 
-        self.pusher_client.trigger_batch(data)
+        self.client.trigger_batch(data)
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
-        self.pusher_client.trigger(channels=self.channel, event_name=self.event_name, data=event_payload)
+        self.client.trigger(channels=self.channel, event_name=self.event_name, data=event_payload)

--- a/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
+++ b/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Attribute, Factory, define, field
 
@@ -11,6 +11,7 @@ from .base_file_manager_driver import BaseFileManagerDriver
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_s3 import S3Client
 
 
 @define
@@ -28,10 +29,10 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     bucket: str = field(kw_only=True)
     workdir: str = field(default="/", kw_only=True)
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: S3Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> S3Client:
         return self.session.client("s3")
 
     @workdir.validator  # pyright: ignore[reportAttributeAccessIssue]

--- a/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
+++ b/griptape/drivers/file_manager/amazon_s3_file_manager_driver.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from attrs import Attribute, Factory, define, field
 
+from griptape.utils.decorators import lazy_property
 from griptape.utils.import_utils import import_optional_dependency
 
 from .base_file_manager_driver import BaseFileManagerDriver
@@ -21,13 +22,17 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
         bucket: The name of the S3 bucket.
         workdir: The absolute working directory (must start with "/"). List, load, and save
             operations will be performed relative to this directory.
-        s3_client: The S3 client to use for S3 operations.
+        client: The S3 client to use for S3 operations.
     """
 
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
     bucket: str = field(kw_only=True)
     workdir: str = field(default="/", kw_only=True)
-    s3_client: Any = field(default=Factory(lambda self: self.session.client("s3"), takes_self=True), kw_only=True)
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("s3")
 
     @workdir.validator  # pyright: ignore[reportAttributeAccessIssue]
     def validate_workdir(self, _: Attribute, workdir: str) -> None:
@@ -51,7 +56,7 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
             raise IsADirectoryError
 
         try:
-            response = self.s3_client.get_object(Bucket=self.bucket, Key=full_key)
+            response = self.client.get_object(Bucket=self.bucket, Key=full_key)
             return response["Body"].read()
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] in {"NoSuchKey", "404"}:
@@ -62,7 +67,7 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
         full_key = self._to_full_key(path)
         if self._is_a_directory(full_key):
             raise IsADirectoryError
-        self.s3_client.put_object(Bucket=self.bucket, Key=full_key, Body=value)
+        self.client.put_object(Bucket=self.bucket, Key=full_key, Body=value)
 
     def _to_full_key(self, path: str) -> str:
         path = path.lstrip("/")
@@ -90,7 +95,7 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
         if max_items is not None:
             pagination_config["MaxItems"] = max_items
 
-        paginator = self.s3_client.get_paginator("list_objects_v2")
+        paginator = self.client.get_paginator("list_objects_v2")
         pages = paginator.paginate(
             Bucket=self.bucket,
             Prefix=full_key,
@@ -116,7 +121,7 @@ class AmazonS3FileManagerDriver(BaseFileManagerDriver):
             return True
 
         try:
-            self.s3_client.head_object(Bucket=self.bucket, Key=full_key)
+            self.client.head_object(Bucket=self.bucket, Key=full_key)
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] in {"NoSuchKey", "404"}:
                 return len(self._list_files_and_dirs(full_key, max_items=1)) > 0

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -8,6 +8,7 @@ from attrs import Factory, define, field
 from griptape.artifacts import ImageArtifact
 from griptape.drivers import BaseMultiModelImageGenerationDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
@@ -20,19 +21,21 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
     Attributes:
         model: Bedrock model ID.
         session: boto3 session.
-        bedrock_client: Bedrock runtime client.
+        client: Bedrock runtime client.
         image_width: Width of output images. Defaults to 512 and must be a multiple of 64.
         image_height: Height of output images. Defaults to 512 and must be a multiple of 64.
         seed: Optionally provide a consistent seed to generation requests, increasing consistency in output.
     """
 
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    bedrock_client: Any = field(
-        default=Factory(lambda self: self.session.client(service_name="bedrock-runtime"), takes_self=True),
-    )
     image_width: int = field(default=512, kw_only=True, metadata={"serializable": True})
     image_height: int = field(default=512, kw_only=True, metadata={"serializable": True})
     seed: Optional[int] = field(default=None, kw_only=True, metadata={"serializable": True})
+    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return self.session.client("bedrock-runtime")
 
     def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         request = self.image_generation_model_driver.text_to_image_request_parameters(
@@ -127,7 +130,7 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
         )
 
     def _make_request(self, request: dict) -> bytes:
-        response = self.bedrock_client.invoke_model(
+        response = self.client.invoke_model(
             body=json.dumps(request),
             modelId=self.model,
             accept="application/json",

--- a/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
+++ b/griptape/drivers/image_generation/amazon_bedrock_image_generation_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
 
@@ -12,6 +12,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_bedrock import BedrockClient
 
 
 @define
@@ -31,10 +32,10 @@ class AmazonBedrockImageGenerationDriver(BaseMultiModelImageGenerationDriver):
     image_width: int = field(default=512, kw_only=True, metadata={"serializable": True})
     image_height: int = field(default=512, kw_only=True, metadata={"serializable": True})
     seed: Optional[int] = field(default=None, kw_only=True, metadata={"serializable": True})
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: BedrockClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> BedrockClient:
         return self.session.client("bedrock-runtime")
 
     def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -35,7 +35,7 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-02-01", kw_only=True, metadata={"serializable": True})
-    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.AzureOpenAI:

--- a/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
+++ b/griptape/drivers/image_generation/azure_openai_image_generation_driver.py
@@ -6,6 +6,7 @@ import openai
 from attrs import Factory, define, field
 
 from griptape.drivers import OpenAiImageGenerationDriver
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -34,17 +35,16 @@ class AzureOpenAiImageGenerationDriver(OpenAiImageGenerationDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-02-01", kw_only=True, metadata={"serializable": True})
-    client: openai.AzureOpenAI = field(
-        default=Factory(
-            lambda self: openai.AzureOpenAI(
-                organization=self.organization,
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_deployment,
-                azure_ad_token=self.azure_ad_token,
-                azure_ad_token_provider=self.azure_ad_token_provider,
-            ),
-            takes_self=True,
-        ),
-    )
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(
+            organization=self.organization,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_deployment,
+            azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider=self.azure_ad_token_provider,
+        )

--- a/griptape/drivers/image_query/amazon_bedrock_image_query_driver.py
+++ b/griptape/drivers/image_query/amazon_bedrock_image_query_driver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
@@ -11,6 +11,7 @@ from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import boto3
+    from mypy_boto3_bedrock import BedrockClient
 
     from griptape.artifacts import ImageArtifact, TextArtifact
 
@@ -18,10 +19,10 @@ if TYPE_CHECKING:
 @define
 class AmazonBedrockImageQueryDriver(BaseMultiModelImageQueryDriver):
     session: boto3.Session = field(default=Factory(lambda: import_optional_dependency("boto3").Session()), kw_only=True)
-    _client: Any = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _client: BedrockClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> BedrockClient:
         return self.session.client("bedrock-runtime")
 
     def try_query(self, query: str, images: list[ImageArtifact]) -> TextArtifact:

--- a/griptape/drivers/image_query/anthropic_image_query_driver.py
+++ b/griptape/drivers/image_query/anthropic_image_query_driver.py
@@ -25,7 +25,7 @@ class AnthropicImageQueryDriver(BaseImageQueryDriver):
 
     api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
     model: str = field(kw_only=True, metadata={"serializable": True})
-    _client: Anthropic = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Anthropic = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Anthropic:

--- a/griptape/drivers/image_query/anthropic_image_query_driver.py
+++ b/griptape/drivers/image_query/anthropic_image_query_driver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
 
@@ -8,6 +8,9 @@ from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.drivers import BaseImageQueryDriver
 from griptape.utils import import_optional_dependency
 from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    from anthropic import Anthropic
 
 
 @define
@@ -22,10 +25,10 @@ class AnthropicImageQueryDriver(BaseImageQueryDriver):
 
     api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
     model: str = field(kw_only=True, metadata={"serializable": True})
-    _client: Any = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Anthropic = field(default=None, kw_only=True, metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Any:
+    def client(self) -> Anthropic:
         return import_optional_dependency("anthropic").Anthropic(api_key=self.api_key)
 
     def try_query(self, query: str, images: list[ImageArtifact]) -> TextArtifact:

--- a/griptape/drivers/image_query/azure_openai_image_query_driver.py
+++ b/griptape/drivers/image_query/azure_openai_image_query_driver.py
@@ -6,6 +6,7 @@ import openai
 from attrs import Factory, define, field
 
 from griptape.drivers.image_query.openai_image_query_driver import OpenAiImageQueryDriver
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -34,17 +35,16 @@ class AzureOpenAiImageQueryDriver(OpenAiImageQueryDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-02-01", kw_only=True, metadata={"serializable": True})
-    client: openai.AzureOpenAI = field(
-        default=Factory(
-            lambda self: openai.AzureOpenAI(
-                organization=self.organization,
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_deployment,
-                azure_ad_token=self.azure_ad_token,
-                azure_ad_token_provider=self.azure_ad_token_provider,
-            ),
-            takes_self=True,
-        ),
-    )
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(
+            organization=self.organization,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_deployment,
+            azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider=self.azure_ad_token_provider,
+        )

--- a/griptape/drivers/image_query/azure_openai_image_query_driver.py
+++ b/griptape/drivers/image_query/azure_openai_image_query_driver.py
@@ -35,7 +35,7 @@ class AzureOpenAiImageQueryDriver(OpenAiImageQueryDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-02-01", kw_only=True, metadata={"serializable": True})
-    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.AzureOpenAI:

--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -6,6 +6,7 @@ import openai
 from attrs import Factory, define, field
 
 from griptape.drivers import OpenAiChatPromptDriver
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from griptape.common import PromptStack
@@ -37,20 +38,19 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2023-05-15", kw_only=True, metadata={"serializable": True})
-    client: openai.AzureOpenAI = field(
-        default=Factory(
-            lambda self: openai.AzureOpenAI(
-                organization=self.organization,
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_deployment,
-                azure_ad_token=self.azure_ad_token,
-                azure_ad_token_provider=self.azure_ad_token_provider,
-            ),
-            takes_self=True,
-        ),
-    )
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(
+            organization=self.organization,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_deployment,
+            azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider=self.azure_ad_token_provider,
+        )
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         params = super()._base_params(prompt_stack)

--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -38,7 +38,7 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2023-05-15", kw_only=True, metadata={"serializable": True})
-    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.AzureOpenAI:

--- a/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
@@ -8,6 +8,7 @@ from griptape.common import DeltaMessage, Message, PromptStack, TextDeltaMessage
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -32,16 +33,6 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
     max_tokens: int = field(default=250, kw_only=True, metadata={"serializable": True})
     params: dict = field(factory=dict, kw_only=True, metadata={"serializable": True})
     model: str = field(kw_only=True, metadata={"serializable": True})
-    client: InferenceClient = field(
-        default=Factory(
-            lambda self: import_optional_dependency("huggingface_hub").InferenceClient(
-                model=self.model,
-                token=self.api_token,
-            ),
-            takes_self=True,
-        ),
-        kw_only=True,
-    )
     tokenizer: HuggingFaceTokenizer = field(
         default=Factory(
             lambda self: HuggingFaceTokenizer(model=self.model, max_output_tokens=self.max_tokens),
@@ -49,6 +40,14 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
+    _client: InferenceClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> InferenceClient:
+        return import_optional_dependency("huggingface_hub").InferenceClient(
+            model=self.model,
+            token=self.api_token,
+        )
 
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:

--- a/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
@@ -14,7 +14,7 @@ from griptape.utils.decorators import lazy_property
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from transformers import Pipeline
+    from transformers import TextGenerationPipeline
 
 
 @define
@@ -36,13 +36,14 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
-    pipeline_task: str = field(default="text-generation", kw_only=True, metadata={"serializable": True})
-    _pipeline: Pipeline = field(default=None, kw_only=True, alias="pipeline", metadata={"serializable": False})
+    _pipeline: TextGenerationPipeline = field(
+        default=None, kw_only=True, alias="pipeline", metadata={"serializable": False}
+    )
 
     @lazy_property()
-    def pipeline(self) -> Pipeline:
+    def pipeline(self) -> TextGenerationPipeline:
         return import_optional_dependency("transformers").pipeline(
-            task=self.pipeline_task,
+            task="text-generation",
             model=self.model,
             max_new_tokens=self.max_tokens,
             tokenizer=self.tokenizer.tokenizer,

--- a/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.py
@@ -9,6 +9,7 @@ from griptape.common import DeltaMessage, Message, PromptStack, TextMessageConte
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import HuggingFaceTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -35,23 +36,24 @@ class HuggingFacePipelinePromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
-    pipe: TextGenerationPipeline = field(
-        default=Factory(
-            lambda self: import_optional_dependency("transformers").pipeline(
-                "text-generation",
-                model=self.model,
-                max_new_tokens=self.max_tokens,
-                tokenizer=self.tokenizer.tokenizer,
-            ),
-            takes_self=True,
-        ),
+    _text_generation_pipeline: TextGenerationPipeline = field(
+        default=None, kw_only=True, alias="text_generation_pipeline", metadata={"serializable": False}
     )
+
+    @lazy_property()
+    def text_generation_pipeline(self) -> TextGenerationPipeline:
+        return import_optional_dependency("transformers").pipeline(
+            "text-generation",
+            model=self.model,
+            max_new_tokens=self.max_tokens,
+            tokenizer=self.tokenizer.tokenizer,
+        )
 
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         messages = self._prompt_stack_to_messages(prompt_stack)
 
-        result = self.pipe(
+        result = self.text_generation_pipeline(
             messages,
             max_new_tokens=self.max_tokens,
             temperature=self.temperature,

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -83,7 +83,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
-    _client: openai.OpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.OpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.OpenAI:

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -25,6 +25,7 @@ from griptape.common import (
 )
 from griptape.drivers import BasePromptDriver
 from griptape.tokenizers import BaseTokenizer, OpenAiTokenizer
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -55,12 +56,6 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     base_url: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     api_key: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
     organization: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    client: openai.OpenAI = field(
-        default=Factory(
-            lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
-            takes_self=True,
-        ),
-    )
     model: str = field(kw_only=True, metadata={"serializable": True})
     tokenizer: BaseTokenizer = field(
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True),
@@ -88,6 +83,15 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         ),
         kw_only=True,
     )
+    _client: openai.OpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.OpenAI:
+        return openai.OpenAI(
+            base_url=self.base_url,
+            api_key=self.api_key,
+            organization=self.organization,
+        )
 
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:

--- a/griptape/drivers/text_to_speech/azure_openai_text_to_speech_driver.py
+++ b/griptape/drivers/text_to_speech/azure_openai_text_to_speech_driver.py
@@ -6,6 +6,7 @@ import openai
 from attrs import Factory, define, field
 
 from griptape.drivers import OpenAiTextToSpeechDriver
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -35,17 +36,16 @@ class AzureOpenAiTextToSpeechDriver(OpenAiTextToSpeechDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-07-01-preview", kw_only=True, metadata={"serializable": True})
-    client: openai.AzureOpenAI = field(
-        default=Factory(
-            lambda self: openai.AzureOpenAI(
-                organization=self.organization,
-                api_key=self.api_key,
-                api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_deployment,
-                azure_ad_token=self.azure_ad_token,
-                azure_ad_token_provider=self.azure_ad_token_provider,
-            ),
-            takes_self=True,
-        ),
-    )
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(
+            organization=self.organization,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_deployment,
+            azure_ad_token=self.azure_ad_token,
+            azure_ad_token_provider=self.azure_ad_token_provider,
+        )

--- a/griptape/drivers/text_to_speech/azure_openai_text_to_speech_driver.py
+++ b/griptape/drivers/text_to_speech/azure_openai_text_to_speech_driver.py
@@ -36,7 +36,7 @@ class AzureOpenAiTextToSpeechDriver(OpenAiTextToSpeechDriver):
         metadata={"serializable": False},
     )
     api_version: str = field(default="2024-07-01-preview", kw_only=True, metadata={"serializable": True})
-    _client: openai.AzureOpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.AzureOpenAI:

--- a/griptape/drivers/text_to_speech/elevenlabs_text_to_speech_driver.py
+++ b/griptape/drivers/text_to_speech/elevenlabs_text_to_speech_driver.py
@@ -1,27 +1,28 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.artifacts.audio_artifact import AudioArtifact
 from griptape.drivers import BaseTextToSpeechDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    from elevenlabs.client import ElevenLabs
 
 
 @define
 class ElevenLabsTextToSpeechDriver(BaseTextToSpeechDriver):
     api_key: str = field(kw_only=True, metadata={"serializable": True})
-    client: Any = field(
-        default=Factory(
-            lambda self: import_optional_dependency("elevenlabs.client").ElevenLabs(api_key=self.api_key),
-            takes_self=True,
-        ),
-        kw_only=True,
-        metadata={"serializable": True},
-    )
     voice: str = field(kw_only=True, metadata={"serializable": True})
     output_format: str = field(default="mp3_44100_128", kw_only=True, metadata={"serializable": True})
+    _client: ElevenLabs = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> ElevenLabs:
+        return import_optional_dependency("elevenlabs.client").ElevenLabs(api_key=self.api_key)
 
     def try_text_to_audio(self, prompts: list[str]) -> AudioArtifact:
         audio = self.client.generate(

--- a/griptape/drivers/text_to_speech/openai_text_to_speech_driver.py
+++ b/griptape/drivers/text_to_speech/openai_text_to_speech_driver.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 import openai
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.artifacts.audio_artifact import AudioArtifact
 from griptape.drivers import BaseTextToSpeechDriver
+from griptape.utils.decorators import lazy_property
 
 
 @define
@@ -23,12 +24,15 @@ class OpenAiTextToSpeechDriver(BaseTextToSpeechDriver):
     base_url: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     api_key: Optional[str] = field(default=None, kw_only=True)
     organization: Optional[str] = field(default=openai.organization, kw_only=True, metadata={"serializable": True})
-    client: openai.OpenAI = field(
-        default=Factory(
-            lambda self: openai.OpenAI(api_key=self.api_key, base_url=self.base_url, organization=self.organization),
-            takes_self=True,
-        ),
-    )
+    _client: openai.OpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> openai.OpenAI:
+        return openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            organization=self.organization,
+        )
 
     def try_text_to_audio(self, prompts: list[str]) -> AudioArtifact:
         response = self.client.audio.speech.create(

--- a/griptape/drivers/text_to_speech/openai_text_to_speech_driver.py
+++ b/griptape/drivers/text_to_speech/openai_text_to_speech_driver.py
@@ -24,7 +24,7 @@ class OpenAiTextToSpeechDriver(BaseTextToSpeechDriver):
     base_url: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     api_key: Optional[str] = field(default=None, kw_only=True)
     organization: Optional[str] = field(default=openai.organization, kw_only=True, metadata={"serializable": True})
-    _client: openai.OpenAI = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: openai.OpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> openai.OpenAI:

--- a/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/amazon_opensearch_vector_store_driver.py
@@ -9,7 +9,6 @@ from griptape.utils import import_optional_dependency, str_to_hash
 
 if TYPE_CHECKING:
     from boto3 import Session
-    from opensearchpy import OpenSearch
 
 
 @define
@@ -31,19 +30,6 @@ class AmazonOpenSearchVectorStoreDriver(OpenSearchVectorStoreDriver):
                 self.session.get_credentials(),
                 self.session.region_name,
                 self.service,
-            ),
-            takes_self=True,
-        ),
-    )
-
-    client: OpenSearch = field(
-        default=Factory(
-            lambda self: import_optional_dependency("opensearchpy").OpenSearch(
-                hosts=[{"host": self.host, "port": self.port}],
-                http_auth=self.http_auth,
-                use_ssl=self.use_ssl,
-                verify_certs=self.verify_certs,
-                connection_class=import_optional_dependency("opensearchpy").RequestsHttpConnection,
             ),
             takes_self=True,
         ),

--- a/griptape/drivers/vector/astradb_vector_store_driver.py
+++ b/griptape/drivers/vector/astradb_vector_store_driver.py
@@ -6,10 +6,11 @@ from attrs import define, field
 
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
-    from astrapy import Collection
-    from astrapy.authentication import TokenProvider
+    import astrapy
+    import astrapy.authentication
 
 
 @define
@@ -26,32 +27,34 @@ class AstraDbVectorStoreDriver(BaseVectorStoreDriver):
             It can be omitted for production Astra DB targets. See `astrapy.constants.Environment` for allowed values.
         astra_db_namespace: optional specification of the namespace (in the Astra database) for the data.
             *Note*: not to be confused with the "namespace" mentioned elsewhere, which is a grouping within this vector store.
+        caller_name: the name of the caller for the Astra DB client. Defaults to "griptape".
+        client: an instance of `astrapy.DataAPIClient` for the Astra DB.
+        collection: an instance of `astrapy.Collection` for the Astra DB.
     """
 
     api_endpoint: str = field(kw_only=True, metadata={"serializable": True})
-    token: Optional[str | TokenProvider] = field(kw_only=True, default=None, metadata={"serializable": False})
+    token: Optional[str | astrapy.authentication.TokenProvider] = field(
+        kw_only=True, default=None, metadata={"serializable": False}
+    )
     collection_name: str = field(kw_only=True, metadata={"serializable": True})
     environment: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
     astra_db_namespace: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
+    caller_name: str = field(default="griptape", kw_only=True, metadata={"serializable": False})
+    _client: astrapy.DataAPIClient = field(default=None, kw_only=True, metadata={"serializable": False})
+    _collection: astrapy.Collection = field(default=None, kw_only=True, metadata={"serializable": False})
 
-    collection: Collection = field(init=False)
-
-    def __attrs_post_init__(self) -> None:
-        astrapy = import_optional_dependency("astrapy")
-        self.collection = (
-            astrapy.DataAPIClient(
-                caller_name="griptape",
-                environment=self.environment,
-            )
-            .get_database(
-                self.api_endpoint,
-                token=self.token,
-                namespace=self.astra_db_namespace,
-            )
-            .get_collection(
-                name=self.collection_name,
-            )
+    @lazy_property()
+    def client(self) -> astrapy.DataAPIClient:
+        return import_optional_dependency("astrapy").DataAPIClient(
+            caller_name=self.caller_name,
+            environment=self.environment,
         )
+
+    @lazy_property()
+    def collection(self) -> astrapy.Collection:
+        return self.client.get_database(
+            self.api_endpoint, token=self.token, namespace=self.astra_db_namespace
+        ).get_collection(self.collection_name)
 
     def delete_vector(self, vector_id: str) -> None:
         """Delete a vector from Astra DB store.

--- a/griptape/drivers/vector/astradb_vector_store_driver.py
+++ b/griptape/drivers/vector/astradb_vector_store_driver.py
@@ -40,8 +40,10 @@ class AstraDbVectorStoreDriver(BaseVectorStoreDriver):
     environment: Optional[str] = field(kw_only=True, default=None, metadata={"serializable": True})
     astra_db_namespace: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     caller_name: str = field(default="griptape", kw_only=True, metadata={"serializable": False})
-    _client: astrapy.DataAPIClient = field(default=None, kw_only=True, metadata={"serializable": False})
-    _collection: astrapy.Collection = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: astrapy.DataAPIClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _collection: astrapy.Collection = field(
+        default=None, kw_only=True, alias="collection", metadata={"serializable": False}
+    )
 
     @lazy_property()
     def client(self) -> astrapy.DataAPIClient:

--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NoReturn, Optional
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape import utils
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import marqo
@@ -21,20 +22,18 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
     Attributes:
         api_key: The API key for the Marqo API.
         url: The URL to the Marqo API.
-        mq: An optional Marqo client. Defaults to a new client with the given URL and API key.
+        client: An optional Marqo client. Defaults to a new client with the given URL and API key.
         index: The name of the index to use.
     """
 
     api_key: str = field(kw_only=True, metadata={"serializable": True})
     url: str = field(kw_only=True, metadata={"serializable": True})
-    mq: Optional[marqo.Client] = field(
-        default=Factory(
-            lambda self: import_optional_dependency("marqo").Client(self.url, api_key=self.api_key),
-            takes_self=True,
-        ),
-        kw_only=True,
-    )
     index: str = field(kw_only=True, metadata={"serializable": True})
+    _client: marqo.Client = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> marqo.Client:
+        return import_optional_dependency("marqo").Client(self.url, api_key=self.api_key)
 
     def upsert_text(
         self,
@@ -65,7 +64,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         if namespace:
             doc["namespace"] = namespace
 
-        response = self.mq.index(self.index).add_documents([doc], tensor_fields=["Description"])
+        response = self.client.index(self.index).add_documents([doc], tensor_fields=["Description"])
         if isinstance(response, dict) and "items" in response and response["items"]:
             return response["items"][0]["_id"]
         else:
@@ -102,7 +101,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
             "namespace": namespace,
         }
 
-        response = self.mq.index(self.index).add_documents([doc], tensor_fields=["Description", "artifact"])
+        response = self.client.index(self.index).add_documents([doc], tensor_fields=["Description", "artifact"])
         if isinstance(response, dict) and "items" in response and response["items"]:
             return response["items"][0]["_id"]
         else:
@@ -118,7 +117,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         Returns:
             The loaded Entry if found, otherwise None.
         """
-        result = self.mq.index(self.index).get_document(document_id=vector_id, expose_facets=True)
+        result = self.client.index(self.index).get_document(document_id=vector_id, expose_facets=True)
 
         if result and "_tensor_facets" in result and len(result["_tensor_facets"]) > 0:
             return BaseVectorStoreDriver.Entry(
@@ -141,15 +140,15 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         filter_string = f"namespace:{namespace}" if namespace else None
 
         if filter_string is not None:
-            results = self.mq.index(self.index).search("", limit=10000, filter_string=filter_string)
+            results = self.client.index(self.index).search("", limit=10000, filter_string=filter_string)
         else:
-            results = self.mq.index(self.index).search("", limit=10000)
+            results = self.client.index(self.index).search("", limit=10000)
 
         # get all _id's from search results
         ids = [r["_id"] for r in results["hits"]]
 
         # get documents corresponding to the ids
-        documents = self.mq.index(self.index).get_documents(document_ids=ids, expose_facets=True)
+        documents = self.client.index(self.index).get_documents(document_ids=ids, expose_facets=True)
 
         # for each document, if it's found, create an Entry object
         entries = []
@@ -195,11 +194,12 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
             "filter_string": f"namespace:{namespace}" if namespace else None,
         } | kwargs
 
-        results = self.mq.index(self.index).search(query, **params)
+        results = self.client.index(self.index).search(query, **params)
 
         if include_vectors:
             results["hits"] = [
-                {**r, **self.mq.index(self.index).get_document(r["_id"], expose_facets=True)} for r in results["hits"]
+                {**r, **self.client.index(self.index).get_document(r["_id"], expose_facets=True)}
+                for r in results["hits"]
             ]
 
         return [
@@ -218,7 +218,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         Args:
             name: The name of the index to delete.
         """
-        return self.mq.delete_index(name)
+        return self.client.delete_index(name)
 
     def get_indexes(self) -> list[str]:
         """Get a list of all indexes in the Marqo client.
@@ -226,7 +226,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         Returns:
             The list of all indexes.
         """
-        return [index["index"] for index in self.mq.get_indexes()["results"]]
+        return [index["index"] for index in self.client.get_indexes()["results"]]
 
     def upsert_vector(
         self,

--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -29,7 +29,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
     api_key: str = field(kw_only=True, metadata={"serializable": True})
     url: str = field(kw_only=True, metadata={"serializable": True})
     index: str = field(kw_only=True, metadata={"serializable": True})
-    _client: marqo.Client = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: marqo.Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> marqo.Client:

--- a/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
@@ -38,7 +38,7 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
         kw_only=True,
         metadata={"serializable": True},
     )  # https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/#fields
-    _client: MongoClient = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: MongoClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> MongoClient:

--- a/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from pymongo import MongoClient
@@ -37,12 +38,11 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
         kw_only=True,
         metadata={"serializable": True},
     )  # https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/#fields
-    client: MongoClient = field(
-        default=Factory(
-            lambda self: import_optional_dependency("pymongo").MongoClient(self.connection_string),
-            takes_self=True,
-        ),
-    )
+    _client: MongoClient = field(default=None, kw_only=True, metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> MongoClient:
+        return import_optional_dependency("pymongo").MongoClient(self.connection_string)
 
     def get_collection(self) -> Collection:
         """Returns the MongoDB Collection instance for the specified database and collection name."""

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, NoReturn, Optional
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape import utils
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from opensearchpy import OpenSearch
@@ -32,19 +33,19 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
     use_ssl: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     verify_certs: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     index_name: str = field(kw_only=True, metadata={"serializable": True})
+    _client: OpenSearch = field(default=None, kw_only=True, metadata={"serializable": False})
 
-    client: OpenSearch = field(
-        default=Factory(
-            lambda self: import_optional_dependency("opensearchpy").OpenSearch(
-                hosts=[{"host": self.host, "port": self.port}],
-                http_auth=self.http_auth,
-                use_ssl=self.use_ssl,
-                verify_certs=self.verify_certs,
-                connection_class=import_optional_dependency("opensearchpy").RequestsHttpConnection,
-            ),
-            takes_self=True,
-        ),
-    )
+    @lazy_property()
+    def client(self) -> OpenSearch:
+        opensearchpy = import_optional_dependency("opensearchpy")
+
+        return opensearchpy.OpenSearch(
+            hosts=[{"host": self.host, "port": self.port}],
+            http_auth=self.http_auth,
+            use_ssl=self.use_ssl,
+            verify_certs=self.verify_certs,
+            connection_class=opensearchpy.RequestsHttpConnection,
+        )
 
     def upsert_vector(
         self,

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -33,7 +33,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
     use_ssl: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     verify_certs: bool = field(default=True, kw_only=True, metadata={"serializable": True})
     index_name: str = field(kw_only=True, metadata={"serializable": True})
-    _client: OpenSearch = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: OpenSearch = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> OpenSearch:

--- a/griptape/drivers/vector/pinecone_vector_store_driver.py
+++ b/griptape/drivers/vector/pinecone_vector_store_driver.py
@@ -6,6 +6,7 @@ from attrs import define, field
 
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency, str_to_hash
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     import pinecone
@@ -17,16 +18,20 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
     index_name: str = field(kw_only=True, metadata={"serializable": True})
     environment: str = field(kw_only=True, metadata={"serializable": True})
     project_name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    index: pinecone.Index = field(init=False)
+    _client: pinecone.Pinecone = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+    _index: pinecone.Index = field(default=None, kw_only=True, alias="index", metadata={"serializable": False})
 
-    def __attrs_post_init__(self) -> None:
-        pinecone = import_optional_dependency("pinecone").Pinecone(
+    @lazy_property()
+    def client(self) -> pinecone.Pinecone:
+        return import_optional_dependency("pinecone").Pinecone(
             api_key=self.api_key,
             environment=self.environment,
             project_name=self.project_name,
         )
 
-        self.index = pinecone.Index(self.index_name)
+    @lazy_property()
+    def index(self) -> pinecone.Index:
+        return self.client.get_index(self.index_name)
 
     def upsert_vector(
         self,

--- a/griptape/drivers/vector/qdrant_vector_store_driver.py
+++ b/griptape/drivers/vector/qdrant_vector_store_driver.py
@@ -61,7 +61,7 @@ class QdrantVectorStoreDriver(BaseVectorStoreDriver):
     collection_name: str = field(kw_only=True, metadata={"serializable": True})
     vector_name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     content_payload_key: str = field(default=CONTENT_PAYLOAD_KEY, kw_only=True, metadata={"serializable": True})
-    _client: QdrantClient = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: QdrantClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> QdrantClient:

--- a/griptape/drivers/vector/qdrant_vector_store_driver.py
+++ b/griptape/drivers/vector/qdrant_vector_store_driver.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
 
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    from qdrant_client import QdrantClient
+
 
 DEFAULT_DISTANCE = "Cosine"
 CONTENT_PAYLOAD_KEY = "data"
@@ -56,9 +61,11 @@ class QdrantVectorStoreDriver(BaseVectorStoreDriver):
     collection_name: str = field(kw_only=True, metadata={"serializable": True})
     vector_name: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     content_payload_key: str = field(default=CONTENT_PAYLOAD_KEY, kw_only=True, metadata={"serializable": True})
+    _client: QdrantClient = field(default=None, kw_only=True, metadata={"serializable": False})
 
-    def __attrs_post_init__(self) -> None:
-        self.client = import_optional_dependency("qdrant_client").QdrantClient(
+    @lazy_property()
+    def client(self) -> QdrantClient:
+        return import_optional_dependency("qdrant_client").QdrantClient(
             location=self.location,
             url=self.url,
             host=self.host,

--- a/griptape/drivers/vector/redis_vector_store_driver.py
+++ b/griptape/drivers/vector/redis_vector_store_driver.py
@@ -34,7 +34,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     db: int = field(kw_only=True, default=0, metadata={"serializable": True})
     password: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
     index: str = field(kw_only=True, metadata={"serializable": True})
-    _client: Redis = field(default=None, kw_only=True, metadata={"serializable": False})
+    _client: Redis = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Redis:

--- a/griptape/drivers/vector/redis_vector_store_driver.py
+++ b/griptape/drivers/vector/redis_vector_store_driver.py
@@ -4,10 +4,11 @@ import json
 from typing import TYPE_CHECKING, NoReturn, Optional
 
 import numpy as np
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.drivers import BaseVectorStoreDriver
 from griptape.utils import import_optional_dependency, str_to_hash
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -33,19 +34,17 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     db: int = field(kw_only=True, default=0, metadata={"serializable": True})
     password: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": False})
     index: str = field(kw_only=True, metadata={"serializable": True})
+    _client: Redis = field(default=None, kw_only=True, metadata={"serializable": False})
 
-    client: Redis = field(
-        default=Factory(
-            lambda self: import_optional_dependency("redis").Redis(
-                host=self.host,
-                port=self.port,
-                db=self.db,
-                password=self.password,
-                decode_responses=False,
-            ),
-            takes_self=True,
-        ),
-    )
+    @lazy_property()
+    def client(self) -> Redis:
+        return import_optional_dependency("redis").Redis(
+            host=self.host,
+            port=self.port,
+            db=self.db,
+            password=self.password,
+            decode_responses=False,
+        )
 
     def upsert_vector(
         self,

--- a/griptape/drivers/web_search/duck_duck_go_web_search_driver.py
+++ b/griptape/drivers/web_search/duck_duck_go_web_search_driver.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.artifacts import ListArtifact, TextArtifact
 from griptape.drivers import BaseWebSearchDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from duckduckgo_search import DDGS
@@ -15,7 +16,11 @@ if TYPE_CHECKING:
 
 @define
 class DuckDuckGoWebSearchDriver(BaseWebSearchDriver):
-    client: DDGS = field(default=Factory(lambda: import_optional_dependency("duckduckgo_search").DDGS()), kw_only=True)
+    _client: DDGS = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> DDGS:
+        return import_optional_dependency("duckduckgo_search").DDGS()
 
     def search(self, query: str, **kwargs) -> ListArtifact:
         try:

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -171,6 +171,7 @@ class BaseSchema(Schema):
                 "BedrockClient": import_optional_dependency("mypy_boto3_bedrock").BedrockClient
                 if is_dependency_installed("mypy_boto3_bedrock")
                 else Any,
+                "voyageai": import_optional_dependency("voyageai") if is_dependency_installed("voyageai") else Any,
             },
         )
 

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -165,6 +165,12 @@ class BaseSchema(Schema):
                 if is_dependency_installed("google.generativeai")
                 else Any,
                 "boto3": import_optional_dependency("boto3") if is_dependency_installed("boto3") else Any,
+                "Anthropic": import_optional_dependency("anthropic").Anthropic
+                if is_dependency_installed("anthropic")
+                else Any,
+                "BedrockClient": import_optional_dependency("mypy_boto3_bedrock").BedrockClient
+                if is_dependency_installed("mypy_boto3_bedrock")
+                else Any,
             },
         )
 

--- a/griptape/tokenizers/google_tokenizer.py
+++ b/griptape/tokenizers/google_tokenizer.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 
 from griptape.tokenizers import BaseTokenizer
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from google.generativeai import GenerativeModel
@@ -17,16 +18,14 @@ class GoogleTokenizer(BaseTokenizer):
     MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS = {"gemini": 2048}
 
     api_key: str = field(kw_only=True, metadata={"serializable": True})
-    model_client: GenerativeModel = field(
-        default=Factory(lambda self: self._default_model_client(), takes_self=True),
-        kw_only=True,
-    )
+    _client: GenerativeModel = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
-    def count_tokens(self, text: str) -> int:
-        return self.model_client.count_tokens(text).total_tokens
-
-    def _default_model_client(self) -> GenerativeModel:
+    @lazy_property()
+    def client(self) -> GenerativeModel:
         genai = import_optional_dependency("google.generativeai")
         genai.configure(api_key=self.api_key)
 
         return genai.GenerativeModel(self.model)
+
+    def count_tokens(self, text: str) -> int:
+        return self.client.count_tokens(text).total_tokens

--- a/griptape/tools/aws_iam/tool.py
+++ b/griptape/tools/aws_iam/tool.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define, field
 from schema import Literal, Schema
 
 from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
 from griptape.tools import BaseAwsTool
-from griptape.utils.decorators import activity
+from griptape.utils.decorators import activity, lazy_property
 
 if TYPE_CHECKING:
-    from mypy_boto3_iam import Client
+    from mypy_boto3_iam import IAMClient
 
 
 @define
 class AwsIamTool(BaseAwsTool):
-    iam_client: Client = field(default=Factory(lambda self: self.session.client("iam"), takes_self=True), kw_only=True)
+    _client: IAMClient = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> IAMClient:
+        return self.session.client("iam")
 
     @activity(
         config={
@@ -33,7 +37,7 @@ class AwsIamTool(BaseAwsTool):
     )
     def get_user_policy(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            policy = self.iam_client.get_user_policy(
+            policy = self.client.get_user_policy(
                 UserName=params["values"]["user_name"],
                 PolicyName=params["values"]["policy_name"],
             )
@@ -44,7 +48,7 @@ class AwsIamTool(BaseAwsTool):
     @activity(config={"description": "Can be used to list AWS MFA Devices"})
     def list_mfa_devices(self, _: dict) -> ListArtifact | ErrorArtifact:
         try:
-            devices = self.iam_client.list_mfa_devices()
+            devices = self.client.list_mfa_devices()
             return ListArtifact([TextArtifact(str(d)) for d in devices["MFADevices"]])
         except Exception as e:
             return ErrorArtifact(f"error listing mfa devices: {e}")
@@ -59,10 +63,10 @@ class AwsIamTool(BaseAwsTool):
     )
     def list_user_policies(self, params: dict) -> ListArtifact | ErrorArtifact:
         try:
-            policies = self.iam_client.list_user_policies(UserName=params["values"]["user_name"])
+            policies = self.client.list_user_policies(UserName=params["values"]["user_name"])
             policy_names = policies["PolicyNames"]
 
-            attached_policies = self.iam_client.list_attached_user_policies(UserName=params["values"]["user_name"])
+            attached_policies = self.client.list_attached_user_policies(UserName=params["values"]["user_name"])
             attached_policy_names = [
                 p["PolicyName"] for p in attached_policies["AttachedPolicies"] if "PolicyName" in p
             ]
@@ -74,7 +78,7 @@ class AwsIamTool(BaseAwsTool):
     @activity(config={"description": "Can be used to list AWS IAM users."})
     def list_users(self, _: dict) -> ListArtifact | ErrorArtifact:
         try:
-            users = self.iam_client.list_users()
+            users = self.client.list_users()
             return ListArtifact([TextArtifact(str(u)) for u in users["Users"]])
         except Exception as e:
             return ErrorArtifact(f"error listing s3 users: {e}")

--- a/griptape/tools/aws_s3/tool.py
+++ b/griptape/tools/aws_s3/tool.py
@@ -11,15 +11,15 @@ from griptape.tools import BaseAwsTool
 from griptape.utils.decorators import activity, lazy_property
 
 if TYPE_CHECKING:
-    from mypy_boto3_s3 import Client
+    from mypy_boto3_s3 import S3Client
 
 
 @define
 class AwsS3Tool(BaseAwsTool):
-    _client: Client = field(default=None, kw_only=True)
+    _client: S3Client = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> Client:
+    def client(self) -> S3Client:
         return self.session.client("s3")
 
     @activity(

--- a/griptape/tools/aws_s3/tool.py
+++ b/griptape/tools/aws_s3/tool.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import io
 from typing import TYPE_CHECKING, Any
 
-from attrs import Factory, define, field
+from attrs import define, field
 from schema import Literal, Schema
 
 from griptape.artifacts import BlobArtifact, ErrorArtifact, InfoArtifact, ListArtifact, TextArtifact
 from griptape.tools import BaseAwsTool
-from griptape.utils.decorators import activity
+from griptape.utils.decorators import activity, lazy_property
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import Client
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
 
 @define
 class AwsS3Tool(BaseAwsTool):
-    s3_client: Client = field(default=Factory(lambda self: self.session.client("s3"), takes_self=True), kw_only=True)
+    _client: Client = field(default=None, kw_only=True)
+
+    @lazy_property()
+    def client(self) -> Client:
+        return self.session.client("s3")
 
     @activity(
         config={
@@ -33,7 +37,7 @@ class AwsS3Tool(BaseAwsTool):
     )
     def get_bucket_acl(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            acl = self.s3_client.get_bucket_acl(Bucket=params["values"]["bucket_name"])
+            acl = self.client.get_bucket_acl(Bucket=params["values"]["bucket_name"])
             return TextArtifact(acl)
         except Exception as e:
             return ErrorArtifact(f"error getting bucket acl: {e}")
@@ -48,7 +52,7 @@ class AwsS3Tool(BaseAwsTool):
     )
     def get_bucket_policy(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            policy = self.s3_client.get_bucket_policy(Bucket=params["values"]["bucket_name"])
+            policy = self.client.get_bucket_policy(Bucket=params["values"]["bucket_name"])
             return TextArtifact(policy)
         except Exception as e:
             return ErrorArtifact(f"error getting bucket policy: {e}")
@@ -66,7 +70,7 @@ class AwsS3Tool(BaseAwsTool):
     )
     def get_object_acl(self, params: dict) -> TextArtifact | ErrorArtifact:
         try:
-            acl = self.s3_client.get_object_acl(
+            acl = self.client.get_object_acl(
                 Bucket=params["values"]["bucket_name"],
                 Key=params["values"]["object_key"],
             )
@@ -77,7 +81,7 @@ class AwsS3Tool(BaseAwsTool):
     @activity(config={"description": "Can be used to list all AWS S3 buckets."})
     def list_s3_buckets(self, _: dict) -> ListArtifact | ErrorArtifact:
         try:
-            buckets = self.s3_client.list_buckets()
+            buckets = self.client.list_buckets()
 
             return ListArtifact([TextArtifact(str(b)) for b in buckets["Buckets"]])
         except Exception as e:
@@ -91,7 +95,7 @@ class AwsS3Tool(BaseAwsTool):
     )
     def list_objects(self, params: dict) -> ListArtifact | ErrorArtifact:
         try:
-            objects = self.s3_client.list_objects_v2(Bucket=params["values"]["bucket_name"])
+            objects = self.client.list_objects_v2(Bucket=params["values"]["bucket_name"])
 
             if "Contents" not in objects:
                 return ErrorArtifact("no objects found in the bucket")
@@ -192,7 +196,7 @@ class AwsS3Tool(BaseAwsTool):
         artifacts = []
         for object_info in objects:
             try:
-                obj = self.s3_client.get_object(Bucket=object_info["bucket_name"], Key=object_info["object_key"])
+                obj = self.client.get_object(Bucket=object_info["bucket_name"], Key=object_info["object_key"])
 
                 content = obj["Body"].read()
                 artifacts.append(BlobArtifact(content, name=object_info["object_key"]))
@@ -203,9 +207,9 @@ class AwsS3Tool(BaseAwsTool):
         return ListArtifact(artifacts)
 
     def _upload_object(self, bucket_name: str, object_name: str, value: Any) -> None:
-        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.client.create_bucket(Bucket=bucket_name)
 
-        self.s3_client.upload_fileobj(
+        self.client.upload_fileobj(
             Fileobj=io.BytesIO(value.encode() if isinstance(value, str) else value),
             Bucket=bucket_name,
             Key=object_name,

--- a/poetry.lock
+++ b/poetry.lock
@@ -7089,4 +7089,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7934a61f67c5726b989c8c53436e38adc36ef7c1702d37a9f30165349e0ff535"
+content-hash = "96cb1c9cb807d112d5b6fdae19b99fad98de4f82ab73ae8b24d313dd5d7ff773"

--- a/poetry.lock
+++ b/poetry.lock
@@ -380,10 +380,14 @@ files = [
 [package.dependencies]
 botocore-stubs = "*"
 mypy-boto3-bedrock = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"bedrock\""}
+mypy-boto3-dynamodb = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"dynamodb\""}
 mypy-boto3-iam = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"iam\""}
+mypy-boto3-iot-data = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"iot-data\""}
 mypy-boto3-opensearch = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"opensearch\""}
+mypy-boto3-redshift-data = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"redshift-data\""}
 mypy-boto3-s3 = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"s3\""}
 mypy-boto3-sagemaker = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"sagemaker\""}
+mypy-boto3-sqs = {version = ">=1.35.0,<1.36.0", optional = true, markers = "extra == \"sqs\""}
 types-s3transfer = "*"
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
 
@@ -3388,6 +3392,20 @@ files = [
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
 
 [[package]]
+name = "mypy-boto3-dynamodb"
+version = "1.35.24"
+description = "Type annotations for boto3.DynamoDB 1.35.24 service generated with mypy-boto3-builder 8.1.1"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_dynamodb-1.35.24-py3-none-any.whl", hash = "sha256:022859543c5314f14fb03ef4e445e34b97b9bc0cecb003c14c10943a2eaa3ff7"},
+    {file = "mypy_boto3_dynamodb-1.35.24.tar.gz", hash = "sha256:55bf897a1d0e354579edb05001f4bc4f472b9452badd9db24876c31bdf3f72a1"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
 name = "mypy-boto3-iam"
 version = "1.35.0"
 description = "Type annotations for boto3.IAM 1.35.0 service generated with mypy-boto3-builder 7.26.0"
@@ -3402,6 +3420,20 @@ files = [
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
 
 [[package]]
+name = "mypy-boto3-iot-data"
+version = "1.35.0"
+description = "Type annotations for boto3.IoTDataPlane 1.35.0 service generated with mypy-boto3-builder 7.26.0"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_iot_data-1.35.0-py3-none-any.whl", hash = "sha256:1f442679a71f22a82b0436ee4f71c06104a9ed722aa71c6800fd93bd345cfc03"},
+    {file = "mypy_boto3_iot_data-1.35.0.tar.gz", hash = "sha256:e83cbbd948bc388ed139d2820442af1d319ca37dce708df44295c4acfcfb30f8"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
 name = "mypy-boto3-opensearch"
 version = "1.35.0"
 description = "Type annotations for boto3.OpenSearchService 1.35.0 service generated with mypy-boto3-builder 7.26.0"
@@ -3410,6 +3442,20 @@ python-versions = ">=3.8"
 files = [
     {file = "mypy_boto3_opensearch-1.35.0-py3-none-any.whl", hash = "sha256:c03c99e6423e6161ac069b36b57bd58d7f8e8bc2cc2edab468b22a19e5136f63"},
     {file = "mypy_boto3_opensearch-1.35.0.tar.gz", hash = "sha256:0102d4e28af87e55cbc53ad9272d171c89fd3054539a01e35168cbcee3f6a570"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
+name = "mypy-boto3-redshift-data"
+version = "1.35.10"
+description = "Type annotations for boto3.RedshiftDataAPIService 1.35.10 service generated with mypy-boto3-builder 7.26.1"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_redshift_data-1.35.10-py3-none-any.whl", hash = "sha256:1d37d8453c4f3e6b688703a91316729ee2dcaec101326c4f58658d8526d5fc09"},
+    {file = "mypy_boto3_redshift_data-1.35.10.tar.gz", hash = "sha256:2cfe518ef3027c2b050facffd2621924458ddf2fb3df9699cdba33e8a6859594"},
 ]
 
 [package.dependencies]
@@ -3438,6 +3484,20 @@ python-versions = ">=3.8"
 files = [
     {file = "mypy_boto3_sagemaker-1.35.0-py3-none-any.whl", hash = "sha256:cca21f0f8fb505a0530fb5650ab9ad2dba421bfdec8a6a12b39b3b230e15b059"},
     {file = "mypy_boto3_sagemaker-1.35.0.tar.gz", hash = "sha256:b6a6809f221fbe8c27195877333b88804fd0f258fea10e89bc544bb25bb0ec0b"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
+
+[[package]]
+name = "mypy-boto3-sqs"
+version = "1.35.0"
+description = "Type annotations for boto3.SQS 1.35.0 service generated with mypy-boto3-builder 7.26.0"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_boto3_sqs-1.35.0-py3-none-any.whl", hash = "sha256:9fd6e622ed231c06f7542ba6f8f0eea92046cace24defa95d0d0ce04e7caee0c"},
+    {file = "mypy_boto3_sqs-1.35.0.tar.gz", hash = "sha256:61752f1c2bf2efa3815f64d43c25b4a39dbdbd9e472ae48aa18d7c6d2a7a6eb8"},
 ]
 
 [package.dependencies]
@@ -6391,6 +6451,11 @@ files = [
     {file = "triton-3.0.0-1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e509deb77f1c067d8640725ef00c5cbfcb2052a1a3cb6a6d343841f92624eb"},
     {file = "triton-3.0.0-1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bcbf3b1c48af6a28011a5c40a5b3b9b5330530c3827716b5fbf6d7adcc1e53e9"},
     {file = "triton-3.0.0-1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6e5727202f7078c56f91ff13ad0c1abab14a0e7f2c87e91b12b6f64f3e8ae609"},
+    {file = "triton-3.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b052da883351fdf6be3d93cedae6db3b8e3988d3b09ed221bccecfa9612230"},
+    {file = "triton-3.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd34f19a8582af96e6291d4afce25dac08cb2a5d218c599163761e8e0827208e"},
+    {file = "triton-3.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d5e10de8c011adeb7c878c6ce0dd6073b14367749e34467f1cff2bde1b78253"},
+    {file = "triton-3.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8903767951bf86ec960b4fe4e21bc970055afc65e9d57e916d79ae3c93665e3"},
+    {file = "triton-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41004fb1ae9a53fcb3e970745feb87f0e3c94c6ce1ba86e95fa3b8537894bef7"},
 ]
 
 [package.dependencies]
@@ -7024,4 +7089,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "bb4af9c531d0029cb1baeca3a2e94566aaf6d7cb701a6dc07f5e9983bffd1285"
+content-hash = "7934a61f67c5726b989c8c53436e38adc36ef7c1702d37a9f30165349e0ff535"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,7 +228,7 @@ optional = true
 ruff = "^0.6.0"
 pyright = "^1.1.376"
 pre-commit = "^3.7.1"
-boto3-stubs = {extras = ["bedrock", "iam", "opensearch", "s3", "sagemaker"], version = "^1.34.105"}
+boto3-stubs = {extras = ["bedrock", "iam", "opensearch", "s3", "sagemaker", "sqs", "iot-data", "dynamodb", "redshift-data"], version = "^1.34.105"}
 typos = "^1.22.9"
 
 

--- a/tests/unit/drivers/event_listener/test_pusher_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_pusher_event_listener_driver.py
@@ -9,11 +9,11 @@ from tests.mocks.mock_event import MockEvent
 class TestPusherEventListenerDriver:
     @pytest.fixture(autouse=True)
     def mock_post(self, mocker):
-        mock_pusher_client = mocker.patch("pusher.Pusher")
-        mock_pusher_client.return_value.trigger.return_value = Mock()
-        mock_pusher_client.return_value.trigger_batch.return_value = Mock()
+        mock_client = mocker.patch("pusher.Pusher")
+        mock_client.return_value.trigger.return_value = Mock()
+        mock_client.return_value.trigger_batch.return_value = Mock()
 
-        return mock_pusher_client
+        return mock_client
 
     @pytest.fixture()
     def driver(self):
@@ -33,12 +33,12 @@ class TestPusherEventListenerDriver:
         data = MockEvent().to_dict()
         driver.try_publish_event_payload(data)
 
-        driver.pusher_client.trigger.assert_called_with(channels="test-channel", event_name="test-event", data=data)
+        driver.client.trigger.assert_called_with(channels="test-channel", event_name="test-event", data=data)
 
     def test_try_publish_event_payload_batch(self, driver):
         data = [MockEvent().to_dict() for _ in range(3)]
         driver.try_publish_event_payload_batch(data)
 
-        driver.pusher_client.trigger_batch.assert_called_with(
+        driver.client.trigger_batch.assert_called_with(
             [{"channel": "test-channel", "name": "test-event", "data": data[i]} for i in range(3)]
         )

--- a/tests/unit/drivers/image_generation/test_amazon_bedrock_stable_diffusion_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_amazon_bedrock_stable_diffusion_image_generation_driver.py
@@ -8,13 +8,13 @@ from griptape.drivers import AmazonBedrockImageGenerationDriver
 
 class TestAmazonBedrockImageGenerationDriver:
     @pytest.fixture()
-    def bedrock_client(self):
+    def client(self):
         return Mock()
 
     @pytest.fixture()
-    def session(self, bedrock_client):
+    def session(self, client):
         session = Mock()
-        session.client.return_value = bedrock_client
+        session.client.return_value = client
 
         return session
 
@@ -40,7 +40,7 @@ class TestAmazonBedrockImageGenerationDriver:
             AmazonBedrockImageGenerationDriver(session=session, model="stability.stable-diffusion-xl-v1")  # pyright: ignore[reportCallIssue]
 
     def test_try_text_to_image(self, driver):
-        driver.bedrock_client.invoke_model.return_value = {
+        driver.client.invoke_model.return_value = {
             "body": io.BytesIO(
                 b"""{
                         "artifacts": [

--- a/tests/unit/drivers/image_query/test_amazon_bedrock_image_query_driver.py
+++ b/tests/unit/drivers/image_query/test_amazon_bedrock_image_query_driver.py
@@ -9,13 +9,13 @@ from griptape.drivers import AmazonBedrockImageQueryDriver
 
 class TestAmazonBedrockImageQueryDriver:
     @pytest.fixture()
-    def bedrock_client(self, mocker):
+    def client(self, mocker):
         return Mock()
 
     @pytest.fixture()
-    def session(self, bedrock_client):
+    def session(self, client):
         session = Mock()
-        session.client.return_value = bedrock_client
+        session.client.return_value = client
 
         return session
 
@@ -35,7 +35,7 @@ class TestAmazonBedrockImageQueryDriver:
         assert image_query_driver
 
     def test_try_query(self, image_query_driver):
-        image_query_driver.bedrock_client.invoke_model.return_value = {"body": io.BytesIO(b"""{"content": []}""")}
+        image_query_driver.client.invoke_model.return_value = {"body": io.BytesIO(b"""{"content": []}""")}
 
         text_artifact = image_query_driver.try_query(
             "Prompt String", [ImageArtifact(value=b"test-data", width=100, height=100, format="png")]
@@ -44,7 +44,7 @@ class TestAmazonBedrockImageQueryDriver:
         assert text_artifact.value == "content"
 
     def test_try_query_no_body(self, image_query_driver):
-        image_query_driver.bedrock_client.invoke_model.return_value = {"body": io.BytesIO(b"")}
+        image_query_driver.client.invoke_model.return_value = {"body": io.BytesIO(b"")}
 
         with pytest.raises(ValueError):
             image_query_driver.try_query(

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -86,7 +86,7 @@ class TestMarqoVectorStorageDriver:
             api_key="foobar",
             url="http://localhost:8000",
             index="test",
-            mq=mock_marqo,
+            client=mock_marqo,
             embedding_driver=MockEmbeddingDriver(),
         )
 

--- a/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
@@ -36,7 +36,9 @@ class TestPgVectorVectorStoreDriver:
 
     def test_initialize_accepts_engine(self, embedding_driver):
         engine: Any = create_engine(self.connection_string)
-        PgVectorVectorStoreDriver(embedding_driver=embedding_driver, engine=engine, table_name=self.table_name)
+        PgVectorVectorStoreDriver(
+            embedding_driver=embedding_driver, sqlalchemy_engine=engine, table_name=self.table_name
+        )
 
     def test_initialize_accepts_connection_string(self, embedding_driver):
         PgVectorVectorStoreDriver(
@@ -48,7 +50,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.merge.return_value = Mock(id=test_id)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         returned_id = driver.upsert_vector([1.0, 2.0, 3.0])
@@ -65,7 +67,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.get.return_value = Mock(id=test_id, vector=test_vec, namespace=test_namespace, meta=test_meta)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         entry = driver.load_entry(vector_id=test_id)
@@ -88,7 +90,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query.return_value = mock_query
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         entries = driver.load_entries()
@@ -104,7 +106,7 @@ class TestPgVectorVectorStoreDriver:
 
     def test_query_invalid_distance_metric(self, mock_engine):
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         with pytest.raises(ValueError):
@@ -122,7 +124,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query().order_by().limit().all.return_value = test_result
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         result = driver.query("some query", include_vectors=True)
@@ -147,7 +149,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query().order_by().filter_by().limit().all.return_value = test_result
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
         )
 
         result = driver.query("some query", include_vectors=True, filter={"namespace": test_namespaces[0]})

--- a/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_pgvector_vector_store_driver.py
@@ -36,9 +36,7 @@ class TestPgVectorVectorStoreDriver:
 
     def test_initialize_accepts_engine(self, embedding_driver):
         engine: Any = create_engine(self.connection_string)
-        PgVectorVectorStoreDriver(
-            embedding_driver=embedding_driver, sqlalchemy_engine=engine, table_name=self.table_name
-        )
+        PgVectorVectorStoreDriver(embedding_driver=embedding_driver, engine=engine, table_name=self.table_name)
 
     def test_initialize_accepts_connection_string(self, embedding_driver):
         PgVectorVectorStoreDriver(
@@ -50,7 +48,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.merge.return_value = Mock(id=test_id)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         returned_id = driver.upsert_vector([1.0, 2.0, 3.0])
@@ -67,7 +65,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.get.return_value = Mock(id=test_id, vector=test_vec, namespace=test_namespace, meta=test_meta)
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         entry = driver.load_entry(vector_id=test_id)
@@ -90,7 +88,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query.return_value = mock_query
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         entries = driver.load_entries()
@@ -106,7 +104,7 @@ class TestPgVectorVectorStoreDriver:
 
     def test_query_invalid_distance_metric(self, mock_engine):
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         with pytest.raises(ValueError):
@@ -124,7 +122,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query().order_by().limit().all.return_value = test_result
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         result = driver.query("some query", include_vectors=True)
@@ -149,7 +147,7 @@ class TestPgVectorVectorStoreDriver:
         mock_session.query().order_by().filter_by().limit().all.return_value = test_result
 
         driver = PgVectorVectorStoreDriver(
-            embedding_driver=MockEmbeddingDriver(), sqlalchemy_engine=mock_engine, table_name=self.table_name
+            embedding_driver=MockEmbeddingDriver(), engine=mock_engine, table_name=self.table_name
         )
 
         result = driver.query("some query", include_vectors=True, filter={"namespace": test_namespaces[0]})

--- a/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
+++ b/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
@@ -7,7 +7,7 @@ from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
 class TestPineconeVectorStorageDriver:
     @pytest.fixture(autouse=True)
-    def _mock_pinecone(self, mocker):
+    def mock_index(self, mocker):
         # Create a fake response
         fake_query_response = {
             "matches": [{"id": "foo", "values": [0, 1, 0], "score": 42, "metadata": {"foo": "bar"}}],
@@ -15,14 +15,21 @@ class TestPineconeVectorStorageDriver:
         }
 
         mock_client = mocker.patch("pinecone.Pinecone")
-        mock_client().Index().upsert.return_value = None
-        mock_client().Index().query.return_value = fake_query_response
-        mock_client().create_index.return_value = None
+        mock_index = mock_client().Index()
+        mock_index.upsert.return_value = None
+        mock_index.query.return_value = fake_query_response
+        mock_index.create_index.return_value = None
+
+        return mock_index
 
     @pytest.fixture()
-    def driver(self):
+    def driver(self, mock_index):
         return PineconeVectorStoreDriver(
-            api_key="foobar", index_name="test", environment="test", embedding_driver=MockEmbeddingDriver()
+            api_key="foobar",
+            index_name="test",
+            environment="test",
+            embedding_driver=MockEmbeddingDriver(),
+            index=mock_index,
         )
 
     def test_upsert_text_artifact(self, driver):

--- a/tests/unit/drivers/vector/test_qdrant_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_qdrant_vector_store_driver.py
@@ -37,30 +37,6 @@ class TestQdrantVectorStoreDriver:
             embedding_driver=embedding_driver,
         )
 
-    def test_attrs_post_init(self, driver):
-        with patch("griptape.drivers.vector.qdrant_vector_store_driver.import_optional_dependency") as mock_import:
-            mock_qdrant_client = MagicMock()
-            mock_import.return_value.QdrantClient.return_value = mock_qdrant_client
-
-            driver.__attrs_post_init__()
-
-            mock_import.assert_called_once_with("qdrant_client")
-            mock_import.return_value.QdrantClient.assert_called_once_with(
-                location=driver.location,
-                url=driver.url,
-                host=driver.host,
-                path=driver.path,
-                port=driver.port,
-                prefer_grpc=driver.prefer_grpc,
-                grpc_port=driver.grpc_port,
-                api_key=driver.api_key,
-                https=driver.https,
-                prefix=driver.prefix,
-                force_disable_check_same_thread=driver.force_disable_check_same_thread,
-                timeout=driver.timeout,
-            )
-            assert driver.client == mock_qdrant_client
-
     def test_delete_vector(self, driver):
         vector_id = "test_vector_id"
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
This normalizes the usage and naming of API clients in various drivers throughout the framework.

Today, any parameters set _after init_ on any drivers that use a `client` are ignored because the `client` is typically initialized during driver initialization via an attrs `Factory`. Adding `@lazy_property` to the clients allow for making parameter modifications on the `Driver` before the client is used, namely in the global `Defaults` object. see #1174 for an example.


## Issue ticket number and link
#1174 
