### PR TITLE
Refactor RuleMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: `JsonExtractionEngine.template_schema` is now required.
 - **BREAKING**: `CsvExtractionEngine.column_names` is now required.
 - `StructureRunTask` now inherits from `PromptTask`.
+- **BREAKING**: Renamed`RuleMixin.all_rulesets` to `RuleMixin.rulesets`.
 - `JsonExtractionEngine.extract_artifacts` now returns a `ListArtifact[JsonArtifact]`.
 - `CsvExtractionEngine.extract_artifacts` now returns a `ListArtifact[CsvRowArtifact]`.
 - Remove `manifest.yml` requirements for custom tool creation.
@@ -74,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Anthropic native Tool calling.
 - Empty `ActionsSubtask.thought` being logged.
+- `RuleMixin` no longer prevents setting `rulesets` _and_ `rules` at the same time.
+- `PromptTask` will merge in its Structure's Rulesets and Rules.
+- `PromptTask` not checking whether Structure was set before building Prompt Stack.
 
 ## [0.32.0] - 2024-09-17
 

--- a/griptape/engines/rag/modules/response/prompt_response_rag_module.py
+++ b/griptape/engines/rag/modules/response/prompt_response_rag_module.py
@@ -56,8 +56,8 @@ class PromptResponseRagModule(BaseResponseRagModule, RuleMixin):
     def default_system_template_generator(self, context: RagContext, artifacts: list[TextArtifact]) -> str:
         params: dict[str, Any] = {"text_chunks": [c.to_text() for c in artifacts]}
 
-        if len(self.all_rulesets) > 0:
-            params["rulesets"] = J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets)
+        if len(self.rulesets) > 0:
+            params["rulesets"] = J2("rulesets/rulesets.j2").render(rulesets=self.rulesets)
 
         if self.metadata is not None:
             params["metadata"] = J2("engines/rag/modules/response/metadata/system.j2").render(metadata=self.metadata)

--- a/griptape/mixins/rule_mixin.py
+++ b/griptape/mixins/rule_mixin.py
@@ -1,56 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
-
-from attrs import Attribute, define, field
+from attrs import define, field
 
 from griptape.rules import BaseRule, Ruleset
-
-if TYPE_CHECKING:
-    from griptape.structures import Structure
 
 
 @define(slots=False)
 class RuleMixin:
     DEFAULT_RULESET_NAME = "Default Ruleset"
-    ADDITIONAL_RULESET_NAME = "Additional Ruleset"
 
-    rulesets: list[Ruleset] = field(factory=list, kw_only=True)
+    _rulesets: list[Ruleset] = field(factory=list, kw_only=True, alias="rulesets")
     rules: list[BaseRule] = field(factory=list, kw_only=True)
-    structure: Optional[Structure] = field(default=None, kw_only=True)
-
-    @rulesets.validator  # pyright: ignore[reportAttributeAccessIssue]
-    def validate_rulesets(self, _: Attribute, rulesets: list[Ruleset]) -> None:
-        if not rulesets:
-            return
-
-        if self.rules:
-            raise ValueError("Can't have both rulesets and rules specified.")
-
-    @rules.validator  # pyright: ignore[reportAttributeAccessIssue]
-    def validate_rules(self, _: Attribute, rules: list[BaseRule]) -> None:
-        if not rules:
-            return
-
-        if self.rulesets:
-            raise ValueError("Can't have both rules and rulesets specified.")
 
     @property
-    def all_rulesets(self) -> list[Ruleset]:
-        structure_rulesets = []
+    def rulesets(self) -> list[Ruleset]:
+        rulesets = self._rulesets
 
-        if self.structure:
-            if self.structure.rulesets:
-                structure_rulesets = self.structure.rulesets
-            elif self.structure.rules:
-                structure_rulesets = [Ruleset(name=self.DEFAULT_RULESET_NAME, rules=self.structure.rules)]
+        if self.rules:
+            rulesets.append(Ruleset(name=self.DEFAULT_RULESET_NAME, rules=self.rules))
 
