### PR TITLE
Fix/contextvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wrapt` dependency for more robust decorators.
 - `BasePromptDriver.extra_params` for passing extra parameters not explicitly declared by the Driver.
 - `RunnableMixin` which adds `on_before_run` and `on_after_run` hooks.
+- `griptape.utils.with_contextvars` utility for running functions with the current `contextvars` context.
 
 ### Changed
 
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EventListener.event_types` will now listen on child types of any provided type.
 - Only install Tool dependencies if the Tool provides a `requirements.txt` and the dependencies are not already met.
 - Implemented `RunnableMixin` in `Structure`, `BaseTask`, and `BaseTool`.
+- `EventBus`'s Event Listeners are now thread/coroutine-local. Event Listeners from the spawning thread will be automatically copied when using concurrent griptape features like Workflows.
 
 ### Fixed
 
@@ -69,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Models occasionally hallucinating `memory_name` and `artifact_namespace` into Tool schemas when using `ToolkitTask`.
 - Models occasionally providing overly succinct final answers when using `ToolkitTask`.
 - Exception getting raised in `FuturesExecutorMixin.__del__`.
+- Issues when using `EventListener` as a context manager in a multi-threaded environment.
 
 ## \[0.33.1\] - 2024-10-11
 

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -11,6 +11,7 @@ from griptape import utils
 from griptape.artifacts import BaseArtifact, ListArtifact, TextArtifact
 from griptape.mixins.futures_executor_mixin import FuturesExecutorMixin
 from griptape.mixins.serializable_mixin import SerializableMixin
+from griptape.utils import with_contextvars
 
 if TYPE_CHECKING:
     from griptape.drivers import BaseEmbeddingDriver
@@ -47,7 +48,9 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         if isinstance(artifacts, list):
             return utils.execute_futures_list(
                 [
-                    self.futures_executor.submit(self.upsert_text_artifact, a, namespace=None, meta=meta, **kwargs)
+                    self.futures_executor.submit(
+                        with_contextvars(self.upsert_text_artifact), a, namespace=None, meta=meta, **kwargs
+                    )
                     for a in artifacts
                 ],
             )
@@ -61,7 +64,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
 
                     futures_dict[namespace].append(
                         self.futures_executor.submit(
-                            self.upsert_text_artifact, a, namespace=namespace, meta=meta, **kwargs
+                            with_contextvars(self.upsert_text_artifact), a, namespace=namespace, meta=meta, **kwargs
                         )
                     )
 

--- a/griptape/engines/rag/stages/response_rag_stage.py
+++ b/griptape/engines/rag/stages/response_rag_stage.py
@@ -7,6 +7,7 @@ from attrs import define, field
 
 from griptape import utils
 from griptape.engines.rag.stages import BaseRagStage
+from griptape.utils import with_contextvars
 
 if TYPE_CHECKING:
     from griptape.engines.rag import RagContext
@@ -32,7 +33,7 @@ class ResponseRagStage(BaseRagStage):
         logging.info("ResponseRagStage: running %s retrieval modules in parallel", len(self.response_modules))
 
         results = utils.execute_futures_list(
-            [self.futures_executor.submit(r.run, context) for r in self.response_modules]
+            [self.futures_executor.submit(with_contextvars(r.run), context) for r in self.response_modules]
         )
 
         context.outputs = results

--- a/griptape/engines/rag/stages/retrieval_rag_stage.py
+++ b/griptape/engines/rag/stages/retrieval_rag_stage.py
@@ -9,6 +9,7 @@ from attrs import define, field
 from griptape import utils
 from griptape.artifacts import TextArtifact
 from griptape.engines.rag.stages import BaseRagStage
+from griptape.utils import with_contextvars
 
 if TYPE_CHECKING:
     from griptape.engines.rag import RagContext
@@ -36,7 +37,7 @@ class RetrievalRagStage(BaseRagStage):
         logging.info("RetrievalRagStage: running %s retrieval modules in parallel", len(self.retrieval_modules))
 
         results = utils.execute_futures_list(
-            [self.futures_executor.submit(r.run, context) for r in self.retrieval_modules]
+            [self.futures_executor.submit(with_contextvars(r.run), context) for r in self.retrieval_modules]
         )
 
         # flatten the list of lists

--- a/griptape/events/event_bus.py
+++ b/griptape/events/event_bus.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import threading
+from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
-from attrs import Factory, define, field
+from attrs import define
 
 from griptape.mixins.singleton_mixin import SingletonMixin
 
