### PR TITLE
Have EventListener flush batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `griptape.configs.logging.JsonFormatter` for formatting logs as JSON.
 - Request/response debug logging to all Prompt Drivers.
+- `BaseEventListener.flush_events()` to flush events from an Event Listener.
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_DefaultsConfig.logging_config` and `Defaults.drivers_config` are now lazily instantiated.
 - `BaseTask.add_parent`/`BaseTask.add_child` now only add the parent/child task to the structure if it is not already present.
 - `BaseEventListener.flush_events()` to flush events from an Event Listener.
+- `BaseEventListener` no longer requires a thread lock for batching events.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `griptape.configs.logging.JsonFormatter` for formatting logs as JSON.
 - Request/response debug logging to all Prompt Drivers.
 - `BaseEventListener.flush_events()` to flush events from an Event Listener.
+- Exponential backoff to `BaseEventListenerDriver` for retrying failed event publishing.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: `BaseEventListener.publish_event` `flush` argument. Use `BaseEventListener.flush_events()` instead.
 - `_DefaultsConfig.logging_config` and `Defaults.drivers_config` are now lazily instantiated.
 - `BaseTask.add_parent`/`BaseTask.add_child` now only add the parent/child task to the structure if it is not already present.
+- `BaseEventListener.flush_events()` to flush events from an Event Listener.
+
+### Fixed
+
+- Structures not flushing events when not listening for `FinishStructureRunEvent`.
 
 ## \[0.33.0\] - 2024-10-09
 

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -38,8 +38,9 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
             self.futures_executor.submit(self._safe_publish_event_payload, event_payload)
 
     def flush_events(self) -> None:
-        self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
-        self._batch = []
+        if self.batch:
+            self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
+            self._batch = []
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -19,7 +18,6 @@ logger = logging.getLogger(__name__)
 class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
     batched: bool = field(default=True, kw_only=True)
     batch_size: int = field(default=10, kw_only=True)
-    thread_lock: threading.Lock = field(default=Factory(lambda: threading.Lock()))
 
     _batch: list[dict] = field(default=Factory(list), kw_only=True)
 
@@ -28,12 +26,21 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
         return self._batch
 
     def publish_event(self, event: BaseEvent | dict) -> None:
-        self.futures_executor.submit(self._safe_try_publish_event, event)
+        event_payload = event if isinstance(event, dict) else event.to_dict()
+
+        try:
+            if self.batched:
+                self._batch.append(event_payload)
+                if len(self.batch) >= self.batch_size:
+                    self._flush_events()
+            else:
+                self.futures_executor.submit(self.try_publish_event_payload, event_payload)
+        except Exception as e:
+            logger.error(e)
 
     def flush_events(self) -> None:
         if self.batch:
-            with self.thread_lock:
-                self._flush_events()
+            self._flush_events()
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...
@@ -41,21 +48,6 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
     @abstractmethod
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None: ...
 
-    def _safe_try_publish_event(self, event: BaseEvent | dict) -> None:
-        try:
-            event_payload = event if isinstance(event, dict) else event.to_dict()
-
-            if self.batched:
-                with self.thread_lock:
-                    self._batch.append(event_payload)
-                    if len(self.batch) >= self.batch_size:
-                        self._flush_events()
-                return
-            else:
-                self.try_publish_event_payload(event_payload)
-        except Exception as e:
-            logger.error(e)
-
     def _flush_events(self) -> None:
-        self.try_publish_event_payload_batch(self.batch)
+        self.futures_executor.submit(self.try_publish_event_payload_batch, self.batch)
         self._batch = []

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
+from griptape.mixins.exponential_backoff_mixin import ExponentialBackoffMixin
 from griptape.mixins.futures_executor_mixin import FuturesExecutorMixin
 
 if TYPE_CHECKING:
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @define
-class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
+class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC):
     batched: bool = field(default=True, kw_only=True)
     batch_size: int = field(default=10, kw_only=True)
 
@@ -28,19 +29,18 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
     def publish_event(self, event: BaseEvent | dict) -> None:
         event_payload = event if isinstance(event, dict) else event.to_dict()
 
-        try:
-            if self.batched:
-                self._batch.append(event_payload)
-                if len(self.batch) >= self.batch_size:
-                    self._flush_events()
-            else:
-                self.futures_executor.submit(self.try_publish_event_payload, event_payload)
-        except Exception as e:
-            logger.error(e)
+        if self.batched:
+            self._batch.append(event_payload)
+            if len(self.batch) >= self.batch_size:
+                self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
+                self._batch = []
+        else:
+            self.futures_executor.submit(self._safe_publish_event_payload, event_payload)
 
     def flush_events(self) -> None:
         if self.batch:
-            self._flush_events()
+            self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
+            self._batch = []
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...
@@ -48,6 +48,16 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ABC):
     @abstractmethod
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None: ...
 
-    def _flush_events(self) -> None:
-        self.futures_executor.submit(self.try_publish_event_payload_batch, self.batch)
-        self._batch = []
+    def _safe_publish_event_payload(self, event_payload: dict) -> None:
+        for attempt in self.retrying():
+            with attempt:
+                self.try_publish_event_payload(event_payload)
+        else:
+            logger.error("event listener driver failed after all retry attempts")
+
+    def _safe_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
+        for attempt in self.retrying():
+            with attempt:
+                self.try_publish_event_payload_batch(event_payload_batch)
+        else:
+            logger.error("event listener driver failed after all retry attempts")

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -38,9 +38,8 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
             self.futures_executor.submit(self._safe_publish_event_payload, event_payload)
 
     def flush_events(self) -> None:
-        if self.batch:
-            self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
-            self._batch = []
+        self.futures_executor.submit(self._safe_publish_event_payload_batch, self.batch)
+        self._batch = []
 
     @abstractmethod
     def try_publish_event_payload(self, event_payload: dict) -> None: ...

--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -42,7 +42,7 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
                 "structure_run_id must be set either in the constructor or as an environment variable (GT_CLOUD_STRUCTURE_RUN_ID).",
             )
 
-    def publish_event(self, event: BaseEvent | dict, *, flush: bool = False) -> None:
+    def publish_event(self, event: BaseEvent | dict) -> None:
         from griptape.observability.observability import Observability
 
         event_payload = event.to_dict() if isinstance(event, BaseEvent) else event
@@ -51,7 +51,7 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
         if span_id is not None:
             event_payload["span_id"] = span_id
 
-        super().publish_event(event_payload, flush=flush)
+        super().publish_event(event_payload)
 
     def try_publish_event_payload(self, event_payload: dict) -> None:
         self._post_event(self._get_event_request(event_payload))

--- a/griptape/events/event_listener.py
+++ b/griptape/events/event_listener.py
@@ -39,6 +39,9 @@ class EventListener:
             event_payload = self.handler(event)
             if self.driver is not None:
                 if event_payload is not None and isinstance(event_payload, dict):
-                    self.driver.publish_event(event_payload, flush=flush)
+                    self.driver.publish_event(event_payload)
                 else:
-                    self.driver.publish_event(event, flush=flush)
+                    self.driver.publish_event(event)
+
+        if self.driver is not None and flush:
+            self.driver.flush_events()

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -9,7 +9,6 @@ class TestBaseEventListenerDriver:
         executor = MagicMock()
         executor.__enter__.return_value = executor
         driver = MockEventListenerDriver(batched=False, futures_executor=executor)
-        driver.try_publish_event_payload = MagicMock(side_effect=driver.try_publish_event_payload)
         mock_event_payload = MockEvent().to_dict()
 
         driver.publish_event(mock_event_payload)
@@ -20,16 +19,15 @@ class TestBaseEventListenerDriver:
         executor = MagicMock()
         executor.__enter__.return_value = executor
         driver = MockEventListenerDriver(batched=True, futures_executor=executor)
-        driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
         mock_event_payload = MockEvent().to_dict()
 
+        # Publish 9 events to fill the batch
         mock_event_payloads = [mock_event_payload for _ in range(0, 9)]
         for mock_event_payload in mock_event_payloads:
             driver.publish_event(mock_event_payload)
 
         assert len(driver._batch) == 9
         executor.submit.assert_not_called()
-        driver.try_publish_event_payload_batch.assert_not_called()
 
         # Publish the 10th event to trigger the batch publish
         driver.publish_event(mock_event_payload)

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -6,37 +6,50 @@ from tests.mocks.mock_event_listener_driver import MockEventListenerDriver
 
 class TestBaseEventListenerDriver:
     def test_publish_event_no_batched(self):
-        driver = MockEventListenerDriver(batched=False)
+        executor = MagicMock()
+        executor.__enter__.return_value = executor
+        driver = MockEventListenerDriver(batched=False, futures_executor=executor)
         driver.try_publish_event_payload = MagicMock(side_effect=driver.try_publish_event_payload)
+        mock_event_payload = MockEvent().to_dict()
 
-        driver.publish_event(MockEvent().to_dict())
+        driver.publish_event(mock_event_payload)
 
-        driver.try_publish_event_payload.assert_called_once()
+        executor.submit.assert_called_once_with(driver._safe_publish_event_payload, mock_event_payload)
 
     def test_publish_event_yes_batched(self):
-        driver = MockEventListenerDriver(batched=True)
+        executor = MagicMock()
+        executor.__enter__.return_value = executor
+        driver = MockEventListenerDriver(batched=True, futures_executor=executor)
         driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
+        mock_event_payload = MockEvent().to_dict()
 
-        for _ in range(0, 9):
-            driver.publish_event(MockEvent().to_dict())
+        mock_event_payloads = [mock_event_payload for _ in range(0, 9)]
+        for mock_event_payload in mock_event_payloads:
+            driver.publish_event(mock_event_payload)
 
         assert len(driver._batch) == 9
+        executor.submit.assert_not_called()
         driver.try_publish_event_payload_batch.assert_not_called()
 
         # Publish the 10th event to trigger the batch publish
-        driver.publish_event(MockEvent().to_dict())
+        driver.publish_event(mock_event_payload)
 
         assert len(driver._batch) == 0
-        driver.try_publish_event_payload_batch.assert_called_once()
+        executor.submit.assert_called_once_with(
+            driver._safe_publish_event_payload_batch, [*mock_event_payloads, mock_event_payload]
+        )
 
     def test_flush_events(self):
-        driver = MockEventListenerDriver(batched=True)
+        executor = MagicMock()
+        executor.__enter__.return_value = executor
+        driver = MockEventListenerDriver(batched=True, futures_executor=executor)
         driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
 
-        for _ in range(0, 3):
-            driver.publish_event(MockEvent().to_dict())
+        mock_event_payloads = [MockEvent().to_dict() for _ in range(0, 3)]
+        for mock_event_payload in mock_event_payloads:
+            driver.publish_event(mock_event_payload)
         assert len(driver.batch) == 3
 
         driver.flush_events()
-        driver.try_publish_event_payload_batch.assert_called_once()
+        executor.submit.assert_called_once_with(driver._safe_publish_event_payload_batch, mock_event_payloads)
         assert len(driver.batch) == 0

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -5,33 +5,38 @@ from tests.mocks.mock_event_listener_driver import MockEventListenerDriver
 
 
 class TestBaseEventListenerDriver:
-    def test_publish_event(self):
-        executor = MagicMock()
-        executor.__enter__.return_value = executor
-        driver = MockEventListenerDriver(futures_executor_fn=lambda: executor)
+    def test_publish_event_no_batched(self):
+        driver = MockEventListenerDriver(batched=False)
+        driver.try_publish_event_payload = MagicMock(side_effect=driver.try_publish_event_payload)
 
         driver.publish_event(MockEvent().to_dict())
 
-        executor.submit.assert_called_once()
+        driver.try_publish_event_payload.assert_called_once()
 
-    def test__safe_try_publish_event(self):
-        driver = MockEventListenerDriver(batched=False)
-
-        for _ in range(4):
-            driver._safe_try_publish_event(MockEvent().to_dict())
-        assert len(driver.batch) == 0
-
-    def test__safe_try_publish_event_batch(self):
+    def test_publish_event_yes_batched(self):
         driver = MockEventListenerDriver(batched=True)
+        driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
+
+        for _ in range(0, 9):
+            driver.publish_event(MockEvent().to_dict())
+
+        assert len(driver._batch) == 9
+        driver.try_publish_event_payload_batch.assert_not_called()
+
+        # Publish the 10th event to trigger the batch publish
+        driver.publish_event(MockEvent().to_dict())
+
+        assert len(driver._batch) == 0
+        driver.try_publish_event_payload_batch.assert_called_once()
+
+    def test_flush_events(self):
+        driver = MockEventListenerDriver(batched=True)
+        driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
 
         for _ in range(0, 3):
-            driver._safe_try_publish_event(MockEvent().to_dict())
+            driver.publish_event(MockEvent().to_dict())
         assert len(driver.batch) == 3
 
-    def test__safe_try_publish_event_batch_flush(self):
-        driver = MockEventListenerDriver(batched=True)
-
-        for _ in range(0, 3):
-            driver._safe_try_publish_event(MockEvent().to_dict())
         driver.flush_events()
+        driver.try_publish_event_payload_batch.assert_called_once()
         assert len(driver.batch) == 0

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -18,19 +18,20 @@ class TestBaseEventListenerDriver:
         driver = MockEventListenerDriver(batched=False)
 
         for _ in range(4):
-            driver._safe_try_publish_event(MockEvent().to_dict(), flush=False)
+            driver._safe_try_publish_event(MockEvent().to_dict())
         assert len(driver.batch) == 0
 
     def test__safe_try_publish_event_batch(self):
         driver = MockEventListenerDriver(batched=True)
 
         for _ in range(0, 3):
-            driver._safe_try_publish_event(MockEvent().to_dict(), flush=False)
+            driver._safe_try_publish_event(MockEvent().to_dict())
         assert len(driver.batch) == 3
 
     def test__safe_try_publish_event_batch_flush(self):
         driver = MockEventListenerDriver(batched=True)
 
         for _ in range(0, 3):
-            driver._safe_try_publish_event(MockEvent().to_dict(), flush=True)
+            driver._safe_try_publish_event(MockEvent().to_dict())
+        driver.flush_events()
         assert len(driver.batch) == 0

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -43,6 +43,9 @@ class TestBaseEventListenerDriver:
         driver = MockEventListenerDriver(batched=True, futures_executor=executor)
         driver.try_publish_event_payload_batch = MagicMock(side_effect=driver.try_publish_event_payload)
 
+        driver.flush_events()
+        driver.try_publish_event_payload_batch.assert_not_called()
+        assert driver.batch == []
         mock_event_payloads = [MockEvent().to_dict() for _ in range(0, 3)]
         for mock_event_payload in mock_event_payloads:
             driver.publish_event(mock_event_payload)

--- a/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
@@ -45,7 +45,8 @@ class TestGriptapeCloudEventListenerDriver:
 
     def test_publish_event_without_span_id(self, mock_post, driver):
         event = MockEvent()
-        driver.publish_event(event, flush=True)
+        driver.publish_event(event)
+        driver.flush_events()
 
         mock_post.assert_called_with(
             url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
@@ -59,7 +60,8 @@ class TestGriptapeCloudEventListenerDriver:
         observability_driver.get_span_id.return_value = "test"
 
         with Observability(observability_driver=observability_driver):
-            driver.publish_event(event, flush=True)
+            driver.publish_event(event)
+        driver.flush_events()
 
         mock_post.assert_called_with(
             url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",

--- a/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
@@ -1,4 +1,5 @@
 import os
+import time
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -48,6 +49,7 @@ class TestGriptapeCloudEventListenerDriver:
         driver.publish_event(event)
         driver.flush_events()
 
+        time.sleep(1)  # Happens asynchronously, so need to wait for it to finish
         mock_post.assert_called_with(
             url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
             json=[driver._get_event_request(event.to_dict())],
@@ -63,6 +65,7 @@ class TestGriptapeCloudEventListenerDriver:
             driver.publish_event(event)
         driver.flush_events()
 
+        time.sleep(1)  # Happens asynchronously, so need to wait for it to finish
         mock_post.assert_called_with(
             url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
             json=[driver._get_event_request({**event.to_dict(), "span_id": "test"})],
@@ -73,6 +76,7 @@ class TestGriptapeCloudEventListenerDriver:
         event = MockEvent()
         driver.try_publish_event_payload(event.to_dict())
 
+        time.sleep(1)  # Happens asynchronously, so need to wait for it to finish
         mock_post.assert_called_once_with(
             url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
             json=driver._get_event_request(event.to_dict()),
@@ -84,6 +88,7 @@ class TestGriptapeCloudEventListenerDriver:
             event = MockEvent()
             driver.try_publish_event_payload(event.to_dict())
 
+            time.sleep(1)  # Happens asynchronously, so need to wait for it to finish
             mock_post.assert_called_with(
                 url="https://cloud123.griptape.ai/api/structure-runs/bar baz/events",
                 json=driver._get_event_request(event.to_dict()),

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -121,7 +121,7 @@ class TestEventListener:
         event_listener = EventListener(event_handler, driver=mock_event_listener_driver, event_types=[MockEvent])
         event_listener.publish_event(mock_event)
 
-        mock_event_listener_driver.publish_event.assert_called_once_with(mock_event, flush=False)
+        mock_event_listener_driver.publish_event.assert_called_once_with(mock_event)
 
     def test_publish_transformed_event(self):
         mock_event_listener_driver = Mock()
@@ -134,7 +134,7 @@ class TestEventListener:
         event_listener = EventListener(event_handler, driver=mock_event_listener_driver, event_types=[MockEvent])
         event_listener.publish_event(mock_event)
 
-        mock_event_listener_driver.publish_event.assert_called_once_with({"event": mock_event.to_dict()}, flush=False)
+        mock_event_listener_driver.publish_event.assert_called_once_with({"event": mock_event.to_dict()})
 
     def test_context_manager(self):
         e1 = EventListener()


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `BaseEventListener.flush_events()` to flush events from an Event Listener.

### Changed

- **BREAKING**: `BaseEventListener.publish_event` `flush` argument. Use `BaseEventListener.flush_events()` instead.
- `BaseEventListener` no longer requires a thread lock for batching events.

### Fixed

- Structures not flushing events when not listening for `FinishStructureRunEvent`.

## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1244