### PR TITLE
Add alias to `GriptapeCloudConversationMemoryDriver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseRulesetDriver` for loading a `Ruleset` from an external source.
   - `LocalRulesetDriver` for loading a `Ruleset` from a local `.json` file.
   - `GriptapeCloudRulesetDriver` for loading a `Ruleset` resource from Griptape Cloud.
+- Parameter `alias` on `GriptapeCloudConversationMemoryDriver` for fetching a Thread by alias.
 
 ### Changed
 - **BREAKING**: Renamed parameters on several classes to `client`:

--- a/docs/griptape-cloud/index.md
+++ b/docs/griptape-cloud/index.md
@@ -8,5 +8,8 @@ Connect to your data with our [Data Sources](data-sources/create-data-source.md)
 ## Host and Run Your Code
 Have Griptape code? Have existing code with another LLM framework? You can host your Python code using [Structures](structures/create-structure.md) whether it uses the Griptape Framework or not.
 
+## Store Configuration for LLM Agents
+[Rules and Rulesets](rules/rulesets.md) enable rapid and collabortive iteration for managing LLM behavior. [Threads and Messages](threads/threads.md) allow for persisted and editable conversation memory across any LLM invocation.
+
 ## APIs
 All of our features can be called via API with a [Griptape Cloud API Key](https://cloud.griptape.ai/configuration/api-keys). See the [API Reference](api/api-reference.md) for detailed information.

--- a/docs/griptape-cloud/rules/rulesets.md
+++ b/docs/griptape-cloud/rules/rulesets.md
@@ -5,5 +5,5 @@ A [Ruleset can be created](https://cloud.griptape.ai/rulesets/create) to store s
 ```bash
 export GT_CLOUD_API_KEY=<your API key here>
 export ALIAS=<your ruleset alias>
-curl -H "Authorization: Bearer ${GT_CLOUD_API_KEY}" https://cloud.griptape.ai/rulesets?alias=${ALIAS}
+curl -H "Authorization: Bearer ${GT_CLOUD_API_KEY}" https://cloud.griptape.ai/api/rulesets?alias=${ALIAS}
 ```

--- a/docs/griptape-cloud/threads/threads.md
+++ b/docs/griptape-cloud/threads/threads.md
@@ -7,5 +7,5 @@ A Thread can be given an `alias` so it can be referenced by a user-provided uniq
 ```bash
 export GT_CLOUD_API_KEY=<your API key here>
 export ALIAS=<your thread alias>
-curl -H "Authorization: Bearer ${GT_CLOUD_API_KEY}" https://cloud.griptape.ai/threads?alias=${ALIAS}
+curl -H "Authorization: Bearer ${GT_CLOUD_API_KEY}" https://cloud.griptape.ai/api/threads?alias=${ALIAS}
 ```

--- a/docs/griptape-cloud/threads/threads.md
+++ b/docs/griptape-cloud/threads/threads.md
@@ -1,0 +1,11 @@
+# Threads
+
+A [Thread can be created](https://cloud.griptape.ai/threads/create) to store conversation history across any LLM invocation. A Thread contains a list of [Messages](https://cloud.griptape.ai/messages/create). Messages can be updated and deleted, in order to control how the LLM recalls past conversations.
+
+A Thread can be given an `alias` so it can be referenced by a user-provided unique identifier:
+
+```bash
+export GT_CLOUD_API_KEY=<your API key here>
+export ALIAS=<your thread alias>
+curl -H "Authorization: Bearer ${GT_CLOUD_API_KEY}" https://cloud.griptape.ai/threads?alias=${ALIAS}
+```

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_griptape_cloud.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_griptape_cloud.py
@@ -1,13 +1,12 @@
 import os
-import uuid
 
 from griptape.drivers import GriptapeCloudConversationMemoryDriver
 from griptape.memory.structure import ConversationMemory
 from griptape.structures import Agent
 
-conversation_id = uuid.uuid4().hex
 cloud_conversation_driver = GriptapeCloudConversationMemoryDriver(
     api_key=os.environ["GT_CLOUD_API_KEY"],
+    alias="my_thread_alias",
 )
 agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=cloud_conversation_driver))
 

--- a/griptape/drivers/memory/conversation/griptape_cloud_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/griptape_cloud_conversation_memory_driver.py
@@ -22,8 +22,8 @@ class GriptapeCloudConversationMemoryDriver(BaseConversationMemoryDriver):
 
     Attributes:
         thread_id: The ID of the Thread to store the conversation memory in. If not provided, the driver will attempt to
-            retrieve the ID from the environment variable `GT_CLOUD_THREAD_ID`. If that is not set, a new Thread will be
-            created.
+            retrieve the ID from the environment variable `GT_CLOUD_THREAD_ID`.
+        alias: The alias of the Thread to store the conversation memory in.
         base_url: The base URL of the Griptape Cloud API. Defaults to the value of the environment variable
             `GT_CLOUD_BASE_URL` or `https://cloud.griptape.ai`.
         api_key: The API key to use for authenticating with the Griptape Cloud API. If not provided, the driver will
@@ -33,7 +33,11 @@ class GriptapeCloudConversationMemoryDriver(BaseConversationMemoryDriver):
         ValueError: If `api_key` is not provided.
     """
 
-    thread_id: str = field(
+    thread_id: Optional[str] = field(
+        default=None,
+        metadata={"serializable": True},
+    )
+    alias: Optional[str] = field(
         default=None,
         metadata={"serializable": True},
     )
@@ -46,15 +50,39 @@ class GriptapeCloudConversationMemoryDriver(BaseConversationMemoryDriver):
         init=False,
     )
 
-    def __attrs_post_init__(self) -> None:
-        if self.thread_id is None:
-            self.thread_id = os.getenv("GT_CLOUD_THREAD_ID", self._get_thread_id())
-
     @api_key.validator  # pyright: ignore[reportAttributeAccessIssue]
     def validate_api_key(self, _: Attribute, value: Optional[str]) -> str:
         if value is None:
             raise ValueError(f"{self.__class__.__name__} requires an API key")
         return value
+
+    @property
+    def thread(self) -> dict:
+        """Try to get the Thread by ID, alias, or create a new one."""
+        thread = None
+        if self.thread_id is None:
+            self.thread_id = os.getenv("GT_CLOUD_THREAD_ID")
+
+        if self.thread_id is not None:
+            res = self._call_api("get", f"/threads/{self.thread_id}", raise_for_status=False)
+            if res.status_code == 200:
+                thread = res.json()
+
+        # use name as 'alias' to get thread
+        if thread is None and self.alias is not None:
+            res = self._call_api("get", f"/threads?alias={self.alias}").json()
+            if res.get("threads"):
+                thread = res["threads"][0]
+                self.thread_id = thread.get("thread_id")
+
+        # no thread by name or thread_id
+        if thread is None:
+            data = {"name": uuid.uuid4().hex} if self.alias is None else {"name": self.alias, "alias": self.alias}
+            thread = self._call_api("post", "/threads", data).json()
+            self.thread_id = thread["thread_id"]
+            self.alias = thread.get("alias")
+
+        return thread
 
     def store(self, runs: list[Run], metadata: dict[str, Any]) -> None:
         # serialize the run artifacts to json strings
@@ -79,25 +107,19 @@ class GriptapeCloudConversationMemoryDriver(BaseConversationMemoryDriver):
 
         # patch the Thread with the new messages and metadata
         # all old Messages are replaced with the new ones
-        response = requests.patch(
-            self._get_url(f"/threads/{self.thread_id}"),
-            json=body,
-            headers=self.headers,
-        )
-        response.raise_for_status()
+        thread_id = self.thread["thread_id"] if self.thread_id is None else self.thread_id
+        self._call_api("patch", f"/threads/{thread_id}", body)
 
     def load(self) -> tuple[list[Run], dict[str, Any]]:
         from griptape.memory.structure import Run
 
+        thread_id = self.thread["thread_id"] if self.thread_id is None else self.thread_id
+
         # get the Messages from the Thread
-        messages_response = requests.get(self._get_url(f"/threads/{self.thread_id}/messages"), headers=self.headers)
-        messages_response.raise_for_status()
-        messages_response = messages_response.json()
+        messages_response = self._call_api("get", f"/threads/{thread_id}/messages").json()
 
         # retrieve the Thread to get the metadata
-        thread_response = requests.get(self._get_url(f"/threads/{self.thread_id}"), headers=self.headers)
-        thread_response.raise_for_status()
-        thread_response = thread_response.json()
+        thread_response = self._call_api("get", f"/threads/{thread_id}").json()
 
         runs = [
             Run(
@@ -110,11 +132,14 @@ class GriptapeCloudConversationMemoryDriver(BaseConversationMemoryDriver):
         ]
         return runs, thread_response.get("metadata", {})
 
-    def _get_thread_id(self) -> str:
-        res = requests.post(self._get_url("/threads"), json={"name": uuid.uuid4().hex}, headers=self.headers)
-        res.raise_for_status()
-        return res.json().get("thread_id")
-
     def _get_url(self, path: str) -> str:
         path = path.lstrip("/")
         return urljoin(self.base_url, f"/api/{path}")
+
+    def _call_api(
+        self, method: str, path: str, json: Optional[dict] = None, *, raise_for_status: bool = True
+    ) -> requests.Response:
+        res = requests.request(method, self._get_url(path), json=json, headers=self.headers)
+        if raise_for_status:
+            res.raise_for_status()
+        return res


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
adding parameter `alias` to `GriptapeCloudConversationMemoryDriver` so a thread can be fetched by the provided alias

## Issue ticket number and link


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1237.org.readthedocs.build//1237/

<!-- readthedocs-preview griptape end -->