@@ -11,14 +11,21 @@ if TYPE_CHECKING:
     from griptape.events import BaseEvent, EventListener
 
 
+# Context Vars must be declared at the top module level.
+# Also, in-place modifications do not trigger the context var's `set` method
+# so we must reassign the context var with the new value when adding or removing event listeners.
+_event_listeners: ContextVar[list[EventListener]] = ContextVar("event_listeners", default=[])
+
+
 @define
 class _EventBus(SingletonMixin):
-    _event_listeners: list[EventListener] = field(factory=list, kw_only=True, alias="_event_listeners")
-    _thread_lock: threading.Lock = field(default=Factory(lambda: threading.Lock()), alias="_thread_lock")
-
     @property
     def event_listeners(self) -> list[EventListener]:
-        return self._event_listeners
+        return _event_listeners.get()
+
+    @event_listeners.setter
+    def event_listeners(self, event_listeners: list[EventListener]) -> None:
+        _event_listeners.set(event_listeners)
 
     def add_event_listeners(self, event_listeners: list[EventListener]) -> list[EventListener]:
         return [self.add_event_listener(event_listener) for event_listener in event_listeners]
@@ -28,24 +35,21 @@ class _EventBus(SingletonMixin):
             self.remove_event_listener(event_listener)
 
     def add_event_listener(self, event_listener: EventListener) -> EventListener:
-        with self._thread_lock:
-            if event_listener not in self._event_listeners:
-                self._event_listeners.append(event_listener)
+        if event_listener not in self.event_listeners:
+            self.event_listeners = self.event_listeners + [event_listener]
 
         return event_listener
 
     def remove_event_listener(self, event_listener: EventListener) -> None:
-        with self._thread_lock:
-            if event_listener in self._event_listeners:
-                self._event_listeners.remove(event_listener)
+        if event_listener in self.event_listeners:
+            self.event_listeners = [listener for listener in self.event_listeners if listener != event_listener]
 
     def publish_event(self, event: BaseEvent, *, flush: bool = False) -> None:
-        for event_listener in self._event_listeners:
+        for event_listener in self.event_listeners:
             event_listener.publish_event(event, flush=flush)
 
     def clear_event_listeners(self) -> None:
-        with self._thread_lock:
-            self._event_listeners.clear()
+        self.event_listeners = []
 
 
 EventBus = _EventBus()

--- a/griptape/events/event_listener.py
+++ b/griptape/events/event_listener.py
@@ -30,8 +30,6 @@ class EventListener(Generic[T]):
     event_types: Optional[list[type[T]]] = field(default=None, kw_only=True)
     event_listener_driver: Optional[BaseEventListenerDriver] = field(default=None, kw_only=True)
 
-    _last_event_listeners: Optional[list[EventListener]] = field(default=None)
-
     def __enter__(self) -> EventListener:
         from griptape.events import EventBus
 
@@ -43,8 +41,6 @@ class EventListener(Generic[T]):
         from griptape.events import EventBus
 
         EventBus.remove_event_listener(self)
-
-        self._last_event_listeners = None
 
     def publish_event(self, event: T, *, flush: bool = False) -> None:
         event_types = self.event_types

--- a/griptape/structures/workflow.py
+++ b/griptape/structures/workflow.py
@@ -10,6 +10,7 @@ from griptape.artifacts import ErrorArtifact
 from griptape.common import observable
 from griptape.mixins.futures_executor_mixin import FuturesExecutorMixin
 from griptape.structures import Structure
+from griptape.utils import with_contextvars
 
 if TYPE_CHECKING:
     from griptape.artifacts import BaseArtifact
@@ -108,7 +109,7 @@ class Workflow(Structure, FuturesExecutorMixin):
 
             for task in ordered_tasks:
                 if task.can_run():
-                    future = self.futures_executor.submit(task.run)
+                    future = self.futures_executor.submit(with_contextvars(task.run))
                     futures_list[future] = task
 
             # Wait for all tasks to complete

--- a/griptape/utils/__init__.py
+++ b/griptape/utils/__init__.py
@@ -17,6 +17,7 @@ from .deprecation import deprecation_warn
 from .structure_visualizer import StructureVisualizer
 from .reference_utils import references_from_artifacts
 from .file_utils import get_mime_type
+from .contextvars_utils import with_contextvars
 
 
 def minify_json(value: str) -> str:
