### PR TITLE
Add RunnableMixin, implement in Structures, Tasks, Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Events `BaseChunkEvent`, `TextChunkEvent`, `ActionChunkEvent`.
 - `wrapt` dependency for more robust decorators.
 - `BasePromptDriver.extra_params` for passing extra parameters not explicitly declared by the Driver.
+- `RunnableMixin` which adds `on_before_run` and `on_after_run` hooks.
 
 ### Changed
 
@@ -35,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: `AnthropicDriversConfig` no longer bundles `VoyageAiEmbeddingDriver`.
 - **BREAKING**: Removed `HuggingFaceHubPromptDriver.params`, use `HuggingFaceHubPromptDriver.extra_params` instead.
 - **BREAKING**: Removed `HuggingFacePipelinePromptDriver.params`, use `HuggingFacePipelinePromptDriver.extra_params` instead.
+- **BREAKING**: Renamed `BaseTask.run` to `BaseTask.try_run`.
+- **BREAKING**: Renamed `BaseTask.execute` to `BaseTask.run`.
+- **BREAKING**: Renamed `BaseTask.can_execute` to `BaseTool.can_run`.
+- **BREAKING**: Renamed `BaseTool.run` to `BaseTool.try_run`.
+- **BREAKING**: Renamed `BaseTool.execute` to `BaseTool.run`.
 - Updated `EventListener.handler` return type to `Optional[BaseEvent | dict]`.
 - `BaseTask.parent_outputs` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.
 - `Workflow.context["parent_outputs"]` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.
@@ -54,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Models in `ToolkitTask` with native tool calling no longer need to provide their final answer as `Answer:`.
 - `EventListener.event_types` will now listen on child types of any provided type.
 - Only install Tool dependencies if the Tool provides a `requirements.txt` and the dependencies are not already met.
+- Implemented `RunnableMixin` in `Structure`, `BaseTask`, and `BaseTool`.
 
 ### Fixed
 

--- a/docs/griptape-framework/structures/src/task_hooks.py
+++ b/docs/griptape-framework/structures/src/task_hooks.py
@@ -1,0 +1,38 @@
+import json
+import re
+
+from griptape.structures import Agent
+from griptape.tasks import PromptTask
+from griptape.tasks.base_task import BaseTask
+
+SSN_PATTERN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+original_input = None
+
+
+def on_before_run(task: BaseTask) -> None:
+    global original_input
+
+    original_input = task.input.value
+
+    if isinstance(task, PromptTask):
+        task.input = SSN_PATTERN.sub("xxx-xx-xxxx", task.input.value)
+
+
+def on_after_run(task: BaseTask) -> None:
+    if task.output is not None:
+        task.output.value = json.dumps(
+            {"original_input": original_input, "masked_input": task.input.value, "output": task.output.value}, indent=2
+        )
+
+
+agent = Agent(
+    tasks=[
+        PromptTask(
+            "Respond to this user: {{ args[0] }}",
+            on_before_run=on_before_run,
+            on_after_run=on_after_run,
+        )
+    ]
+)
+agent.run("Hello! My favorite color is blue, and my social security number is 123-45-6789.")

