### PR TITLE
Set mkdocs site_url to RTD canonical url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Griptape Docs
+site_url: !ENV READTHEDOCS_CANONICAL_URL
 hooks:
   - docs/plugins/swagger_ui_plugin.py
 strict: true


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Set site url to RTD provided [canonical URL](https://docs.readthedocs.io/en/stable/canonical-urls.html)
## Issue ticket number and link
NA