### PR TITLE
Only install tool deps if available and required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `ToolkitTask` system prompt to no longer mention `memory_name` and `artifact_namespace`.
 - Models in `ToolkitTask` with native tool calling no longer need to provide their final answer as `Answer:`.
 - `EventListener.event_types` will now listen on child types of any provided type.
+- Only install Tool dependencies if the Tool provides a `requirements.txt` and the dependencies are not already met.
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,7 +35,6 @@ Defaults.drivers_config = AnthropicDriversConfig(
 )
 ```
 
-
 ## 0.33.X to 0.34.X
 
 ### Removed `CompletionChunkEvent`

--- a/docs/griptape-tools/official-tools/prompt-summary-tool.md
+++ b/docs/griptape-tools/official-tools/prompt-summary-tool.md
@@ -4,7 +4,7 @@ The [PromptSummaryTool](../../reference/griptape/tools/prompt_summary/tool.md) e
 --8<-- "docs/griptape-tools/official-tools/src/prompt_summary_tool_1.py"
 ```
 
-```
+````
 [08/12/24 15:54:46] INFO     ToolkitTask 8be73eb542c44418ba880399044c017a
                              Input: How can I build Neovim from source for MacOS according to this https://github.com/neovim/neovim/blob/master/BUILD.md
 [08/12/24 15:54:47] INFO     Subtask cd362a149e1d400997be93c1342d1663
@@ -103,4 +103,4 @@ The [PromptSummaryTool](../../reference/griptape/tools/prompt_summary/tool.md) e
 
                              By following these steps, you should be able to build and install Neovim from source on macOS. For more detailed instructions and
                              troubleshooting tips, refer to the [BUILD.md](https://github.com/neovim/neovim/blob/master/BUILD.md) file in the Neovim repository.
-```
+````

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -7,8 +7,10 @@ import re
 import subprocess
 import sys
 from abc import ABC
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+import pkg_resources
 import schema
 from attrs import Attribute, Factory, define, field
 from schema import Literal, Or, Schema
@@ -55,7 +57,11 @@ class BaseTool(ActivityMixin, SerializableMixin, ABC):
     off_prompt: bool = field(default=False, kw_only=True, metadata={"serializable": True})
 
     def __attrs_post_init__(self) -> None:
-        if self.install_dependencies_on_init:
+        if (
+            self.install_dependencies_on_init
+            and self.has_requirements
+            and not self.are_requirements_met(self.requirements_path)
+        ):
             self.install_dependencies(os.environ.copy())
 
     @output_memory.validator  # pyright: ignore[reportAttributeAccessIssue]
@@ -83,6 +89,10 @@ class BaseTool(ActivityMixin, SerializableMixin, ABC):
     @property
     def abs_dir_path(self) -> str:
         return os.path.dirname(self.abs_file_path)
+
+    @property
+    def has_requirements(self) -> bool:
+        return os.path.exists(self.requirements_path)
 
     # This method has to remain a method and can't be decorated with @property because
     # of the max depth recursion issue in `self.activities`.
@@ -223,3 +233,13 @@ class BaseTool(ActivityMixin, SerializableMixin, ABC):
             raise ValueError("Activity name can only contain letters, numbers, and underscores.")
 
         return f"{tool_name}_{activity_name}"
+
+    def are_requirements_met(self, requirements_path: str) -> bool:
+        requirements = Path(requirements_path).read_text().splitlines()
+
+        try:
+            pkg_resources.require(requirements)
+
+            return True
+        except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
+            return False


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes 
### Changed
- Only install Tool dependencies if the Tool provides a `requirements.txt` and the dependencies are not already met.
## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1284.org.readthedocs.build//1284/

<!-- readthedocs-preview griptape end -->