--- a/docs/griptape-framework/structures/tasks.md
+++ b/docs/griptape-framework/structures/tasks.md
@@ -54,6 +54,28 @@ Additional [context](../../reference/griptape/structures/structure.md#griptape.s
                              sleeves, and let's get baking! 🍰🎉
 ```
 
+## Hooks
+
+All Tasks implement [RunnableMixin](../../reference/griptape/mixins/runnable_mixin.md) which provides `on_before_run` and `on_after_run` hooks for the Task lifecycle.
+
+These hooks can be used to perform actions before and after the Task is run. For example, you can mask sensitive information before running the Task, and transform the output after the Task is run.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/task_hooks.py"
+```
+
+```
+[10/15/24 15:14:10] INFO     PromptTask 63a0c734059c42808c87dff351adc8ab
+                             Input: Respond to this user: Hello! My favorite color is blue, and my social security number is xxx-xx-xxxx.
+[10/15/24 15:14:11] INFO     PromptTask 63a0c734059c42808c87dff351adc8ab
+                             Output: {
+                               "original_input": "Respond to this user: Hello! My favorite color is blue, and my social security number is 123-45-6789.",
+                               "masked_input": "Respond to this user: Hello! My favorite color is blue, and my social security number is xxx-xx-xxxx.",
+                               "output": "Hello! It's great to hear that your favorite color is blue. However, it's important to keep your personal information, like your
+                             social security number, private and secure. If you have any questions or need assistance, feel free to ask!"
+                             }
+```
+
 ## Prompt Task
 
 For general purpose prompting, use the [PromptTask](../../reference/griptape/tasks/prompt_task.md):

--- a/griptape/mixins/runnable_mixin.py
+++ b/griptape/mixins/runnable_mixin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
+
+from attrs import define, field
+
+# Generics magic that allows us to reference the type of the class that is implementing the mixin
+T = TypeVar("T", bound="RunnableMixin")
+
+
+@define()
+class RunnableMixin(ABC, Generic[T]):
+    """Mixin for classes that can be "run".
+
+    Implementing classes should pass themselves as the generic type to ensure that the correct type is used in the callbacks.
+
+    Attributes:
+        on_before_run: Optional callback that is called at the very beginning of the `run` method.
+        on_after_run: Optional callback that is called at the very end of the `run` method.
+    """
+
+    on_before_run: Optional[Callable[[T], None]] = field(kw_only=True, default=None)
+    on_after_run: Optional[Callable[[T], None]] = field(kw_only=True, default=None)
+
+    def before_run(self, *args, **kwargs) -> Any:
+        if self.on_before_run is not None:
+            self.on_before_run(cast(T, self))
+
+    @abstractmethod
+    def run(self, *args, **kwargs) -> Any: ...
+
+    def after_run(self, *args, **kwargs) -> Any:
+        if self.on_after_run is not None:
+            self.on_after_run(cast(T, self))

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -74,6 +74,6 @@ class Agent(Structure):
 
     @observable
     def try_run(self, *args) -> Agent:
-        self.task.execute()
+        self.task.run()
 
         return self

--- a/griptape/structures/pipeline.py
+++ b/griptape/structures/pipeline.py
@@ -72,7 +72,7 @@ class Pipeline(Structure):
         if task is None:
             return
         else:
-            if isinstance(task.execute(), ErrorArtifact) and self.fail_fast:
+            if isinstance(task.run(), ErrorArtifact) and self.fail_fast:
                 return
             else:
                 self.__run_from_task(next(iter(task.children), None))

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -12,6 +12,7 @@ from griptape.memory import TaskMemory
 from griptape.memory.meta import MetaMemory
 from griptape.memory.structure import ConversationMemory, Run
 from griptape.mixins.rule_mixin import RuleMixin
+from griptape.mixins.runnable_mixin import RunnableMixin
 from griptape.mixins.serializable_mixin import SerializableMixin
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @define
-class Structure(ABC, RuleMixin, SerializableMixin):
+class Structure(RuleMixin, SerializableMixin, RunnableMixin["Structure"], ABC):
     id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True, metadata={"serializable": True})
     _tasks: list[Union[BaseTask, list[BaseTask]]] = field(
         factory=list, kw_only=True, alias="tasks", metadata={"serializable": True}
@@ -139,6 +140,7 @@ class Structure(ABC, RuleMixin, SerializableMixin):
 
     @observable
     def before_run(self, args: Any) -> None:
+        super().before_run(args)
         self._execution_args = args
 
         [task.reset() for task in self.tasks]
@@ -155,6 +157,7 @@ class Structure(ABC, RuleMixin, SerializableMixin):
 
     @observable
     def after_run(self) -> None:
+        super().after_run()
         if self.conversation_memory and self.output_task.output is not None:
             run = Run(input=self.input_task.input, output=self.output_task.output)
 

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -107,8 +107,8 @@ class Workflow(Structure, FuturesExecutorMixin):
             ordered_tasks = self.order_tasks()
 
             for task in ordered_tasks:
-                if task.can_execute():
-                    future = self.futures_executor.submit(task.execute)
+                if task.can_run():
+                    future = self.futures_executor.submit(task.run)
                     futures_list[future] = task
 
             # Wait for all tasks to complete

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -113,14 +113,14 @@ class ActionsSubtask(BaseTask):
         ]
         logger.info("".join(parts))
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         try:
             if any(isinstance(a.output, ErrorArtifact) for a in self.actions):
                 errors = [a.output.value for a in self.actions if isinstance(a.output, ErrorArtifact)]
 
                 self.output = ErrorArtifact("\n\n".join(errors))
             else:
