### PR TITLE
Chat utility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseEventListener.flush_events()` to flush events from an Event Listener.
 - Exponential backoff to `BaseEventListenerDriver` for retrying failed event publishing.
 - `BaseTask.task_outputs` to get a dictionary of all task outputs. This has been added to `Workflow.context` and `Pipeline.context`.
+- `Chat.input_fn` for customizing the input to the Chat utility.
 
 ### Changed
 
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseEventListener.flush_events()` to flush events from an Event Listener.
 - `BaseEventListener` no longer requires a thread lock for batching events.
 - Updated `ToolkitTask` system prompt to retry/fix actions when using native tool calling.
+- `Chat` input now uses a slightly customized version of `Rich.prompt.Prompt` by default.
+- `Chat` output now uses `Rich.print` by default.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `ToolkitTask` system prompt to retry/fix actions when using native tool calling.
 - `Chat` input now uses a slightly customized version of `Rich.prompt.Prompt` by default.
 - `Chat` output now uses `Rich.print` by default.
+- `Chat.output_fn`'s now takes an optional kwarg parameter, `stream`.
 
 ### Fixed
 

--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
 
 @define
 class Chat:
+    """Utility for running a chat with a Structure.
+
+    Attributes:
+        structure: The Structure to run.
+        exit_keywords: Keywords that will exit the chat.
+        exiting_text: Text to display when exiting the chat.
+        processing_text: Text to display while processing the user's input.
+        intro_text: Text to display when the chat starts.
+        prompt_prefix: Prefix for the user's input.
+        response_prefix: Prefix for the assistant's response.
+        input_fn: Function to get the user's input.
+        output_fn: Function to output text. Takes a `text` argument for the text to output.
+                   Also takes a `stream` argument which will be set to True when streaming Prompt Tasks are present.
+    """
+
     class ChatPrompt(Prompt):
         prompt_suffix = ""  # We don't want rich's default prompt suffix
 

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -10,9 +10,8 @@ from griptape.utils import Chat
 
 
 class TestConversation:
-    @pytest.mark.parametrize("stream", [True, False])
-    def test_init(self, stream):
-        agent = Agent(conversation_memory=ConversationMemory(), stream=stream)
+    def test_init(self):
+        agent = Agent(conversation_memory=ConversationMemory())
 
         chat = Chat(
             agent,
@@ -37,7 +36,7 @@ class TestConversation:
         assert chat.logger_level == logging.INFO
 
     @patch("builtins.input", side_effect=["exit"])
-    def test_chat_logger_level(self, mock_input):
+    def test_start_chat_logger_level(self, mock_input):
         agent = Agent(conversation_memory=ConversationMemory())
 
         chat = Chat(agent)
@@ -54,3 +53,34 @@ class TestConversation:
 
     def test_chat_prompt(self):
         assert Chat.ChatPrompt.prompt_suffix == ""
+
+    @pytest.mark.parametrize("stream", [True, False])
+    @patch("builtins.input", side_effect=["foo", "exit"])
+    def test_start(self, mock_input, stream):
+        mock_output_fn = Mock()
+        agent = Agent(conversation_memory=ConversationMemory(), stream=stream)
+
+        chat = Chat(agent, intro_text="foo", output_fn=mock_output_fn)
+
+        chat.start()
+
+        mock_input.assert_has_calls([call(), call()])
+        if stream:
+            mock_output_fn.assert_has_calls(
+                [
+                    call("foo"),
+                    call("Thinking..."),
+                    call("Assistant: mock output", stream=True),
+                    call("\n", stream=True),
+                    call("Exiting..."),
+                ]
+            )
+        else:
+            mock_output_fn.assert_has_calls(
+                [
+                    call("foo"),
+                    call("Thinking..."),
+                    call("Assistant: mock output"),
+                    call("Exiting..."),
+                ]
+            )

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import patch
 
+import pytest
+
 from griptape.configs import Defaults
 from griptape.memory.structure import ConversationMemory
 from griptape.structures import Agent
@@ -8,8 +10,9 @@ from griptape.utils import Chat
 
 
 class TestConversation:
-    def test_init(self):
-        agent = Agent(conversation_memory=ConversationMemory())
+    @pytest.mark.parametrize("stream", [True, False])
+    def test_init(self, stream):
+        agent = Agent(conversation_memory=ConversationMemory(), stream=stream)
 
         chat = Chat(
             agent,
@@ -19,6 +22,7 @@ class TestConversation:
             intro_text="hello...",
             prompt_prefix="Question: ",
             response_prefix="Answer: ",
+            input_fn=input,
             output_fn=logging.info,
             logger_level=logging.INFO,
         )
@@ -28,6 +32,7 @@ class TestConversation:
         assert chat.intro_text == "hello..."
         assert chat.prompt_prefix == "Question: "
         assert chat.response_prefix == "Answer: "
+        assert callable(chat.input_fn)
         assert callable(chat.output_fn)
         assert chat.logger_level == logging.INFO
 
@@ -46,3 +51,6 @@ class TestConversation:
 
         assert logger.getEffectiveLevel() == logging.DEBUG
         assert mock_input.call_count == 1
+
+    def test_chat_prompt(self):
+        assert Chat.ChatPrompt.prompt_suffix == ""


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `Chat.input_fn` for customizing the input to the Chat utility.
### Changed
- `Chat` input now uses a slightly customized version of `Rich.prompt.Prompt` by default.
- `Chat` output now uses `Rich.print` by default.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/746