@@ -47,4 +48,5 @@ __all__ = [
     "StructureVisualizer",
     "references_from_artifacts",
     "get_mime_type",
+    "with_contextvars",
 ]

--- a/griptape/utils/contextvars_utils.py
+++ b/griptape/utils/contextvars_utils.py
@@ -1,0 +1,9 @@
+import contextvars
+import functools
+from typing import Callable
+
+
+def with_contextvars(wrapped: Callable) -> Callable:
+    ctx = contextvars.copy_context()
+
+    return functools.partial(ctx.run, wrapped)

--- a/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_base_event_listener_driver.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 from tests.mocks.mock_event import MockEvent
 from tests.mocks.mock_event_listener_driver import MockEventListenerDriver
@@ -13,7 +13,7 @@ class TestBaseEventListenerDriver:
 
         driver.publish_event(mock_event_payload)
 
-        executor.submit.assert_called_once_with(driver._safe_publish_event_payload, mock_event_payload)
+        executor.submit.assert_called_once_with(ANY, mock_event_payload)
 
     def test_publish_event_yes_batched(self):
         executor = MagicMock()
@@ -33,9 +33,7 @@ class TestBaseEventListenerDriver:
         driver.publish_event(mock_event_payload)
 
         assert len(driver._batch) == 0
-        executor.submit.assert_called_once_with(
-            driver._safe_publish_event_payload_batch, [*mock_event_payloads, mock_event_payload]
-        )
+        executor.submit.assert_called_once_with(ANY, [*mock_event_payloads, mock_event_payload])
 
     def test_flush_events(self):
         executor = MagicMock()
@@ -52,7 +50,7 @@ class TestBaseEventListenerDriver:
         assert len(driver.batch) == 3
 
         driver.flush_events()
-        executor.submit.assert_called_once_with(driver._safe_publish_event_payload_batch, mock_event_payloads)
+        executor.submit.assert_called_once_with(ANY, mock_event_payloads)
         assert len(driver.batch) == 0
 
     def test__safe_publish_event_payload(self):

--- a/tests/unit/events/test_event_bus.py
+++ b/tests/unit/events/test_event_bus.py
@@ -1,6 +1,9 @@
 from unittest.mock import Mock
 
 from griptape.events import EventBus, EventListener
+from griptape.events.finish_prompt_event import FinishPromptEvent
+from griptape.events.start_prompt_event import StartPromptEvent
+from griptape.utils import with_contextvars
 from tests.mocks.mock_event import MockEvent
 
 
@@ -57,3 +60,132 @@ class TestEventBus:
 
         # Then
         mock_handler.assert_called_once_with(mock_event)