-                results = self.execute_actions(self.actions)
+                results = self.run_actions(self.actions)
 
                 actions_output = []
                 for result in results:
@@ -138,13 +138,13 @@ class ActionsSubtask(BaseTask):
         else:
             return ErrorArtifact("no tool output")
 
-    def execute_actions(self, actions: list[ToolAction]) -> list[tuple[str, BaseArtifact]]:
-        return utils.execute_futures_list([self.futures_executor.submit(self.execute_action, a) for a in actions])
+    def run_actions(self, actions: list[ToolAction]) -> list[tuple[str, BaseArtifact]]:
+        return utils.execute_futures_list([self.futures_executor.submit(self.run_action, a) for a in actions])
 
-    def execute_action(self, action: ToolAction) -> tuple[str, BaseArtifact]:
+    def run_action(self, action: ToolAction) -> tuple[str, BaseArtifact]:
         if action.tool is not None:
             if action.path is not None:
-                output = action.tool.execute(getattr(action.tool, action.path), self, action)
+                output = action.tool.run(getattr(action.tool, action.path), self, action)
             else:
                 output = ErrorArtifact("action path not found")
         else:

--- a/griptape/tasks/audio_transcription_task.py
+++ b/griptape/tasks/audio_transcription_task.py
@@ -18,5 +18,5 @@ class AudioTranscriptionTask(BaseAudioInputTask):
         kw_only=True,
     )
 
-    def run(self) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         return self.audio_transcription_engine.run(self.input)

--- a/griptape/tasks/code_execution_task.py
+++ b/griptape/tasks/code_execution_task.py
@@ -14,5 +14,5 @@ if TYPE_CHECKING:
 class CodeExecutionTask(BaseTextInputTask):
     run_fn: Callable[[CodeExecutionTask], BaseArtifact] = field(kw_only=True)
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         return self.run_fn(self)

--- a/griptape/tasks/extraction_task.py
+++ b/griptape/tasks/extraction_task.py
@@ -17,5 +17,5 @@ class ExtractionTask(BaseTextInputTask):
     extraction_engine: BaseExtractionEngine = field(kw_only=True)
     args: dict = field(kw_only=True, factory=dict)
 
-    def run(self) -> ListArtifact | ErrorArtifact:
+    def try_run(self) -> ListArtifact | ErrorArtifact:
         return self.extraction_engine.extract_artifacts(ListArtifact([self.input]), rulesets=self.rulesets, **self.args)

--- a/griptape/tasks/image_query_task.py
+++ b/griptape/tasks/image_query_task.py
@@ -64,7 +64,7 @@ class ImageQueryTask(BaseTask):
     ) -> None:
         self._input = value
 
-    def run(self) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         query = self.input.value[0]
 
         if all(isinstance(artifact, ImageArtifact) for artifact in self.input.value[1:]):

--- a/griptape/tasks/inpainting_image_generation_task.py
+++ b/griptape/tasks/inpainting_image_generation_task.py
@@ -59,7 +59,7 @@ class InpaintingImageGenerationTask(BaseImageGenerationTask):
     ) -> None:
         self._input = value
 
-    def run(self) -> ImageArtifact:
+    def try_run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
 
         image_artifact = self.input[1]

--- a/griptape/tasks/outpainting_image_generation_task.py
+++ b/griptape/tasks/outpainting_image_generation_task.py
@@ -59,7 +59,7 @@ class OutpaintingImageGenerationTask(BaseImageGenerationTask):
     ) -> None:
         self._input = value
 
-    def run(self) -> ImageArtifact:
+    def try_run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
 
         image_artifact = self.input[1]

--- a/griptape/tasks/prompt_image_generation_task.py
+++ b/griptape/tasks/prompt_image_generation_task.py
@@ -50,7 +50,7 @@ class PromptImageGenerationTask(BaseImageGenerationTask):
     def input(self, value: TextArtifact) -> None:
         self._input = value
 
