### PR TITLE
Various RestApiTool improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Updated `EventListener.handler` return value behavior.
   - If `EventListener.handler` returns `None`, the event will not be published to the `event_listener_driver`.
   - If `EventListener.handler` is None, the event will be published to the `event_listener_driver` as-is.
+- **BREAKING**: `RestApiTool` now returns a `JsonArtifact` instead of a `TextArtifact`.
+- **BREAKING**: Removed `RestApiTool.response_body`, `RestApiTool.request_path_params_schema`.
+- **BREAKING**: Changed `RestApiTool` fields from `str` to `dict`:
+  - `RestApiTool.request_query_params_schema` (`dict`)
+  - `RestApiTool.request_body_schema` (`dict`)
 - Updated `EventListener.handler` return type to `Optional[BaseEvent | dict]`.
 - `BaseTask.parent_outputs` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.
 - `Workflow.context["parent_outputs"]` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.
@@ -43,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Structures not flushing events when not listening for `FinishStructureRunEvent`.
 - `EventListener.event_types` and the argument to `BaseEventListenerDriver.handler` being out of sync.
+- `RestApiTool` failing with native tool calling due to schemas being in schema description.
 
 ## \[0.33.1\] - 2024-10-11
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,6 +49,118 @@ EventListener(handler=handler_fn_return_dict, event_listener_driver=driver)
 EventListener(handler=handler_fn_return_base_event, event_listener_driver=driver)
 ```
 
+### Changed `RestApiTool` fields
+
+The following fields are no longer stringified full schemas. They are now just the properties of the schema.
+
+- `RestApiTool.request_path_params_schema` (`list`)
+- `RestApiTool.request_query_params_schema` (`dict`)
+- `RestApiTool.request_body_schema` (`dict`)
+
+#### Before
+
+```python
+posts_client = RestApiTool(
+    base_url="https://jsonplaceholder.typicode.com",
+    path="posts",
+    description="Allows for creating, updating, deleting, patching, and getting posts.",
+    request_body_schema=dumps(
+        {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/example.json",
+            "type": "object",
+            "default": {},
+            "title": "Root Schema",
+            "required": ["title", "body", "userId"],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The title Schema",
+                },
+                "body": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The body Schema",
+                },
+                "userId": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The userId Schema",
+                },
+            },
+        }
+    ),
+    request_query_params_schema=dumps(
+        {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/example.json",
+            "type": "object",
+            "default": {},
+            "title": "Root Schema",
+            "required": ["userId"],
+            "properties": {
+                "userId": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The userId Schema",
+                },
+            },
+        }
+    ),
+    response_body_schema=dumps(
+        {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$id": "http://example.com/example.json",
+            "type": "object",
+            "default": {},
+            "title": "Root Schema",
+            "required": ["id", "title", "body", "userId"],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The id Schema",
+                },
+                "title": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The title Schema",
+                },
+                "body": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The body Schema",
+                },
+                "userId": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The userId Schema",
+                },
+            },
+        }
+    ),
+)
+```
+
+#### After
+
+```python
+posts_client = RestApiTool(
+    base_url="https://jsonplaceholder.typicode.com",
+    path="posts",
+    description="Allows for creating, updating, deleting, patching, and getting posts.",
+    request_body_schema={
+        "title": str,
+        "body": str,
+        "userId": int,
+    },
+    request_query_params_schema={
+        "userId": str,
+    },
+)
+```
+
 ## 0.32.X to 0.33.X
 
 ### Removed `DataframeLoader`

--- a/docs/griptape-framework/misc/events.md
+++ b/docs/griptape-framework/misc/events.md
@@ -156,6 +156,7 @@ Assistant:
 ## `EventListenerDriver.handler` Return Value Behavior
 
 The value that gets returned from the [`EventListener.handler`](../../reference/griptape/events/event_listener.md#griptape.events.event_listener.EventListener.handler) will determine what gets sent to the `event_listener_driver`.
+
 ### `EventListener.handler` is None
 
 By default, the `EventListener.handler` function is `None`. Any events that the `EventListener` is listening for will get sent to the `event_listener_driver` as-is.

--- a/docs/griptape-tools/official-tools/src/rest_api_tool_1.py
+++ b/docs/griptape-tools/official-tools/src/rest_api_tool_1.py
@@ -1,5 +1,3 @@
-from json import dumps
-
 from griptape.configs import Defaults
 from griptape.configs.drivers import DriversConfig
 from griptape.drivers import OpenAiChatPromptDriver
@@ -15,100 +13,45 @@ Defaults.drivers_config = DriversConfig(
 posts_client = RestApiTool(
     base_url="https://jsonplaceholder.typicode.com",
     path="posts",
-    description="Allows for creating, updating, deleting, patching, and getting posts.",
-    request_body_schema=dumps(
-        {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://example.com/example.json",
-            "type": "object",
-            "default": {},
-            "title": "Root Schema",
-            "required": ["title", "body", "userId"],
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The title Schema",
-                },
-                "body": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The body Schema",
-                },
-                "userId": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The userId Schema",
-                },
+    description="Allows for creating, updating, deleting, patching, and getting posts. Can also be used to access subresources.",
+    extra_schema_properties={
+        "put": {
+            RestApiTool.BODY_KEY: {
+                "title": str,
+                "body": str,
+                "userId": int,
+            }
+        },
+        "post": {
+            RestApiTool.BODY_KEY: {
+                "title": str,
+                "body": str,
+                "userId": int,
+            }
+        },
+        "patch": {
+            RestApiTool.BODY_KEY: {
+                "title": str,
             },
-        }
-    ),
-    request_query_params_schema=dumps(
-        {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://example.com/example.json",
-            "type": "object",
-            "default": {},
-            "title": "Root Schema",
-            "required": ["userId"],
-            "properties": {
-                "userId": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The userId Schema",
-                },
-            },
-        }
-    ),
-    request_path_params_schema=dumps(
-        {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://example.com/example.json",
-            "type": "array",
-            "default": [],
-            "title": "Root Schema",
-            "items": {
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "title": "Post id",
-                    },
-                ]
-            },
-        }
-    ),
-    response_body_schema=dumps(
-        {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": "http://example.com/example.json",
-            "type": "object",
-            "default": {},
-            "title": "Root Schema",
-            "required": ["id", "title", "body", "userId"],
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The id Schema",
-                },
-                "title": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The title Schema",
-                },
-                "body": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The body Schema",
-                },
-                "userId": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The userId Schema",
-                },
-            },
-        }
-    ),
+            RestApiTool.PATH_PARAMS_KEY: [str],
+        },
+        "delete": {RestApiTool.PATH_PARAMS_KEY: [str]},
+        "get": {RestApiTool.PATH_PARAMS_KEY: [str]},
+    },
+)
+
+comments_client = RestApiTool(
+    base_url="https://jsonplaceholder.typicode.com",
+    path="comments",
+    description="Allows for getting comments for a post.",
+    allowlist=["get"],
+    extra_schema_properties={
+        "get": {
+            RestApiTool.QUERY_PARAMS_KEY: {
+                "postId": str,
+            }
+        },
+    },
 )
 
 pipeline = Pipeline(
@@ -139,6 +82,10 @@ pipeline.add_tasks(
     ToolkitTask(
         "Output the body of all the comments for post 1.",
         tools=[posts_client],
+    ),
+    ToolkitTask(
+        "Get the comments for post 1.",
+        tools=[comments_client],
     ),
 )
 

--- a/griptape/tools/rest_api/tool.py
+++ b/griptape/tools/rest_api/tool.py
@@ -4,11 +4,10 @@ from textwrap import dedent
 from typing import Optional
 from urllib.parse import urljoin
 
-import schema
 from attrs import define, field
-from schema import Literal, Schema
+from schema import Schema
 
-from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact
+from griptape.artifacts import BaseArtifact, ErrorArtifact, JsonArtifact
 from griptape.tools import BaseTool
 from griptape.utils.decorators import activity
 
@@ -24,190 +23,110 @@ class RestApiTool(BaseTool):
         request_body_schema: A JSON schema string describing the request body. Recommended for PUT, POST, and PATCH requests.
         request_query_params_schema: A JSON schema string describing the available query parameters.
         request_path_params_schema: A JSON schema string describing the available path parameters. The schema must describe an array of string values.
-        response_body_schema: A JSON schema string describing the response body.
         request_headers: Headers to include in the requests.
     """
+
+    QUERY_PARAMS_KEY = "query_params"
+    PATH_PARAMS_KEY = "path_params"
+    BODY_KEY = "body"
 
     base_url: str = field(kw_only=True)
     path: Optional[str] = field(default=None, kw_only=True)
     description: str = field(kw_only=True)
-    request_path_params_schema: Optional[str] = field(default=None, kw_only=True)
-    request_query_params_schema: Optional[str] = field(default=None, kw_only=True)
-    request_body_schema: Optional[str] = field(default=None, kw_only=True)
-    response_body_schema: Optional[str] = field(default=None, kw_only=True)
+    timeout: int = field(default=30, kw_only=True)
+    request_query_params_schema: Optional[dict] = field(default=None, kw_only=True)
+    request_body_schema: Optional[dict] = field(default=None, kw_only=True)
     request_headers: Optional[dict[str, str]] = field(default=None, kw_only=True)
 
-    @property
-    def full_url(self) -> str:
-        return self._build_url(self.base_url, path=self.path)
-
     @activity(
-        config={
-            "description": dedent(
-                """
-                This tool can be used to make a put request to the rest api url: {{ _self.full_url }}
-                This rest api has the following description: {{ _self.description }}
-                {% if _self.request_body_schema %}The request body must follow this JSON schema: {{ _self.request_body_schema }}{% endif %}
-                {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
-                """,
-            ),
-            "schema": Schema({Literal("body", description="The request body."): dict}),
-        },
+        config={"description": "{{ _self._build_description('put') }}", "schema": Schema({})},
     )
     def put(self, params: dict) -> BaseArtifact:
         from requests import exceptions, put
 
         values = params["values"]
-        base_url = self.base_url
-        path = self.path
-        body = values["body"]
-        url = self._build_url(base_url, path=path)
+        args = self._build_args(values)
+        url = self._build_url(self.base_url, path=self.path)
 
         try:
-            response = put(url, json=body, timeout=30, headers=self.request_headers)
+            response = put(url, **args, timeout=self.timeout, headers=self.request_headers)
 
-            return TextArtifact(response.text)
+            return JsonArtifact(response.json(), meta={"status_code": response.status_code})
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
 
     @activity(
         config={
-            "description": dedent(
-                """
-                This tool can be used to make a patch request to the rest api url: {{ _self.full_url }}
-                This rest api has the following description: {{ _self.description }}
-                {% if _self.request_path_parameters %}The request path parameters must follow this JSON schema: {{ _self.request_path_params_schema }}{% endif %}
-                {% if _self.request_body_schema %}The request body must follow this JSON schema: {{ _self.request_body_schema }}{% endif %}
-                {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
-                """,
-            ),
-            "schema": Schema(
-                {
-                    Literal("path_params", description="The request path parameters."): Schema([str]),
-                    Literal("body", description="The request body."): dict,
-                },
-            ),
+            "description": "{{ _self._build_description('patch') }}",
+            "schema": Schema({}),
         },
     )
     def patch(self, params: dict) -> BaseArtifact:
         from requests import exceptions, patch
 
         values = params["values"]
-        base_url = self.base_url
-        path = self.path
-        body = values["body"]
-        path_params = values["path_params"]
-        url = self._build_url(base_url, path=path, path_params=path_params)
+        path_params = values.get("path_params", [])
+        args = self._build_args(values)
+        url = self._build_url(self.base_url, path=self.path, path_params=path_params)
 
         try:
-            response = patch(url, json=body, timeout=30, headers=self.request_headers)
-            return TextArtifact(response.text)
+            response = patch(url, **args, timeout=self.timeout, headers=self.request_headers)
+            return JsonArtifact(response.json(), meta={"status_code": response.status_code})
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
 
     @activity(
-        config={
-            "description": dedent(
-                """
-                This tool can be used to make a post request to the rest api url: {{ _self.full_url }}
-                This rest api has the following description: {{ _self.description }}
-                {% if _self.request_body_schema %}The request body must follow this JSON schema: {{ _self.request_body_schema }}{% endif %}
-                {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
-                """,
-            ),
-            "schema": Schema({Literal("body", description="The request body."): dict}),
-        },
+        config={"description": "{{ _self._build_description('post') }}", "schema": Schema({})},
     )
     def post(self, params: dict) -> BaseArtifact:
         from requests import exceptions, post
 
         values = params["values"]
-        base_url = self.base_url
-        path = self.path
-        url = self._build_url(base_url, path=path)
-        body = values["body"]
+        args = self._build_args(values)
+        url = self._build_url(self.base_url, path=self.path)
 
         try:
-            response = post(url, json=body, timeout=30, headers=self.request_headers)
-            return TextArtifact(response.text)
+            response = post(url, **args, timeout=self.timeout, headers=self.request_headers)
+            return JsonArtifact(response.json(), meta={"status_code": response.status_code})
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
 
     @activity(
         config={
-            "description": dedent(
-                """
-                This tool can be used to make a get request to the rest api url: {{ _self.full_url }}
-                This rest api has the following description: {{ _self.description }}
-                {% if _self.request_path_parameters %}The request path parameters must follow this JSON schema: {{ _self.request_path_params_schema }}{% endif %}
-                {% if _self.request_query_parameters %}The request query parameters must follow this JSON schema: {{ _self.request_path_params_schema }}{% endif %}
-                {% if _self.response_body_schema %}The response body must follow this JSON schema: {{ _self.response_body_schema }}{% endif %}
-                """,
-            ),
-            "schema": schema.Optional(
-                Schema(
-                    {
-                        schema.Optional(Literal("query_params", description="The request query parameters.")): dict,
-                        schema.Optional(Literal("path_params", description="The request path parameters.")): Schema(
-                            [str]
-                        ),
-                    },
-                ),
-            ),
+            "description": "{{ _self._build_description('get') }}",
+            "schema": Schema({}),
         },
     )
     def get(self, params: dict) -> BaseArtifact:
         from requests import exceptions, get
 
         values = params["values"]
-        base_url = self.base_url
-        path = self.path
 
-        query_params = {}
-        path_params = []
-        if values:
-            query_params = values.get("query_params", {})
-            path_params = values.get("path_params", [])
-        url = self._build_url(base_url, path=path, path_params=path_params)
+        path_params = values.get("path_params", [])
+        args = self._build_args(values)
+        url = self._build_url(self.base_url, path=self.path, path_params=path_params)
 
         try:
-            response = get(url, params=query_params, timeout=30, headers=self.request_headers)
-            return TextArtifact(response.text)
+            response = get(url, **args, timeout=self.timeout, headers=self.request_headers)
+            return JsonArtifact(response.json(), meta={"status_code": response.status_code})
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
 
     @activity(
-        config={
-            "description": dedent(
-                """
-                This tool can be used to make a delete request to the rest api url: {{ _self.full_url }}
-                This rest api has the following description: {{ _self.description }}
-                {% if _self.request_path_parameters %}The request path parameters must follow this JSON schema: {{ _self.request_path_params_schema }}{% endif %}
-                {% if _self.request_query_parameters %}The request query parameters must follow this JSON schema: {{ _self.request_path_params_schema }}{% endif %}
-                """,
-            ),
-            "schema": Schema(
-                {
-                    schema.Optional(Literal("query_params", description="The request query parameters.")): dict,
-                    schema.Optional(Literal("path_params", description="The request path parameters.")): Schema([str]),
-                },
-            ),
-        },
+        config={"description": "{{ _self._build_description('delete') }}", "schema": Schema({})},
     )
     def delete(self, params: dict) -> BaseArtifact:
         from requests import delete, exceptions
 
         values = params["values"]
-        base_url = self.base_url
-        path = self.path
 
-        query_params = values.get("query_params", {})
         path_params = values.get("path_params", [])
-        url = self._build_url(base_url, path=path, path_params=path_params)
+        args = self._build_args(values)
+        url = self._build_url(self.base_url, path=self.path, path_params=path_params)
 
         try:
-            response = delete(url, params=query_params, timeout=30, headers=self.request_headers)
-            return TextArtifact(response.text)
+            response = delete(url, **args, timeout=self.timeout, headers=self.request_headers)
+            return JsonArtifact(response.json(), meta={"status_code": response.status_code})
         except exceptions.RequestException as err:
             return ErrorArtifact(str(err))
 
@@ -221,3 +140,15 @@ class RestApiTool(BaseTool):
             url += f'/{str.join("/", map(str, path_params))}'
 
         return urljoin(base_url.strip("/"), url)
+
+    def _build_args(self, values: dict) -> dict:
+        query_params = values.get("query_params", {})
+        body = values.get("body", {})
+
+        return {"params": query_params, "json": body}
+
+    def _build_description(self, method: str) -> str:
+        full_url = self._build_url(self.base_url, path=self.path)
+        return dedent(f"""
+                This tool can be used to make a {method} request to the rest api url: { full_url }
+                This rest api has the following description: { self.description }""")

--- a/tests/unit/tools/test_rest_api_tool.py
+++ b/tests/unit/tools/test_rest_api_tool.py
@@ -1,38 +1,79 @@
 import pytest
 
-from griptape.artifacts import BaseArtifact
-
 
 class TestRestApi:
     @pytest.fixture()
-    def client(self):
+    def client(self, mocker):
         from griptape.tools import RestApiTool
+
+        mock_return_value = {"value": "foo bar"}
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = mock_return_value
+        mocker.patch("requests.put", return_value=mock_response)
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = mock_return_value
+        mocker.patch("requests.post", return_value=mock_response)
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_return_value
+        mocker.patch("requests.get", return_value=mock_response)
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = mock_return_value
+        mocker.patch("requests.delete", return_value=mock_response)
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_return_value
+        mocker.patch("requests.patch", return_value=mock_response)
 
         return RestApiTool(base_url="http://www.griptape.ai", description="Griptape website.")
 
     def test_put(self, client):
-        assert isinstance(client.post({"values": {"body": {}}}), BaseArtifact)
+        response = client.put({"values": {"body": {}}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 201
 
     def test_post(self, client):
-        assert isinstance(client.post({"values": {"body": {}}}), BaseArtifact)
+        response = client.post({"values": {"body": {}}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 201
 
     def test_get_one(self, client):
-        assert isinstance(client.get({"values": {"path_params": ["1"]}}), BaseArtifact)
+        response = client.get({"values": {"path_params": ["1"]}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 200
 
     def test_get_all(self, client):
-        assert isinstance(client.get({"values": {}}), BaseArtifact)
+        response = client.get({"values": {}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 200
 
     def test_get_filtered(self, client):
-        assert isinstance(client.get({"values": {"query_params": {"limit": 10}}}), BaseArtifact)
+        response = client.get({"values": {"query_params": {"limit": 10}}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 200
 
     def test_delete_one(self, client):
-        assert isinstance(client.delete({"values": {"path_params": ["1"]}}), BaseArtifact)
+        response = client.delete({"values": {"path_params": ["1"]}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 204
 
     def test_delete_multiple(self, client):
-        assert isinstance(client.delete({"values": {"query_params": {"ids": [1, 2]}}}), BaseArtifact)
+        response = client.delete({"values": {"query_params": {"ids": [1, 2]}}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 204
 
     def test_patch(self, client):
-        assert isinstance(client.patch({"values": {"path_params": ["1"], "body": {}}}), BaseArtifact)
+        response = client.patch({"values": {"path_params": ["1"], "body": {}}})
+        assert response.value == {"value": "foo bar"}
+        assert response.meta["status_code"] == 200
 
     def test_build_url(self, client):
         url = client._build_url("https://foo.bar")


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- **BREAKING**: `RestApiTool` now returns a `JsonArtifact` instead of a `TextArtifact`.
- **BREAKING**: Removed `RestApiTool.response_body`.
- **BREAKING**: Changed `RestApiTool` fields from `str` to `dict`/`list`:
  - `RestApiTool.request_path_params_schema` (`list`)
  - `RestApiTool.request_query_params_schema` (`dict`)
  - `RestApiTool.request_body_schema` (`dict`)
### Fixed
- `RestApiTool` failing with native tool calling due to schemas being in schema description. 
## Issue ticket number and link
[Discord conversation](https://discord.com/channels/1096466116672487547/1105169591619027055/1293149956080930818).

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1239.org.readthedocs.build//1239/

<!-- readthedocs-preview griptape end -->