### PR TITLE
Prompt the LLM to retry/fix actions when using native tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseTask.add_parent`/`BaseTask.add_child` now only add the parent/child task to the structure if it is not already present.
 - `BaseEventListener.flush_events()` to flush events from an Event Listener.
 - `BaseEventListener` no longer requires a thread lock for batching events.
+- Updated `TookitTask` system prompt to retry/fix actions when using native tool calling.
 
 ### Fixed
 

--- a/griptape/templates/tasks/toolkit_task/system.j2
+++ b/griptape/templates/tasks/toolkit_task/system.j2
@@ -6,10 +6,11 @@ You must use the following format when executing actions:
 Thought: <your step-by-step thought process describing what actions you need to use>
 Actions: <JSON array of actions that MUST follow this schema: {{ actions_schema }}>
 {{ stop_sequence }}: <action outputs>
-...repeat Thought/Actions/{{ stop_sequence }} as many times as you need
-"Thought", "Actions", "{{ stop_sequence }}" must always start on a new line. If {{ stop_sequence }} contains an error, you MUST ALWAYS try to fix the error with another Thought/Actions/{{ stop_sequence }}.
+"Thought", "Actions", "{{ stop_sequence }}" must always start on a new line.
 
 {% endif %}
+Repeat executing actions as many times as you need.
+If an action's output contains an error, you MUST ALWAYS try to fix the error by executing another action. 
 You must use the following format when providing your final answer:
 Answer: <final answer>
 


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
I've noticed that when using native tool calling the LLM is much more likely to give up early. This may be because we don't instruct the LLM to retry/fix as many times as needed like we do for non native tool calling. This change moves around the prompt a bit to include this wording for both kinds of tool calling.
## Issue ticket number and link
NA