-    def run(self) -> ImageArtifact:
+    def try_run(self) -> ImageArtifact:
         image_artifact = self.image_generation_engine.run(
             prompts=[self.input.to_text()],
             rulesets=self.rulesets,

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -94,7 +94,7 @@ class PromptTask(RuleMixin, BaseTask):
 
         logger.info("%s %s\nOutput: %s", self.__class__.__name__, self.id, self.output.to_text())
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         message = self.prompt_driver.run(self.prompt_stack)
 
         return message.to_artifact()

--- a/griptape/tasks/rag_task.py
+++ b/griptape/tasks/rag_task.py
@@ -11,7 +11,7 @@ from griptape.tasks import BaseTextInputTask
 class RagTask(BaseTextInputTask):
     rag_engine: RagEngine = field(kw_only=True, default=Factory(lambda: RagEngine()))
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         outputs = self.rag_engine.process_query(self.input.to_text()).outputs
 
         if len(outputs) > 0:

--- a/griptape/tasks/structure_run_task.py
+++ b/griptape/tasks/structure_run_task.py
@@ -22,7 +22,7 @@ class StructureRunTask(PromptTask):
 
     driver: BaseStructureRunDriver = field(kw_only=True)
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         if isinstance(self.input, ListArtifact):
             return self.driver.run(*self.input.value)
         else:

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -16,5 +16,5 @@ if TYPE_CHECKING:
 class TextSummaryTask(BaseTextInputTask):
     summary_engine: BaseSummaryEngine = field(default=Factory(lambda: PromptSummaryEngine()), kw_only=True)
 
-    def run(self) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         return TextArtifact(self.summary_engine.summarize_text(self.input.to_text(), rulesets=self.rulesets))

--- a/griptape/tasks/text_to_speech_task.py
+++ b/griptape/tasks/text_to_speech_task.py
@@ -34,7 +34,7 @@ class TextToSpeechTask(BaseAudioGenerationTask):
     def input(self, value: TextArtifact) -> None:
         self._input = value
 
-    def run(self) -> AudioArtifact:
+    def try_run(self) -> AudioArtifact:
         audio_artifact = self.text_to_speech_engine.run(prompts=[self.input.to_text()], rulesets=self.rulesets)
 
         if self.output_dir or self.output_file:

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -60,7 +60,7 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
     def actions_schema(self) -> Schema:
         return self._actions_schema_for_tools([self.tool])
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         result = self.prompt_driver.run(prompt_stack=self.prompt_stack)
 
         if self.prompt_driver.use_native_tools:

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -165,7 +165,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
                 if tool.output_memory is None and tool.off_prompt:
                     tool.output_memory = {getattr(a, "name"): [self.task_memory] for a in tool.activities()}
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         from griptape.tasks import ActionsSubtask
 
         self.subtasks.clear()

--- a/griptape/tasks/variation_image_generation_task.py
+++ b/griptape/tasks/variation_image_generation_task.py
@@ -56,7 +56,7 @@ class VariationImageGenerationTask(BaseImageGenerationTask):
     def input(self, value: tuple[str | TextArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact]) -> None:
         self._input = value
 
-    def run(self) -> ImageArtifact:
+    def try_run(self) -> ImageArtifact:
         prompt_artifact = self.input[0]
 
         image_artifact = self.input[1]

--- a/tests/mocks/mock_audio_input_task.py
+++ b/tests/mocks/mock_audio_input_task.py
@@ -6,5 +6,5 @@ from griptape.tasks.base_audio_input_task import BaseAudioInputTask
 
 @define
 class MockAudioInputTask(BaseAudioInputTask):
-    def run(self) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         return TextArtifact(self.input.to_text())

--- a/tests/mocks/mock_image_generation_task.py
+++ b/tests/mocks/mock_image_generation_task.py
@@ -1,4 +1,4 @@
-from attrs import define, field
+from attrs import Factory, define, field
 
 from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.tasks import BaseImageGenerationTask
@@ -6,7 +6,7 @@ from griptape.tasks import BaseImageGenerationTask
 
 @define
 class MockImageGenerationTask(BaseImageGenerationTask):
-    _input: TextArtifact = field(default="input")
+    _input: TextArtifact = field(default=Factory(lambda: TextArtifact("input")))
 
     @property
     def input(self) -> TextArtifact:
@@ -16,5 +16,5 @@ class MockImageGenerationTask(BaseImageGenerationTask):
     def input(self, value: str) -> None:
         self._input = TextArtifact(value)
 
-    def run(self) -> ImageArtifact:
+    def try_run(self) -> ImageArtifact:
         return ImageArtifact(value=b"image data", format="png", width=512, height=512)

--- a/tests/mocks/mock_task.py
+++ b/tests/mocks/mock_task.py
@@ -12,5 +12,5 @@ class MockTask(BaseTask):
     def input(self) -> BaseArtifact:
         return TextArtifact(self.mock_input)
 
-    def run(self) -> BaseArtifact:
+    def try_run(self) -> BaseArtifact:
         return self.input

--- a/tests/mocks/mock_text_input_task.py
+++ b/tests/mocks/mock_text_input_task.py
@@ -6,5 +6,5 @@ from griptape.tasks import BaseTextInputTask
 
 @define
 class MockTextInputTask(BaseTextInputTask):
-    def run(self) -> TextArtifact:
+    def try_run(self) -> TextArtifact:
         return TextArtifact(self.input.to_text())

--- a/tests/unit/mixins/test_runnable_mixin.py
+++ b/tests/unit/mixins/test_runnable_mixin.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+from tests.unit.tasks.test_base_task import MockTask
+
+
+class TestRunnableMixin:
+    def test_before_run(self):
+        mock_on_before_run = Mock()
+        mock_task = MockTask(on_before_run=mock_on_before_run)
+
+        mock_task.run()
+
+        assert mock_on_before_run.called
+
+    def test_after_run(self):
+        mock_on_after_run = Mock()
+        mock_task = MockTask(on_after_run=mock_on_after_run)
+
+        mock_task.run()
+
+        assert mock_on_after_run.called

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from griptape.memory import TaskMemory
@@ -296,3 +298,14 @@ class TestAgent:
 
         assert len(deserialized_agent.task_outputs) == 1
         assert deserialized_agent.task_outputs[task.id].value == "mock output"
+
+    def test_runnable_mixin(self):
+        mock_on_before_run = Mock()
+        mock_after_run = Mock()
+        agent = Agent(prompt_driver=MockPromptDriver(), on_before_run=mock_on_before_run, on_after_run=mock_after_run)
+
+        args = "test"
+        agent.run(args)
+
+        mock_on_before_run.assert_called_once_with(agent)
+        mock_after_run.assert_called_once_with(agent)

--- a/tests/unit/tasks/test_actions_subtask.py
+++ b/tests/unit/tasks/test_actions_subtask.py
@@ -220,7 +220,7 @@ class TestActionsSubtask:
         task = ToolkitTask(tools=[MockTool()])
         Agent().add_task(task)
         subtask = task.add_subtask(ActionsSubtask(valid_input))
-        subtask.execute()
+        subtask.run()
 
         assert isinstance(subtask.output, ListArtifact)
         assert isinstance(subtask.output.value[0], TextArtifact)
@@ -235,7 +235,7 @@ class TestActionsSubtask:
         task = ToolkitTask(tools=[MockTool()])
         Agent().add_task(task)
         subtask = task.add_subtask(ActionsSubtask(valid_input))
-        subtask.execute()
+        subtask.run()
 
         assert isinstance(subtask.output, ListArtifact)
         assert isinstance(subtask.output.value[0], ErrorArtifact)

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -111,8 +111,8 @@ class TestBaseTask:
 
         assert len(parent.children) == 3
 
-    def test_execute_publish_events(self, task):
-        task.execute()
+    def test_run_publish_events(self, task):
+        task.run()
 
         assert EventBus.event_listeners[0].handler.call_count == 2
 
@@ -191,3 +191,19 @@ class TestBaseTask:
         assert str(workflow.tasks[0].state) == "State.FINISHED"
         assert workflow.tasks[0].id == deserialized_task.id
         assert workflow.tasks[0].output.value == "foobar"
+
+    def test_runnable_mixin(self):
+        mock_on_before_run = Mock()
+        mock_after_run = Mock()
+        task = MockTask("foobar", on_before_run=mock_on_before_run, on_after_run=mock_after_run)
+
+        task.run()
+
+        mock_on_before_run.assert_called_once_with(task)
+        mock_after_run.assert_called_once_with(task)
+
+    def test_full_context(self, task):
+        task.structure = Agent()
+        task.structure._execution_args = ("foo", "bar")
+
+        assert task.full_context == {"args": ("foo", "bar"), "structure": task.structure}

--- a/tests/unit/tasks/test_code_execution_task.py
+++ b/tests/unit/tasks/test_code_execution_task.py
@@ -23,7 +23,7 @@ class TestCodeExecutionTask:
     def test_hello_world_fn(self):
         task = CodeExecutionTask(run_fn=hello_world)
 
-        assert task.run().value == "Hello World!"
+        assert task.try_run().value == "Hello World!"
 
     # Using a Pipeline
     # Overriding the input because we are implementing the task not the Pipeline
@@ -31,11 +31,11 @@ class TestCodeExecutionTask:
         pipeline = Pipeline()
         task = CodeExecutionTask("No Op", run_fn=non_outputting)
         pipeline.add_task(task)
-        temp = task.run()
+        temp = task.try_run()
         assert temp.value == "No Op"
 
     def test_error_fn(self):
         task = CodeExecutionTask(run_fn=deliberate_exception)
 
         with pytest.raises(ValueError):
-            task.run()
+            task.try_run()

--- a/tests/unit/tasks/test_image_query_task.py
+++ b/tests/unit/tasks/test_image_query_task.py
@@ -73,4 +73,4 @@ class TestImageQueryTask:
 
     def test_bad_run(self, image_query_engine, text_artifact, image_artifact):
         with pytest.raises(ValueError, match="All inputs"):
-            ImageQueryTask(("foo", [image_artifact, text_artifact]), image_query_engine=image_query_engine).run()
+            ImageQueryTask(("foo", [image_artifact, text_artifact]), image_query_engine=image_query_engine).try_run()

--- a/tests/unit/tasks/test_inpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_inpainting_image_generation_task.py
@@ -43,10 +43,10 @@ class TestInpaintingImageGenerationTask:
 
     def test_bad_input(self, image_artifact):
         with pytest.raises(ValueError):
-            InpaintingImageGenerationTask(("foo", "bar", image_artifact)).run()  # pyright: ignore[reportArgumentType]
+            InpaintingImageGenerationTask(("foo", "bar", image_artifact)).try_run()  # pyright: ignore[reportArgumentType]
 
         with pytest.raises(ValueError):
-            InpaintingImageGenerationTask(("foo", image_artifact, "baz")).run()  # pyright: ignore[reportArgumentType]
+            InpaintingImageGenerationTask(("foo", image_artifact, "baz")).try_run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = InpaintingImageGenerationTask((text_artifact, image_artifact, image_artifact))

--- a/tests/unit/tasks/test_outpainting_image_generation_task.py
+++ b/tests/unit/tasks/test_outpainting_image_generation_task.py
@@ -43,10 +43,10 @@ class TestOutpaintingImageGenerationTask:
 
     def test_bad_input(self, image_artifact):
         with pytest.raises(ValueError):
-            OutpaintingImageGenerationTask(("foo", "bar", image_artifact)).run()  # pyright: ignore[reportArgumentType]
+            OutpaintingImageGenerationTask(("foo", "bar", image_artifact)).try_run()  # pyright: ignore[reportArgumentType]
 
         with pytest.raises(ValueError):
-            OutpaintingImageGenerationTask(("foo", image_artifact, "baz")).run()  # pyright: ignore[reportArgumentType]
+            OutpaintingImageGenerationTask(("foo", image_artifact, "baz")).try_run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = OutpaintingImageGenerationTask((text_artifact, image_artifact, image_artifact))

--- a/tests/unit/tasks/test_variation_image_generation_task.py
+++ b/tests/unit/tasks/test_variation_image_generation_task.py
@@ -43,7 +43,7 @@ class TestVariationImageGenerationTask:
 
     def test_bad_input(self, image_artifact):
         with pytest.raises(ValueError):
-            VariationImageGenerationTask(("foo", "bar")).run()  # pyright: ignore[reportArgumentType]
+            VariationImageGenerationTask(("foo", "bar")).try_run()  # pyright: ignore[reportArgumentType]
 
     def test_config_image_generation_engine(self, text_artifact, image_artifact):
         task = VariationImageGenerationTask((text_artifact, image_artifact))


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `RunnableMixin` which adds `on_before_run` and `on_after_run` hooks.
### Changed
- **BREAKING**: Renamed `BaseTask.run` to `BaseTask.try_run`.
- **BREAKING**: Renamed `BaseTask.execute` to `BaseTask.run`.
- **BREAKING**: Renamed `BaseTask.can_execute` to `BaseTool.can_run`.
- **BREAKING**: Renamed `BaseTool.run` to `BaseTool.try_run`.
- **BREAKING**: Renamed `BaseTool.execute` to `BaseTool.run`.
- Implemented `RunnableMixin` in `Structure`, `BaseTask`, and `BaseTool`.
## Issue ticket number and link
Closes #924 
Closes #416 