### PR TITLE
Don't add to structure if already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `_DefaultsConfig.logging_config` and `Defaults.drivers_config` are now lazily instantiated.
+- `BaseTask.add_parent`/`BaseTask.add_child` now only add the parent/child task to the structure if it is not already present.
 
 ## \[0.33.0\] - 2024-10-09
 

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -100,7 +100,7 @@ class BaseTask(FuturesExecutorMixin, ABC):
         if self.id not in parent.child_ids:
             parent.child_ids.append(self.id)
 
-        if self.structure is not None:
+        if self.structure is not None and parent not in self.structure.tasks:
             self.structure.add_task(parent)
 
         return self
@@ -116,7 +116,7 @@ class BaseTask(FuturesExecutorMixin, ABC):
         if self.id not in child.parent_ids:
             child.parent_ids.append(self.id)
 
-        if self.structure is not None:
+        if self.structure is not None and child not in self.structure.tasks:
             self.structure.add_task(child)
 
         return self

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -118,22 +118,30 @@ class TestBaseTask:
         assert EventBus.event_listeners[0].handler.call_count == 2
 
     def test_add_parent(self, task):
-        parent = MockTask("parent foobar", id="parent_foobar")
+        agent = Agent()
+        parent = MockTask("parent foobar", id="parent_foobar", structure=agent)
 
+        result = task.add_parent(parent)
         result = task.add_parent(parent)
 
         assert parent.id in task.parent_ids
         assert task.id in parent.child_ids
         assert result == task
 
-    def test_add_child(self, task):
-        child = MockTask("child foobar", id="child_foobar")
+        assert agent.tasks == [parent]
 
+    def test_add_child(self, task):
+        agent = Agent()
+        child = MockTask("child foobar", id="child_foobar", structure=agent)
+
+        result = task.add_child(child)
         result = task.add_child(child)
 
         assert child.id in task.child_ids
         assert task.id in child.parent_ids
         assert result == task
+
+        assert agent.tasks == [child]
 
     def test_add_parent_bitshift(self, task):
         parent = MockTask("parent foobar", id="parent_foobar")


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- `BaseTask.add_parent`/`BaseTask.add_child` now only add the parent/child task to the structure if it is not already present.
## Issue ticket number and link
NA