### PR TITLE
Add media tags to markdownify exclude list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Structure.output`'s type is now `BaseArtifact` and raises an exception if the output is `None`.
 - **BREAKING**: Update `pypdf` dependency to `^5.0.1`.
 - **BREAKING**: Update `redis` dependency to `^5.1.0`.
+- `MarkdownifyWebScraperDriver.DEFAULT_EXCLUDE_TAGS` now includes media/blob-like HTML tags
 
 ### Fixed
 - Anthropic native Tool calling

--- a/griptape/drivers/web_scraper/markdownify_web_scraper_driver.py
+++ b/griptape/drivers/web_scraper/markdownify_web_scraper_driver.py
@@ -27,7 +27,7 @@ class MarkdownifyWebScraperDriver(BaseWebScraperDriver):
             the browser has emitted the "load" event.
     """
 
-    DEFAULT_EXCLUDE_TAGS = ["script", "style", "head"]
+    DEFAULT_EXCLUDE_TAGS = ["script", "style", "head", "audio", "img", "picture", "source", "video"]
 
     include_links: bool = field(default=True, kw_only=True)
     exclude_tags: list[str] = field(


### PR DESCRIPTION
- [X] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
With the MarkdownifyWebScraperDriver returning TextArtifact, media content can be excluded from the default output. This will reduce the noise and size of webscraper output

## Issue ticket number and link
