### PR TITLE
Catch errors from event driver publish retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Structures not flushing events when not listening for `FinishStructureRunEvent`.
 - `EventListener.event_types` and the argument to `BaseEventListenerDriver.handler` being out of sync.
+- Methods `_safe_publish_event_payload` and `_safe_publish_event_payload_batch` on `BaseEventListenerDriver` not catching exceptions after failed retries.
 
 ## \[0.33.1\] - 2024-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Structures not flushing events when not listening for `FinishStructureRunEvent`.
 - `EventListener.event_types` and the argument to `BaseEventListenerDriver.handler` being out of sync.
-- Methods `_safe_publish_event_payload` and `_safe_publish_event_payload_batch` on `BaseEventListenerDriver` not catching exceptions after failed retries.
 
 ## \[0.33.1\] - 2024-10-11
 

--- a/docs/griptape-framework/misc/events.md
+++ b/docs/griptape-framework/misc/events.md
@@ -156,6 +156,7 @@ Assistant:
 ## `EventListenerDriver.handler` Return Value Behavior
 
 The value that gets returned from the [`EventListener.handler`](../../reference/griptape/events/event_listener.md#griptape.events.event_listener.EventListener.handler) will determine what gets sent to the `event_listener_driver`.
+
 ### `EventListener.handler` is None
 
 By default, the `EventListener.handler` function is `None`. Any events that the `EventListener` is listening for will get sent to the `event_listener_driver` as-is.

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -52,6 +52,7 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
         for attempt in self.retrying():
             with attempt:
                 self.try_publish_event_payload(event_payload)
+                return
         else:
             logger.error("event listener driver failed after all retry attempts")
 

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -60,5 +60,6 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
         for attempt in self.retrying():
             with attempt:
                 self.try_publish_event_payload_batch(event_payload_batch)
+                return
         else:
             logger.error("event listener driver failed after all retry attempts")

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -54,7 +54,7 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
                 with attempt:
                     self.try_publish_event_payload(event_payload)
         except Exception:
-            logger.exception("Failed to publish event after %s attempts", self.max_attempts)
+            logger.warning("Failed to publish event after %s attempts", self.max_attempts, exc_info=True)
 
     def _safe_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
         try:
@@ -62,4 +62,4 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
                 with attempt:
                     self.try_publish_event_payload_batch(event_payload_batch)
         except Exception:
-            logger.exception("Failed to publish event batch after %s attempts", self.max_attempts)
+            logger.warning("Failed to publish event batch after %s attempts", self.max_attempts, exc_info=True)

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -52,14 +52,8 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
         for attempt in self.retrying():
             with attempt:
                 self.try_publish_event_payload(event_payload)
-                return
-        else:
-            logger.error("event listener driver failed after all retry attempts")
 
     def _safe_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
         for attempt in self.retrying():
             with attempt:
                 self.try_publish_event_payload_batch(event_payload_batch)
-                return
-        else:
-            logger.error("event listener driver failed after all retry attempts")

--- a/griptape/drivers/event_listener/base_event_listener_driver.py
+++ b/griptape/drivers/event_listener/base_event_listener_driver.py
@@ -49,11 +49,17 @@ class BaseEventListenerDriver(FuturesExecutorMixin, ExponentialBackoffMixin, ABC
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None: ...
 
     def _safe_publish_event_payload(self, event_payload: dict) -> None:
-        for attempt in self.retrying():
-            with attempt:
-                self.try_publish_event_payload(event_payload)
+        try:
+            for attempt in self.retrying():
+                with attempt:
+                    self.try_publish_event_payload(event_payload)
+        except Exception:
+            logger.exception("Failed to publish event after %s attempts", self.max_attempts)
 
     def _safe_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
-        for attempt in self.retrying():
-            with attempt:
-                self.try_publish_event_payload_batch(event_payload_batch)
+        try:
+            for attempt in self.retrying():
+                with attempt:
+                    self.try_publish_event_payload_batch(event_payload_batch)
+        except Exception:
+            logger.exception("Failed to publish event batch after %s attempts", self.max_attempts)

--- a/tests/mocks/mock_event_listener_driver.py
+++ b/tests/mocks/mock_event_listener_driver.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
-from attrs import define
+from typing import Callable, Optional
+
+from attrs import define, field
 
 from griptape.drivers import BaseEventListenerDriver
 
 
 @define
 class MockEventListenerDriver(BaseEventListenerDriver):
+    try_publish_event_payload_fn: Optional[Callable[[dict], None]] = field(default=None, kw_only=True)
+    try_publish_event_payload_batch_fn: Optional[Callable[[list[dict]], None]] = field(default=None, kw_only=True)
+
     def try_publish_event_payload(self, event_payload: dict) -> None:
-        pass
+        if self.try_publish_event_payload_fn is not None:
+            self.try_publish_event_payload_fn(event_payload)
 
     def try_publish_event_payload_batch(self, event_payload_batch: list[dict]) -> None:
-        pass
+        if self.try_publish_event_payload_batch_fn is not None:
+            self.try_publish_event_payload_batch_fn(event_payload_batch)

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -54,3 +54,27 @@ class TestBaseEventListenerDriver:
         driver.flush_events()
         executor.submit.assert_called_once_with(driver._safe_publish_event_payload_batch, mock_event_payloads)
         assert len(driver.batch) == 0
+
+    def test__safe_publish_event_payload(self):
+        mock_fn = MagicMock()
+        driver = MockEventListenerDriver(
+            batched=False,
+            try_publish_event_payload_fn=mock_fn,
+        )
+        mock_event_payload = MockEvent().to_dict()
+
+        driver._safe_publish_event_payload(mock_event_payload)
+
+        mock_fn.assert_called_once_with(mock_event_payload)
+
+    def test__safe_publish_event_payload_batch(self):
+        mock_fn = MagicMock()
+        driver = MockEventListenerDriver(
+            batched=True,
+            try_publish_event_payload_batch_fn=mock_fn,
+        )
+        mock_event_payloads = [MockEvent().to_dict() for _ in range(0, 3)]
+
+        driver._safe_publish_event_payload_batch(mock_event_payloads)
+
+        mock_fn.assert_called_once_with(mock_event_payloads)

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -84,7 +84,9 @@ class TestBaseEventListenerDriver:
         driver = MockEventListenerDriver(
             batched=False,
             try_publish_event_payload_fn=mock_fn,
-            max_attempts=1,
+            max_attempts=2,
+            max_retry_delay=0.1,
+            min_retry_delay=0.1,
         )
         mock_fn.side_effect = Exception("Test Exception")
         mock_event_payload = MockEvent().to_dict()
@@ -99,7 +101,9 @@ class TestBaseEventListenerDriver:
         driver = MockEventListenerDriver(
             batched=True,
             try_publish_event_payload_batch_fn=mock_fn,
-            max_attempts=1,
+            max_attempts=2,
+            max_retry_delay=0.1,
+            min_retry_delay=0.1,
         )
         mock_fn.side_effect = Exception("Test Exception")
         mock_event_payloads = [MockEvent().to_dict() for _ in range(0, 3)]

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -91,7 +91,8 @@ class TestBaseEventListenerDriver:
 
         driver._safe_publish_event_payload(mock_event_payload)
 
-        assert mock_fn.call_count == MockEventListenerDriver.max_attempts
+        assert mock_fn.call_count == driver.max_attempts
+        mock_fn.assert_called_with(mock_event_payload)
 
     def test__safe_publish_event_payload_batch_error(self):
         mock_fn = MagicMock()
@@ -105,5 +106,5 @@ class TestBaseEventListenerDriver:
 
         driver._safe_publish_event_payload_batch(mock_event_payloads)
 
-        assert mock_fn.call_count == MockEventListenerDriver.max_attempts
-        assert driver.batch == mock_event_payloads
+        assert mock_fn.call_count == driver.max_attempts
+        mock_fn.assert_called_with(mock_event_payloads)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
The error statement was always getting logged, regardless of success or failure

## Issue ticket number and link


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1264.org.readthedocs.build//1264/

<!-- readthedocs-preview griptape end -->