-        task_rulesets = []
-        if self.rulesets:
-            task_rulesets = self.rulesets
-        elif self.rules:
-            task_ruleset_name = self.ADDITIONAL_RULESET_NAME if structure_rulesets else self.DEFAULT_RULESET_NAME
-
-            task_rulesets = [Ruleset(name=task_ruleset_name, rules=self.rules)]
-
-        return structure_rulesets + task_rulesets
+        return rulesets

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -4,26 +4,24 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
 
-from attrs import Attribute, Factory, define, field
+from attrs import Factory, define, field
 
 from griptape.common import observable
 from griptape.events import EventBus, FinishStructureRunEvent, StartStructureRunEvent
 from griptape.memory import TaskMemory
 from griptape.memory.meta import MetaMemory
 from griptape.memory.structure import ConversationMemory, Run
+from griptape.mixins.rule_mixin import RuleMixin
 
 if TYPE_CHECKING:
     from griptape.artifacts import BaseArtifact
     from griptape.memory.structure import BaseConversationMemory
-    from griptape.rules import BaseRule, Rule, Ruleset
     from griptape.tasks import BaseTask
 
 
 @define
-class Structure(ABC):
+class Structure(ABC, RuleMixin):
     id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True)
-    rulesets: list[Ruleset] = field(factory=list, kw_only=True)
-    rules: list[BaseRule] = field(factory=list, kw_only=True)
     _tasks: list[BaseTask | list[BaseTask]] = field(factory=list, kw_only=True, alias="tasks")
     conversation_memory: Optional[BaseConversationMemory] = field(
         default=Factory(lambda: ConversationMemory()),
@@ -36,22 +34,6 @@ class Structure(ABC):
     meta_memory: MetaMemory = field(default=Factory(lambda: MetaMemory()), kw_only=True)
     fail_fast: bool = field(default=True, kw_only=True)
     _execution_args: tuple = ()
-
-    @rulesets.validator  # pyright: ignore[reportAttributeAccessIssue]
-    def validate_rulesets(self, _: Attribute, rulesets: list[Ruleset]) -> None:
-        if not rulesets:
-            return
-
-        if self.rules:
-            raise ValueError("can't have both rulesets and rules specified")
-
-    @rules.validator  # pyright: ignore[reportAttributeAccessIssue]
-    def validate_rules(self, _: Attribute, rules: list[Rule]) -> None:
-        if not rules:
-            return
-
-        if self.rulesets:
-            raise ValueError("can't have both rules and rulesets specified")
 
     def __attrs_post_init__(self) -> None:
         tasks = self._tasks.copy()

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -78,7 +78,7 @@ class BaseTask(FuturesExecutorMixin, ABC):
 
     @property
     def meta_memories(self) -> list[BaseMetaEntry]:
-        if self.structure and self.structure.meta_memory:
+        if self.structure is not None and self.structure.meta_memory:
             if self.max_meta_memory_entries:
                 return self.structure.meta_memory.entries[: self.max_meta_memory_entries]
             else:
@@ -191,7 +191,7 @@ class BaseTask(FuturesExecutorMixin, ABC):
 
     @property
     def full_context(self) -> dict[str, Any]:
-        if self.structure:
+        if self.structure is not None:
             structure_context = self.structure.context(self)
 
             structure_context.update(self.context)

--- a/griptape/tasks/extraction_task.py
+++ b/griptape/tasks/extraction_task.py
@@ -18,6 +18,4 @@ class ExtractionTask(BaseTextInputTask):
     args: dict = field(kw_only=True, factory=dict)
 
     def run(self) -> ListArtifact | ErrorArtifact:
-        return self.extraction_engine.extract_artifacts(
-            ListArtifact([self.input]), rulesets=self.all_rulesets, **self.args
-        )
+        return self.extraction_engine.extract_artifacts(ListArtifact([self.input]), rulesets=self.rulesets, **self.args)

--- a/griptape/tasks/inpainting_image_generation_task.py
+++ b/griptape/tasks/inpainting_image_generation_task.py
@@ -74,7 +74,7 @@ class InpaintingImageGenerationTask(BaseImageGenerationTask):
             prompts=[prompt_artifact.to_text()],
             image=image_artifact,
             mask=mask_artifact,
-            rulesets=self.all_rulesets,
+            rulesets=self.rulesets,
             negative_rulesets=self.negative_rulesets,
         )
 

