### PR TITLE
Change Stucture.output behavior/return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `model_client` on `GoogleTokenizer`.
 - **BREAKING**: Renamed parameter `pipe` on `HuggingFacePipelinePromptDriver` to `pipeline`.
 - Several places where API clients are initialized are now lazy loaded.
+- `Structure.output`'s type is now `BaseArtifact` and raises an exception if the output is `None`.
 
 
 ## [0.32.0] - 2024-09-17

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -7,7 +7,6 @@ from attrs import Attribute, Factory, define, field
 from griptape.artifacts.text_artifact import TextArtifact
 from griptape.common import observable
 from griptape.configs import Defaults
-from griptape.memory.structure import Run
 from griptape.structures import Structure
 from griptape.tasks import PromptTask, ToolkitTask
 
@@ -76,10 +75,5 @@ class Agent(Structure):
     @observable
     def try_run(self, *args) -> Agent:
         self.task.execute()
-
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
-
-            self.conversation_memory.add_run(run)
 
         return self

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -6,7 +6,6 @@ from attrs import define
 
 from griptape.artifacts import ErrorArtifact
 from griptape.common import observable
-from griptape.memory.structure import Run
 from griptape.structures import Structure
 
 if TYPE_CHECKING:
@@ -52,11 +51,6 @@ class Pipeline(Structure):
     @observable
     def try_run(self, *args) -> Pipeline:
         self.__run_from_task(self.input_task)
-
-        if self.conversation_memory and self.output_task.output is not None:
-            run = Run(input=self.input_task.input, output=self.output_task.output)
-
-            self.conversation_memory.add_run(run)
 
         return self
 

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -53,8 +53,8 @@ class Pipeline(Structure):
     def try_run(self, *args) -> Pipeline:
         self.__run_from_task(self.input_task)
 
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
+        if self.conversation_memory and self.output_task.output is not None:
+            run = Run(input=self.input_task.input, output=self.output_task.output)
 
             self.conversation_memory.add_run(run)
 

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -85,8 +85,10 @@ class Structure(ABC):
         return self.tasks[-1] if self.tasks else None
 
     @property
-    def output(self) -> Optional[BaseArtifact]:
-        return self.output_task.output if self.output_task is not None else None
+    def output(self) -> BaseArtifact:
+        if self.output_task.output is None:
+            raise ValueError("Structure's output Task has no output. Run the Structure to generate output.")
+        return self.output_task.output
 
     @property
     def finished_tasks(self) -> list[BaseTask]:

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -10,7 +10,7 @@ from griptape.common import observable
 from griptape.events import EventBus, FinishStructureRunEvent, StartStructureRunEvent
 from griptape.memory import TaskMemory
 from griptape.memory.meta import MetaMemory
-from griptape.memory.structure import ConversationMemory
+from griptape.memory.structure import ConversationMemory, Run
 
 if TYPE_CHECKING:
     from griptape.artifacts import BaseArtifact
@@ -165,6 +165,11 @@ class Structure(ABC):
 
     @observable
     def after_run(self) -> None:
+        if self.conversation_memory and self.output_task.output is not None:
+            run = Run(input=self.input_task.input, output=self.output_task.output)
+
+            self.conversation_memory.add_run(run)
+
         EventBus.publish_event(
             FinishStructureRunEvent(
                 structure_id=self.id,

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -8,7 +8,6 @@ from graphlib import TopologicalSorter
 
 from griptape.artifacts import ErrorArtifact
 from griptape.common import observable
-from griptape.memory.structure import Run
 from griptape.mixins.futures_executor_mixin import FuturesExecutorMixin
 from griptape.structures import Structure
 
@@ -113,11 +112,6 @@ class Workflow(Structure, FuturesExecutorMixin):
                     exit_loop = True
 
                     break
-
-        if self.conversation_memory and self.output_task.output is not None:
-            run = Run(input=self.input_task.input, output=self.output_task.output)
-
-            self.conversation_memory.add_run(run)
 
         return self
 

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -114,8 +114,8 @@ class Workflow(Structure, FuturesExecutorMixin):
 
                     break
 
-        if self.conversation_memory and self.output is not None:
-            run = Run(input=self.input_task.input, output=self.output)
+        if self.conversation_memory and self.output_task.output is not None:
+            run = Run(input=self.input_task.input, output=self.output_task.output)
 
             self.conversation_memory.add_run(run)
 

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -367,7 +367,8 @@ class TestPipeline:
         pipeline = Pipeline(tasks=[waiting_task, error_artifact_task, end_task])
         pipeline.run()
 
-        assert pipeline.output is None
+        with pytest.raises(ValueError, match="Structure's output Task has no output. Run"):
+            assert pipeline.output
 
     def test_run_with_error_artifact_no_fail_fast(self, error_artifact_task, waiting_task):
         end_task = PromptTask("end")

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -752,7 +752,8 @@ class TestWorkflow:
         workflow = Workflow(tasks=[waiting_task, error_artifact_task, end_task])
         workflow.run()
 
-        assert workflow.output is None
+        with pytest.raises(ValueError, match="Structure's output Task has no output. Run"):
+            assert workflow.output
 
     def test_run_with_error_artifact_no_fail_fast(self, error_artifact_task, waiting_task):
         end_task = PromptTask("end")


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- `Structure.output`'s type is now `BaseArtifact` and raises an exception if the output is `None`.
Cuts out `None` checks post Structure run
## Issue ticket number and link
NA