### PR TITLE
Add Prompt Driver extra params field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseFileManagerDriver.load_artifact()` & `BaseFileManagerDriver.save_artifact()` for loading & saving artifacts as files.
 - Events `BaseChunkEvent`, `TextChunkEvent`, `ActionChunkEvent`.
 - `wrapt` dependency for more robust decorators.
+- `BasePromptDriver.extra_params` for passing extra parameters not explicitly declared by the Driver.
 
 ### Changed
 
@@ -32,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If `EventListener.handler` is None, the event will be published to the `event_listener_driver` as-is.
 - **BREAKING**: Moved `griptape.common.observable.observable` to `griptape.common.decorators.observable`.
 - **BREAKING**: `AnthropicDriversConfig` no longer bundles `VoyageAiEmbeddingDriver`.
+- **BREAKING**: Removed `HuggingFaceHubPromptDriver.params`, use `HuggingFaceHubPromptDriver.extra_params` instead.
+- **BREAKING**: Removed `HuggingFacePipelinePromptDriver.params`, use `HuggingFacePipelinePromptDriver.extra_params` instead.
 - Updated `EventListener.handler` return type to `Optional[BaseEvent | dict]`.
 - `BaseTask.parent_outputs` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.
 - `Workflow.context["parent_outputs"]` type has changed from `dict[str, str | None]` to `dict[str, BaseArtifact]`.

--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -117,6 +117,7 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
                 if prompt_stack.tools and self.use_native_tools
                 else {}
             ),
+            **self.extra_params,
         }
 
     def __to_bedrock_messages(self, messages: list[Message]) -> list[dict]:

--- a/griptape/drivers/prompt/amazon_sagemaker_jumpstart_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_sagemaker_jumpstart_prompt_driver.py
@@ -105,6 +105,7 @@ class AmazonSageMakerJumpstartPromptDriver(BasePromptDriver):
             "eos_token_id": self.tokenizer.tokenizer.eos_token_id,
             "stop_strings": self.tokenizer.stop_sequences,
             "return_full_text": False,
+            **self.extra_params,
         }
 
     def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -124,6 +124,7 @@ class AnthropicPromptDriver(BasePromptDriver):
                 else {}
             ),
             **({"system": system_message} if system_message else {}),
+            **self.extra_params,
         }
 
     def __to_anthropic_messages(self, messages: list[Message]) -> list[dict]:

--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -45,6 +45,7 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
         tokenizer: An instance of `BaseTokenizer` to when calculating tokens.
         stream: Whether to stream the completion or not. `CompletionChunkEvent`s will be published to the `Structure` if one is provided.
         use_native_tools: Whether to use LLM's native function calling capabilities. Must be supported by the model.
+        extra_params: Extra parameters to pass to the model.
     """
 
     temperature: float = field(default=0.1, metadata={"serializable": True})
@@ -54,6 +55,7 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
     tokenizer: BaseTokenizer
     stream: bool = field(default=False, kw_only=True, metadata={"serializable": True})
     use_native_tools: bool = field(default=False, kw_only=True, metadata={"serializable": True})
+    extra_params: dict = field(factory=dict, kw_only=True, metadata={"serializable": True})
 
     def before_run(self, prompt_stack: PromptStack) -> None:
         EventBus.publish_event(StartPromptEvent(model=self.model, prompt_stack=prompt_stack))

--- a/griptape/drivers/prompt/cohere_prompt_driver.py
+++ b/griptape/drivers/prompt/cohere_prompt_driver.py
@@ -128,6 +128,7 @@ class CoherePromptDriver(BasePromptDriver):
                 else {}
             ),
             **({"preamble": preamble} if preamble else {}),
+            **self.extra_params,
         }
 
     def __to_cohere_messages(self, messages: list[Message]) -> list[dict]:

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -145,6 +145,7 @@ class GooglePromptDriver(BasePromptDriver):
                     "temperature": self.temperature,
                     "top_p": self.top_p,
                     "top_k": self.top_k,
+                    **self.extra_params,
                 },
             ),
             **(

--- a/griptape/drivers/prompt/ollama_prompt_driver.py
+++ b/griptape/drivers/prompt/ollama_prompt_driver.py
@@ -116,6 +116,7 @@ class OllamaPromptDriver(BasePromptDriver):
                 and not self.stream  # Tool calling is only supported when not streaming
                 else {}
             ),
+            **self.extra_params,
         }
 
     def _prompt_stack_to_messages(self, prompt_stack: PromptStack) -> list[dict]:

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -154,6 +154,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             **({"stop": self.tokenizer.stop_sequences} if self.tokenizer.stop_sequences else {}),
             **({"max_tokens": self.max_tokens} if self.max_tokens is not None else {}),
             **({"stream_options": {"include_usage": True}} if self.stream else {}),
+            **self.extra_params,
         }
 
         if self.response_format is not None:

--- a/tests/unit/configs/drivers/test_amazon_bedrock_drivers_config.py
+++ b/tests/unit/configs/drivers/test_amazon_bedrock_drivers_config.py
@@ -57,6 +57,7 @@ class TestAmazonBedrockDriversConfig:
                 "type": "AmazonBedrockPromptDriver",
                 "tool_choice": {"auto": {}},
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "vector_store_driver": {
                 "embedding_driver": {
@@ -117,6 +118,7 @@ class TestAmazonBedrockDriversConfig:
                 "type": "AmazonBedrockPromptDriver",
                 "tool_choice": {"auto": {}},
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "vector_store_driver": {
                 "embedding_driver": {

--- a/tests/unit/configs/drivers/test_anthropic_drivers_config.py
+++ b/tests/unit/configs/drivers/test_anthropic_drivers_config.py
@@ -25,6 +25,7 @@ class TestAnthropicDriversConfig:
                 "top_p": 0.999,
                 "top_k": 250,
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "image_generation_driver": {"type": "DummyImageGenerationDriver"},
             "image_query_driver": {

--- a/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
+++ b/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
@@ -35,6 +35,7 @@ class TestAzureOpenAiDriversConfig:
                 "stream": False,
                 "user": "",
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "conversation_memory_driver": {
                 "type": "LocalConversationMemoryDriver",

--- a/tests/unit/configs/drivers/test_cohere_drivers_config.py
+++ b/tests/unit/configs/drivers/test_cohere_drivers_config.py
@@ -27,6 +27,7 @@ class TestCohereDriversConfig:
                 "model": "command-r",
                 "force_single_step": False,
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "embedding_driver": {
                 "type": "CohereEmbeddingDriver",

--- a/tests/unit/configs/drivers/test_drivers_config.py
+++ b/tests/unit/configs/drivers/test_drivers_config.py
@@ -18,6 +18,7 @@ class TestDriversConfig:
                 "max_tokens": None,
                 "stream": False,
                 "use_native_tools": False,
+                "extra_params": {},
             },
             "conversation_memory_driver": {
                 "type": "LocalConversationMemoryDriver",

--- a/tests/unit/configs/drivers/test_google_drivers_config.py
+++ b/tests/unit/configs/drivers/test_google_drivers_config.py
@@ -25,6 +25,7 @@ class TestGoogleDriversConfig:
                 "top_k": None,
                 "tool_choice": "auto",
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "image_generation_driver": {"type": "DummyImageGenerationDriver"},
             "image_query_driver": {"type": "DummyImageQueryDriver"},

--- a/tests/unit/configs/drivers/test_openai_driver_config.py
+++ b/tests/unit/configs/drivers/test_openai_driver_config.py
@@ -27,6 +27,7 @@ class TestOpenAiDriversConfig:
                 "stream": False,
                 "user": "",
                 "use_native_tools": True,
+                "extra_params": {},
             },
             "conversation_memory_driver": {
                 "type": "LocalConversationMemoryDriver",

--- a/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
@@ -359,7 +359,9 @@ class TestAmazonBedrockPromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     def test_try_run(self, mock_converse, prompt_stack, messages, use_native_tools):
         # Given
-        driver = AmazonBedrockPromptDriver(model="ai21.j2", use_native_tools=use_native_tools)
+        driver = AmazonBedrockPromptDriver(
+            model="ai21.j2", use_native_tools=use_native_tools, extra_params={"foo": "bar"}
+        )
 
         # When
         message = driver.try_run(prompt_stack)
@@ -376,6 +378,7 @@ class TestAmazonBedrockPromptDriver:
                 if use_native_tools
                 else {}
             ),
+            foo="bar",
         )
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -390,7 +393,9 @@ class TestAmazonBedrockPromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     def test_try_stream_run(self, mock_converse_stream, prompt_stack, messages, use_native_tools):
         # Given
-        driver = AmazonBedrockPromptDriver(model="ai21.j2", stream=True, use_native_tools=use_native_tools)
+        driver = AmazonBedrockPromptDriver(
+            model="ai21.j2", stream=True, use_native_tools=use_native_tools, extra_params={"foo": "bar"}
+        )
 
         # When
         stream = driver.try_stream(prompt_stack)
@@ -408,6 +413,7 @@ class TestAmazonBedrockPromptDriver:
                 if prompt_stack.tools and use_native_tools
                 else {}
             ),
+            foo="bar",
         )
 
         event = next(stream)

--- a/tests/unit/drivers/prompt/test_amazon_sagemaker_jumpstart_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_sagemaker_jumpstart_prompt_driver.py
@@ -37,7 +37,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
 
     def test_try_run(self, mock_client):
         # Given
-        driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model")
+        driver = AmazonSageMakerJumpstartPromptDriver(endpoint="model", model="model", extra_params={"foo": "bar"})
         prompt_stack = PromptStack()
         prompt_stack.add_user_message("prompt-stack")
 
@@ -61,6 +61,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
                         "eos_token_id": 1,
                         "stop_strings": [],
                         "return_full_text": False,
+                        "foo": "bar",
                     },
                 }
             ),
@@ -91,6 +92,7 @@ class TestAmazonSageMakerJumpstartPromptDriver:
                         "eos_token_id": 1,
                         "stop_strings": [],
                         "return_full_text": False,
+                        "foo": "bar",
                     },
                 }
             ),

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -345,7 +345,9 @@ class TestAnthropicPromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools):
         # Given
-        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", use_native_tools=use_native_tools)
+        driver = AnthropicPromptDriver(
+            model="claude-3-haiku", api_key="api-key", use_native_tools=use_native_tools, extra_params={"foo": "bar"}
+        )
 
         # When
         message = driver.try_run(prompt_stack)
@@ -361,6 +363,7 @@ class TestAnthropicPromptDriver:
             top_k=250,
             **{"system": "system-input"} if prompt_stack.system_messages else {},
             **{"tools": self.ANTHROPIC_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -376,7 +379,11 @@ class TestAnthropicPromptDriver:
     def test_try_stream_run(self, mock_stream_client, prompt_stack, messages, use_native_tools):
         # Given
         driver = AnthropicPromptDriver(
-            model="claude-3-haiku", api_key="api-key", stream=True, use_native_tools=use_native_tools
+            model="claude-3-haiku",
+            api_key="api-key",
+            stream=True,
+            use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
         )
 
         # When
@@ -395,6 +402,7 @@ class TestAnthropicPromptDriver:
             top_k=250,
             **{"system": "system-input"} if prompt_stack.system_messages else {},
             **{"tools": self.ANTHROPIC_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
         assert event.usage.input_tokens == 5
 

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -74,6 +74,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             azure_deployment="deployment-id",
             model="gpt-4",
             use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
         )
 
         # When
@@ -86,6 +87,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             messages=messages,
             **{"tools": self.OPENAI_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -104,6 +106,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             model="gpt-4",
             stream=True,
             use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
         )
 
         # When
@@ -118,6 +121,7 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stream=True,
             messages=messages,
             **{"tools": self.OPENAI_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
 
         assert isinstance(event.content, TextDeltaMessageContent)

--- a/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_cohere_prompt_driver.py
@@ -136,7 +136,9 @@ class TestCoherePromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     def test_try_run(self, mock_client, prompt_stack, use_native_tools):
         # Given
-        driver = CoherePromptDriver(model="command", api_key="api-key", use_native_tools=use_native_tools)
+        driver = CoherePromptDriver(
+            model="command", api_key="api-key", use_native_tools=use_native_tools, extra_params={"foo": "bar"}
+        )
 
         # When
         message = driver.try_run(prompt_stack)
@@ -171,6 +173,7 @@ class TestCoherePromptDriver:
             ],
             stop_sequences=[],
             temperature=0.1,
+            foo="bar",
         )
 
         assert isinstance(message.value[0], TextArtifact)
@@ -187,7 +190,13 @@ class TestCoherePromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     def test_try_stream_run(self, mock_stream_client, prompt_stack, use_native_tools):
         # Given
-        driver = CoherePromptDriver(model="command", api_key="api-key", stream=True, use_native_tools=use_native_tools)
+        driver = CoherePromptDriver(
+            model="command",
+            api_key="api-key",
+            stream=True,
+            use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
+        )
 
         # When
         stream = driver.try_stream(prompt_stack)
@@ -223,6 +232,7 @@ class TestCoherePromptDriver:
             ],
             stop_sequences=[],
             temperature=0.1,
+            foo="bar",
         )
 
         assert isinstance(event.content, TextDeltaMessageContent)

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -169,7 +169,12 @@ class TestGooglePromptDriver:
     def test_try_run(self, mock_generative_model, prompt_stack, messages, use_native_tools):
         # Given
         driver = GooglePromptDriver(
-            model="gemini-pro", api_key="api-key", top_p=0.5, top_k=50, use_native_tools=use_native_tools
+            model="gemini-pro",
+            api_key="api-key",
+            top_p=0.5,
+            top_k=50,
+            use_native_tools=use_native_tools,
+            extra_params={"max_output_tokens": 10},
         )
 
         # When
@@ -185,7 +190,9 @@ class TestGooglePromptDriver:
         call_args = mock_generative_model.return_value.generate_content.call_args
         assert messages == call_args.args[0]
         generation_config = call_args.kwargs["generation_config"]
-        assert generation_config == GenerationConfig(temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[])
+        assert generation_config == GenerationConfig(
+            temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[], max_output_tokens=10
+        )
         if use_native_tools:
             tool_declarations = call_args.kwargs["tools"]
             assert [
@@ -206,7 +213,13 @@ class TestGooglePromptDriver:
     def test_try_stream(self, mock_stream_generative_model, prompt_stack, messages, use_native_tools):
         # Given
         driver = GooglePromptDriver(
-            model="gemini-pro", api_key="api-key", stream=True, top_p=0.5, top_k=50, use_native_tools=use_native_tools
+            model="gemini-pro",
+            api_key="api-key",
+            stream=True,
+            top_p=0.5,
+            top_k=50,
+            use_native_tools=use_native_tools,
+            extra_params={"max_output_tokens": 10},
         )
 
         # When
@@ -225,7 +238,7 @@ class TestGooglePromptDriver:
         assert messages == call_args.args[0]
         assert call_args.kwargs["stream"] is True
         assert call_args.kwargs["generation_config"] == GenerationConfig(
-            temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[]
+            temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[], max_output_tokens=10
         )
         if use_native_tools:
             tool_declarations = call_args.kwargs["tools"]

--- a/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_hub_prompt_driver.py
@@ -47,25 +47,40 @@ class TestHuggingFaceHubPromptDriver:
 
     def test_try_run(self, prompt_stack, mock_client):
         # Given
-        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id")
+        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id", extra_params={"foo": "bar"})
 
         # When
         message = driver.try_run(prompt_stack)
 
         # Then
+        mock_client.text_generation.assert_called_once_with(
+            "foo\n\nUser: bar",
+            return_full_text=False,
+            max_new_tokens=250,
+            foo="bar",
+        )
         assert message.value == "model-output"
         assert message.usage.input_tokens == 3
         assert message.usage.output_tokens == 3
 
     def test_try_stream(self, prompt_stack, mock_client_stream):
         # Given
-        driver = HuggingFaceHubPromptDriver(api_token="api-token", model="repo-id", stream=True)
+        driver = HuggingFaceHubPromptDriver(
+            api_token="api-token", model="repo-id", stream=True, extra_params={"foo": "bar"}
+        )
 
         # When
         stream = driver.try_stream(prompt_stack)
         event = next(stream)
 
         # Then
+        mock_client_stream.text_generation.assert_called_once_with(
+            "foo\n\nUser: bar",
+            return_full_text=False,
+            max_new_tokens=250,
+            foo="bar",
+            stream=True,
+        )
         assert isinstance(event.content, TextDeltaMessageContent)
         assert event.content.text == "model-output"
 

--- a/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_hugging_face_pipeline_prompt_driver.py
@@ -33,17 +33,28 @@ class TestHuggingFacePipelinePromptDriver:
         prompt_stack.add_assistant_message("assistant-input")
         return prompt_stack
 
+    @pytest.fixture()
+    def messages(self):
+        return [
+            {"role": "system", "content": "system-input"},
+            {"role": "user", "content": "user-input"},
+            {"role": "assistant", "content": "assistant-input"},
+        ]
+
     def test_init(self):
         assert HuggingFacePipelinePromptDriver(model="gpt2", max_tokens=42)
 
-    def test_try_run(self, prompt_stack):
+    def test_try_run(self, prompt_stack, messages, mock_pipeline):
         # Given
-        driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42)
+        driver = HuggingFacePipelinePromptDriver(model="foo", max_tokens=42, extra_params={"foo": "bar"})
 
         # When
         message = driver.try_run(prompt_stack)
 
         # Then
+        mock_pipeline.return_value.assert_called_once_with(
+            messages, max_new_tokens=42, temperature=0.1, do_sample=True, foo="bar"
+        )
         assert message.value == "model-output"
         assert message.usage.input_tokens == 3
         assert message.usage.output_tokens == 3

--- a/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
@@ -205,7 +205,7 @@ class TestOllamaPromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True])
     def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools):
         # Given
-        driver = OllamaPromptDriver(model="llama")
+        driver = OllamaPromptDriver(model="llama", extra_params={"foo": "bar"})
 
         # When
         message = driver.try_run(prompt_stack)
@@ -220,6 +220,7 @@ class TestOllamaPromptDriver:
                 "num_predict": driver.max_tokens,
             },
             **{"tools": self.OLLAMA_TOOLS} if use_native_tools else {},
+            foo="bar",
         )
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -256,7 +257,7 @@ class TestOllamaPromptDriver:
             {"role": "user", "content": "user-input", "images": ["aW1hZ2UtZGF0YQ=="]},
             {"role": "assistant", "content": "assistant-input"},
         ]
-        driver = OllamaPromptDriver(model="llama", stream=True)
+        driver = OllamaPromptDriver(model="llama", stream=True, extra_params={"foo": "bar"})
 
         # When
         text_artifact = next(driver.try_stream(prompt_stack))
@@ -267,6 +268,7 @@ class TestOllamaPromptDriver:
             model=driver.model,
             options={"temperature": driver.temperature, "stop": [], "num_predict": driver.max_tokens},
             stream=True,
+            foo="bar",
         )
         if isinstance(text_artifact, TextDeltaMessageContent):
             assert text_artifact.text == "model-output"

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -343,7 +343,9 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_try_run(self, mock_chat_completion_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, use_native_tools=use_native_tools
+            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
+            use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
         )
 
         # When
@@ -357,6 +359,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             messages=messages,
             seed=driver.seed,
             **{"tools": self.OPENAI_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -439,7 +442,10 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
     def test_try_stream_run(self, mock_chat_completion_stream_create, prompt_stack, messages, use_native_tools):
         # Given
         driver = OpenAiChatPromptDriver(
-            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL, stream=True, use_native_tools=use_native_tools
+            model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_3_CHAT_MODEL,
+            stream=True,
+            use_native_tools=use_native_tools,
+            extra_params={"foo": "bar"},
         )
 
         # When
@@ -456,6 +462,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             seed=driver.seed,
             stream_options={"include_usage": True},
             **{"tools": self.OPENAI_TOOLS, "tool_choice": driver.tool_choice} if use_native_tools else {},
+            foo="bar",
         )
 
         assert isinstance(event.content, TextDeltaMessageContent)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `BasePromptDriver.extra_params` for passing extra parameters not explicitly declared by the Driver.
### Changed
- **BREAKING**: Removed `HuggingFaceHubPromptDriver.params`, use `HuggingFaceHubPromptDriver.extra_params` instead.
- **BREAKING**: Removed `HuggingFacePipelinePromptDriver.params`, use `HuggingFacePipelinePromptDriver.extra_params` instead.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/236
Closes https://github.com/griptape-ai/griptape/issues/293