--- a/griptape/tasks/outpainting_image_generation_task.py
+++ b/griptape/tasks/outpainting_image_generation_task.py
@@ -74,7 +74,7 @@ class OutpaintingImageGenerationTask(BaseImageGenerationTask):
             prompts=[prompt_artifact.to_text()],
             image=image_artifact,
             mask=mask_artifact,
-            rulesets=self.all_rulesets,
+            rulesets=self.rulesets,
             negative_rulesets=self.negative_rulesets,
         )
 

--- a/griptape/tasks/prompt_image_generation_task.py
+++ b/griptape/tasks/prompt_image_generation_task.py
@@ -53,7 +53,7 @@ class PromptImageGenerationTask(BaseImageGenerationTask):
     def run(self) -> ImageArtifact:
         image_artifact = self.image_generation_engine.run(
             prompts=[self.input.to_text()],
-            rulesets=self.all_rulesets,
+            rulesets=self.rulesets,
             negative_rulesets=self.negative_rulesets,
         )
 

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -17,4 +17,4 @@ class TextSummaryTask(BaseTextInputTask):
     summary_engine: BaseSummaryEngine = field(default=Factory(lambda: PromptSummaryEngine()), kw_only=True)
 
     def run(self) -> TextArtifact:
-        return TextArtifact(self.summary_engine.summarize_text(self.input.to_text(), rulesets=self.all_rulesets))
+        return TextArtifact(self.summary_engine.summarize_text(self.input.to_text(), rulesets=self.rulesets))

--- a/griptape/tasks/text_to_speech_task.py
+++ b/griptape/tasks/text_to_speech_task.py
@@ -35,7 +35,7 @@ class TextToSpeechTask(BaseAudioGenerationTask):
         self._input = value
 
     def run(self) -> AudioArtifact:
-        audio_artifact = self.text_to_speech_engine.run(prompts=[self.input.to_text()], rulesets=self.all_rulesets)
+        audio_artifact = self.text_to_speech_engine.run(prompts=[self.input.to_text()], rulesets=self.rulesets)
 
         if self.output_dir or self.output_file:
             self._write_to_file(audio_artifact)

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -51,7 +51,7 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
 
     def default_system_template_generator(self, _: PromptTask) -> str:
         return J2("tasks/tool_task/system.j2").render(
-            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets),
+            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.rulesets),
             action_schema=utils.minify_json(json.dumps(self.tool.schema())),
             meta_memory=J2("memory/meta/meta_memory.j2").render(meta_memories=self.meta_memories),
             use_native_tools=self.prompt_driver.use_native_tools,

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -68,7 +68,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
     @property
     def prompt_stack(self) -> PromptStack:
         stack = PromptStack(tools=self.tools)
-        memory = self.structure.conversation_memory
+        memory = self.structure.conversation_memory if self.structure is not None else None
 
         stack.add_system_message(self.generate_system_template(self))
 
@@ -113,7 +113,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
                     stack.add_assistant_message(self.generate_assistant_subtask_template(s))
                     stack.add_user_message(self.generate_user_subtask_template(s))
 
-        if memory:
+        if memory is not None:
             # inserting at index 1 to place memory right after system prompt
             memory.add_to_prompt_stack(self.prompt_driver, stack, 1)
 
@@ -132,7 +132,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
         schema["minItems"] = 1  # The `schema` library doesn't support `minItems` so we must add it manually.
 
         return J2("tasks/toolkit_task/system.j2").render(
-            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.all_rulesets),
+            rulesets=J2("rulesets/rulesets.j2").render(rulesets=self.rulesets),
             action_names=str.join(", ", [tool.name for tool in self.tools]),
             actions_schema=utils.minify_json(json.dumps(schema)),
             meta_memory=J2("memory/meta/meta_memory.j2").render(meta_memories=self.meta_memories),

--- a/griptape/tasks/variation_image_generation_task.py
+++ b/griptape/tasks/variation_image_generation_task.py
@@ -66,7 +66,7 @@ class VariationImageGenerationTask(BaseImageGenerationTask):
         output_image_artifact = self.image_generation_engine.run(
             prompts=[prompt_artifact.to_text()],
             image=image_artifact,
-            rulesets=self.all_rulesets,
+            rulesets=self.rulesets,
             negative_rulesets=self.negative_rulesets,
         )
 

