### PR TITLE
support loading secrets from local .env file

### DIFF
--- a/docs/examples/src/multi_agent_workflow_1.py
+++ b/docs/examples/src/multi_agent_workflow_1.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 
 from griptape.drivers import GoogleWebSearchDriver, LocalStructureRunDriver
 from griptape.rules import Rule, Ruleset
@@ -26,6 +27,7 @@ WRITERS = [
 
 def build_researcher() -> Agent:
     """Builds a Researcher Structure."""
+    load_dotenv()
     return Agent(
         id="researcher",
         tools=[


### PR DESCRIPTION
- [X] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Used the python-dotenv library to load up environment variables from local .env file

## Issue ticket number and link
[Support local .env file in multi_agent_workflow_1 sample](#1281)


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1282.org.readthedocs.build//1282/

<!-- readthedocs-preview griptape end -->