+
+    def test_context_manager(self):
+        e1 = EventListener()
+        EventBus.add_event_listeners([e1])
+
+        with EventListener(lambda e: e) as e2:
+            assert EventBus.event_listeners == [e1, e2]
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_context_manager_multiple(self):
+        e1 = EventListener()
+        EventBus.add_event_listener(e1)
+
+        with EventListener(lambda e: e) as e2, EventListener(lambda e: e) as e3:
+            assert EventBus.event_listeners == [e1, e2, e3]
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_nested_context_manager(self):
+        e1 = EventListener()
+        EventBus.add_event_listener(e1)
+
+        with EventListener(lambda e: e) as e2:
+            assert EventBus.event_listeners == [e1, e2]
+            with EventListener(lambda e: e) as e3:
+                assert EventBus.event_listeners == [e1, e2, e3]
+            assert EventBus.event_listeners == [e1, e2]
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_thread_pool_with_context_vars(self):
+        from concurrent import futures
+
+        e1 = EventListener(event_types=[StartPromptEvent])
+        EventBus.add_event_listener(e1)
+
+        def handler(_) -> None:
+            with EventListener(event_types=[FinishPromptEvent]) as e2:
+                assert EventBus.event_listeners == [e1, e2]
+
+        with futures.ThreadPoolExecutor() as executor:
+            list(executor.map(with_contextvars(handler), range(10)))
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_thread_pool_without_context_vars(self):
+        from concurrent import futures
+
+        e1 = EventListener(event_types=[StartPromptEvent])
+        EventBus.add_event_listener(e1)
+
+        def handler(_) -> None:
+            with EventListener(event_types=[FinishPromptEvent]) as e2:
+                assert EventBus.event_listeners == [e2]
+
+        with futures.ThreadPoolExecutor() as executor:
+            list(executor.map(handler, range(10)))
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_thread_with_contextvars(self):
+        import threading
+
+        e1 = EventListener(lambda e: e)
+        EventBus.add_event_listener(e1)
+
+        def handler() -> None:
+            assert EventBus.event_listeners == [e1]
+            e2 = EventListener(lambda e: e)
+            EventBus.add_event_listener(e2)
+            assert EventBus.event_listeners == [e1, e2]
+            EventBus.remove_event_listener(e2)
+            assert EventBus.event_listeners == [e1]
+            EventBus.clear_event_listeners()
+            assert EventBus.event_listeners == []
+            EventBus.add_event_listener(e2)
+            assert EventBus.event_listeners == [e2]
+
+        for _ in range(10):
+            thread = threading.Thread(target=with_contextvars(handler))
+            thread.start()
+            thread.join()
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_thread_without_contextvars(self):
+        import threading
+
+        e1 = EventListener(lambda e: e)
+        EventBus.add_event_listener(e1)
+
+        def handler() -> None:
+            assert EventBus.event_listeners == []
+            e2 = EventListener(lambda e: e)
+            EventBus.add_event_listener(e2)
+            assert EventBus.event_listeners == [e2]
+            EventBus.remove_event_listener(e2)
+            assert EventBus.event_listeners == []
+            EventBus.clear_event_listeners()
+            assert EventBus.event_listeners == []
+            EventBus.add_event_listener(e2)
+
+        for _ in range(10):
+            thread = threading.Thread(target=handler)
+            thread.start()
+            thread.join()
+
+        assert EventBus.event_listeners == [e1]
+
+    def test_coroutine(self):
+        import asyncio
+
+        e1 = EventListener(lambda e: e)
+        EventBus.add_event_listener(e1)
+
+        async def handler() -> None:
+            e2 = EventListener(lambda e: e)
+            EventBus.add_event_listener(e2)
+            assert EventBus.event_listeners == [e1, e2]
+            EventBus.remove_event_listener(e2)
+            assert EventBus.event_listeners == [e1]
+            EventBus.clear_event_listeners()
+            assert EventBus.event_listeners == []
+            EventBus.add_event_listener(e2)
+
+        asyncio.run(handler())
+
+        assert EventBus.event_listeners == [e1]

--- a/tests/unit/events/test_event_listener.py
+++ b/tests/unit/events/test_event_listener.py
@@ -185,6 +185,18 @@ class TestEventListener:
 
         assert EventBus.event_listeners == [e1]
 
+    def test_context_manager_nested(self):
+        e1 = EventListener()
+        EventBus.add_event_listener(e1)
+
+        with EventListener(lambda e: e) as e2:
+            assert EventBus.event_listeners == [e1, e2]
+            with EventListener(lambda e: e) as e3:
+                assert EventBus.event_listeners == [e1, e2, e3]
+            assert EventBus.event_listeners == [e1, e2]
+
+        assert EventBus.event_listeners == [e1]
+
     def test_publish_event_yes_flush(self):
         mock_event_listener_driver = MockEventListenerDriver()
         mock_event_listener_driver.flush_events = Mock(side_effect=mock_event_listener_driver.flush_events)

--- a/tests/unit/utils/test_contextvars_utils.py
+++ b/tests/unit/utils/test_contextvars_utils.py
@@ -1,0 +1,31 @@
+import contextvars
+import threading
+
+from griptape.utils import with_contextvars
+
+context_var = contextvars.ContextVar("context_var")
+
+
+class TestContextvarsUtils:
+    def test_with_contextvars(self):
+        context_var.set("test")
+
+        def function(vals: list) -> None:
+            try:
+                vals.append(context_var.get())
+            except LookupError:
+                vals.append("fallback")
+
+        return_values = []
+        thread = threading.Thread(target=with_contextvars(function), args=(return_values,))
+        thread.start()
+        thread.join()
+
+        assert return_values == ["test"]
+
+        return_values = []
+        thread = threading.Thread(target=function, args=(return_values,))
+        thread.start()
+        thread.join()
+
+        assert return_values == ["fallback"]


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `griptape.utils.decorators.with_context` decorator for running functions with the current `contextvars` context.
### Changed
- Using `EventListener`s as a context manager now sets thread-local `EventListener`s on the Event Bus instead of adding/removing them.
### Fixed
- Issues when using `EventListener` as a context manager in a multi-threaded environment.

## Issue ticket number and link
NA