--- a/griptape/tools/prompt_summary/tool.py
+++ b/griptape/tools/prompt_summary/tool.py
@@ -52,4 +52,4 @@ class PromptSummaryTool(BaseTool, RuleMixin):
             else:
                 return ErrorArtifact("memory not found")
 
-        return self.prompt_summary_engine.summarize_artifacts(artifacts, rulesets=self.all_rulesets)
+        return self.prompt_summary_engine.summarize_artifacts(artifacts, rulesets=self.rulesets)

--- a/tests/unit/mixins/test_rule_mixin.py
+++ b/tests/unit/mixins/test_rule_mixin.py
@@ -1,5 +1,3 @@
-import pytest
-
 from griptape.mixins.rule_mixin import RuleMixin
 from griptape.rules import Rule, Ruleset
 from griptape.structures import Agent
@@ -23,8 +21,13 @@ class TestRuleMixin:
         assert mixin.rulesets == [ruleset]
 
     def test_rules_and_rulesets(self):
-        with pytest.raises(ValueError):
-            RuleMixin(rules=[Rule("foo")], rulesets=[Ruleset("bar", [Rule("baz")])])
+        mixin = RuleMixin(rules=[Rule("foo")], rulesets=[Ruleset("bar", [Rule("baz")])])
+
+        assert mixin.rules == [Rule("foo")]
+        assert mixin.rulesets[0].name == "bar"
+        assert mixin.rulesets[0].rules == [Rule("baz")]
+        assert mixin.rulesets[1].name == "Default Ruleset"
+        assert mixin.rulesets[1].rules == [Rule("foo")]
 
     def test_inherits_structure_rulesets(self):
         # Tests that a task using the mixin inherits rulesets from its structure.
@@ -35,4 +38,4 @@ class TestRuleMixin:
         task = PromptTask(rulesets=[ruleset2])
         agent.add_task(task)
 
-        assert task.all_rulesets == [ruleset1, ruleset2]
+        assert task.rulesets == [ruleset1, ruleset2]

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -29,9 +29,9 @@ class TestAgent:
         agent.add_task(PromptTask(rulesets=[Ruleset("Bar", [Rule("bar test")])]))
 
         assert isinstance(agent.task, PromptTask)
-        assert len(agent.task.all_rulesets) == 2
-        assert agent.task.all_rulesets[0].name == "Foo"
-        assert agent.task.all_rulesets[1].name == "Bar"
+        assert len(agent.task.rulesets) == 2
+        assert agent.task.rulesets[0].name == "Foo"
+        assert agent.task.rulesets[1].name == "Bar"
 
     def test_rules(self):
         agent = Agent(rules=[Rule("foo test")])
@@ -39,17 +39,22 @@ class TestAgent:
         agent.add_task(PromptTask(rules=[Rule("bar test")]))
 
         assert isinstance(agent.task, PromptTask)
-        assert len(agent.task.all_rulesets) == 2
-        assert agent.task.all_rulesets[0].name == "Default Ruleset"
-        assert agent.task.all_rulesets[1].name == "Additional Ruleset"
+        assert len(agent.task.rulesets) == 1
+        assert agent.task.rulesets[0].name == "Default Ruleset"
+        assert len(agent.task.rulesets[0].rules) == 2
+        assert agent.task.rulesets[0].rules[0].value == "foo test"
+        assert agent.task.rulesets[0].rules[1].value == "bar test"
 
     def test_rules_and_rulesets(self):
-        with pytest.raises(ValueError):
-            Agent(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        agent = Agent(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        assert len(agent.rulesets) == 2
+        assert len(agent.rules) == 1
 
         agent = Agent()
-        with pytest.raises(ValueError):
-            agent.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        agent.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        assert isinstance(agent.task, PromptTask)
+        assert len(agent.task.rulesets) == 2
+        assert len(agent.task.rules) == 1
 
     def test_with_task_memory(self):
         agent = Agent(tools=[MockTool(off_prompt=True)])

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -45,14 +45,14 @@ class TestPipeline:
         )
 
         assert isinstance(pipeline.tasks[0], PromptTask)
-        assert len(pipeline.tasks[0].all_rulesets) == 2
-        assert pipeline.tasks[0].all_rulesets[0].name == "Foo"
-        assert pipeline.tasks[0].all_rulesets[1].name == "Bar"
+        assert len(pipeline.tasks[0].rulesets) == 2
+        assert pipeline.tasks[0].rulesets[0].name == "Foo"
+        assert pipeline.tasks[0].rulesets[1].name == "Bar"
 
         assert isinstance(pipeline.tasks[1], PromptTask)
-        assert len(pipeline.tasks[1].all_rulesets) == 2
-        assert pipeline.tasks[1].all_rulesets[0].name == "Foo"
-        assert pipeline.tasks[1].all_rulesets[1].name == "Baz"
+        assert len(pipeline.tasks[1].rulesets) == 2
+        assert pipeline.tasks[1].rulesets[0].name == "Foo"
+        assert pipeline.tasks[1].rulesets[1].name == "Baz"
 
     def test_rules(self):
         pipeline = Pipeline(rules=[Rule("foo test")])
@@ -60,21 +60,24 @@ class TestPipeline:
         pipeline.add_tasks(PromptTask(rules=[Rule("bar test")]), PromptTask(rules=[Rule("baz test")]))
 
         assert isinstance(pipeline.tasks[0], PromptTask)
-        assert len(pipeline.tasks[0].all_rulesets) == 2
-        assert pipeline.tasks[0].all_rulesets[0].name == "Default Ruleset"
-        assert pipeline.tasks[0].all_rulesets[1].name == "Additional Ruleset"
+        assert len(pipeline.tasks[0].rulesets) == 1
+        assert pipeline.tasks[0].rulesets[0].name == "Default Ruleset"
+        assert len(pipeline.tasks[0].rulesets[0].rules) == 2
 
         assert isinstance(pipeline.tasks[1], PromptTask)
-        assert pipeline.tasks[1].all_rulesets[0].name == "Default Ruleset"
-        assert pipeline.tasks[1].all_rulesets[1].name == "Additional Ruleset"
+        assert pipeline.tasks[1].rulesets[0].name == "Default Ruleset"
+        assert len(pipeline.tasks[1].rulesets[0].rules) == 2
 
     def test_rules_and_rulesets(self):
-        with pytest.raises(ValueError):
-            Pipeline(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        pipeline = Pipeline(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        assert len(pipeline.rulesets) == 2
+        assert len(pipeline.rules) == 1
 
         pipeline = Pipeline()
-        with pytest.raises(ValueError):
-            pipeline.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        pipeline.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        assert isinstance(pipeline.tasks[0], PromptTask)
+        assert len(pipeline.tasks[0].rulesets) == 2
+        assert len(pipeline.tasks[0].rules) == 1
 
     def test_with_no_task_memory(self):
         pipeline = Pipeline()

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -42,14 +42,14 @@ class TestWorkflow:
         )
 
         assert isinstance(workflow.tasks[0], PromptTask)
-        assert len(workflow.tasks[0].all_rulesets) == 2
-        assert workflow.tasks[0].all_rulesets[0].name == "Foo"
-        assert workflow.tasks[0].all_rulesets[1].name == "Bar"
+        assert len(workflow.tasks[0].rulesets) == 2
+        assert workflow.tasks[0].rulesets[0].name == "Foo"
+        assert workflow.tasks[0].rulesets[1].name == "Bar"
 
         assert isinstance(workflow.tasks[1], PromptTask)
-        assert len(workflow.tasks[1].all_rulesets) == 2
-        assert workflow.tasks[1].all_rulesets[0].name == "Foo"
-        assert workflow.tasks[1].all_rulesets[1].name == "Baz"
+        assert len(workflow.tasks[1].rulesets) == 2
+        assert workflow.tasks[1].rulesets[0].name == "Foo"
+        assert workflow.tasks[1].rulesets[1].name == "Baz"
 
     def test_rules(self):
         workflow = Workflow(rules=[Rule("foo test")])
@@ -57,22 +57,25 @@ class TestWorkflow:
         workflow.add_tasks(PromptTask(rules=[Rule("bar test")]), PromptTask(rules=[Rule("baz test")]))
 
         assert isinstance(workflow.tasks[0], PromptTask)
-        assert len(workflow.tasks[0].all_rulesets) == 2
-        assert workflow.tasks[0].all_rulesets[0].name == "Default Ruleset"
-        assert workflow.tasks[0].all_rulesets[1].name == "Additional Ruleset"
+        assert len(workflow.tasks[0].rulesets) == 1
+        assert workflow.tasks[0].rulesets[0].name == "Default Ruleset"
+        assert len(workflow.tasks[0].rulesets[0].rules) == 2
 
         assert isinstance(workflow.tasks[1], PromptTask)
-        assert len(workflow.tasks[1].all_rulesets) == 2
-        assert workflow.tasks[1].all_rulesets[0].name == "Default Ruleset"
-        assert workflow.tasks[1].all_rulesets[1].name == "Additional Ruleset"
+        assert len(workflow.tasks[1].rulesets) == 1
+        assert workflow.tasks[1].rulesets[0].name == "Default Ruleset"
+        assert len(workflow.tasks[1].rulesets[0].rules) == 2
 
     def test_rules_and_rulesets(self):
-        with pytest.raises(ValueError):
-            Workflow(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        workflow = Workflow(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])])
+        assert len(workflow.rulesets) == 2
+        assert len(workflow.rules) == 1
 
         workflow = Workflow()
-        with pytest.raises(ValueError):
-            workflow.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        workflow.add_task(PromptTask(rules=[Rule("foo test")], rulesets=[Ruleset("Bar", [Rule("bar test")])]))
+        assert isinstance(workflow.tasks[0], PromptTask)
+        assert len(workflow.tasks[0].rulesets) == 2
+        assert len(workflow.tasks[0].rules) == 1
 
     def test_with_no_task_memory(self):
         workflow = Workflow()

--- a/tests/unit/tasks/test_base_text_input_task.py
+++ b/tests/unit/tasks/test_base_text_input_task.py
@@ -49,11 +49,11 @@ class TestBaseTextInputTask:
             rulesets=[Ruleset("Foo", [Rule("foo test")]), Ruleset("Bar", [Rule("bar test")])]
         )
 
-        assert len(prompt_task.all_rulesets) == 2
-        assert prompt_task.all_rulesets[0].name == "Foo"
-        assert prompt_task.all_rulesets[1].name == "Bar"
+        assert len(prompt_task.rulesets) == 2
+        assert prompt_task.rulesets[0].name == "Foo"
+        assert prompt_task.rulesets[1].name == "Bar"
 
     def test_rules(self):
         prompt_task = MockTextInputTask(rules=[Rule("foo test"), Rule("bar test")])
 
-        assert prompt_task.all_rulesets[0].name == "Default Ruleset"
+        assert prompt_task.rulesets[0].name == "Default Ruleset"

--- a/tests/utils/structure_tester.py
+++ b/tests/utils/structure_tester.py
@@ -248,7 +248,7 @@ class StructureTester:
         task_names = [task.__class__.__name__ for task in structure.tasks]
         prompt = structure.input_task.input.to_text()
         actual = structure.output.to_text()
-        rules = [rule.value for ruleset in structure.input_task.all_rulesets for rule in ruleset.rules]
+        rules = [rule.value for ruleset in structure.input_task.rulesets for rule in ruleset.rules]
 
         agent = Agent(
             rulesets=[


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
This PR was originally to solve https://github.com/griptape-ai/griptape/issues/1155 but it revealed an odd quirk of `RuleMixin`. `RuleMixin.structure` was added so that framework components that implement this mixin could inherit rules/rulesets from a Structure. In practice this is only really relevant in Tasks that want to inherit from their Structure. But Tasks already have a `structure` field which lead to some weirdness duplicate fields. 

This PR removes `RuleMixin.structure` and moves the inheritance logic to PromptTask. Additionally, inherited `rules` will be merged into the Structure's "Default Ruleset" instead of having a weird "Additional Ruleset". It also removes the restriction on passing both `rules` and `rulesets`. If you pass `rules`, they will just be added to a `Default Ruleset`.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1155
Unblocks https://github.com/griptape-ai/griptape/issues/1154