### PR TITLE
add prometheus observability driver

### DIFF
--- a/griptape/drivers/observability/prometheus_observability_driver.py
+++ b/griptape/drivers/observability/prometheus_observability_driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any, Optional
 
 from attrs import Attribute, define, field
@@ -10,15 +11,40 @@ from griptape.utils.import_utils import import_optional_dependency
 
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import SpanProcessor
+    from prometheus_client.registry import CollectorRegistry
 
     from griptape.common.observable import Observable
 
 
+def to_valid_prometheus_metric_name(class_name: str, func_name: str) -> str:
+    # Combine class name and function name
+    method_name = f"{class_name}_{func_name}"
+
+    # Convert to lowercase and replace invalid characters
+    valid_name = re.sub(r'[^a-z0-9_]', '_', method_name.lower())
+
+    # Ensure it starts with a letter
+    if not valid_name[0].isalpha():
+        valid_name = 'metric_' + valid_name  # prefix with 'metric_' if it doesn't start with a letter
+
+    return valid_name
+
+
 @define
 class PrometheusObservabilityDriver(OpenTelemetryObservabilityDriver):
+    """Example usage:
+
+    get_experts_observability_driver = PrometheusObservabilityDriver(
+        service_name="griptape_get_experts", span_processor=BatchSpanProcessor(ConsoleSpanExporter()), custom_registry=instrumentator.registry
+    )
+    simple_query_observability_driver = PrometheusObservabilityDriver(
+            service_name="griptape_run_simple_query", span_processor=BatchSpanProcessor(ConsoleSpanExporter()), custom_registry=instrumentator.registry
+    )
+    """  # noqa: D415
     span_processor: SpanProcessor = field(kw_only=True)
     request_count: Counter = field(init=False)
     request_duration: Histogram = field(init=False)
+    custom_registry: CollectorRegistry = field(kw_only=True)
 
     @span_processor.validator
     def validate_span_processor(self, _: Attribute, span_processor: SpanProcessor) -> None:
@@ -31,11 +57,13 @@ class PrometheusObservabilityDriver(OpenTelemetryObservabilityDriver):
             f"{self.service_name}_request_count",
             "Total number of requests",
             labelnames=['method'],
+            registry=self.custom_registry
         )
         self.request_duration = Histogram(
             f"{self.service_name}_request_duration_seconds",
             "Duration of requests in seconds",
             labelnames=['method'],
+            registry=self.custom_registry
         )
         super().__attrs_post_init__()  # Call to parent class initializer
 
@@ -44,14 +72,15 @@ class PrometheusObservabilityDriver(OpenTelemetryObservabilityDriver):
         instance = call.instance
 
         class_name = f"{instance.__class__.__name__}." if instance else ""
-        method_name = f"{class_name}{func.__name__}()"
+        method_name = to_valid_prometheus_metric_name(class_name, func.__name__)
 
         # Start timing
         with self.request_duration.labels(method=method_name).time():
             # Increment the request count
             self.request_count.labels(method=method_name).inc()
             try:
-                return call()
+                result = call()
+                return result
             except Exception as e:
                 # Handle exceptions as needed
                 raise e

--- a/griptape/drivers/observability/prometheus_observability_driver.py
+++ b/griptape/drivers/observability/prometheus_observability_driver.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Optional
+
+from attrs import Attribute, Factory, define, field
+from prometheus_client import Counter, Histogram
+
+from griptape.drivers.observability.open_telemetry_observability_driver import OpenTelemetryObservabilityDriver
+from griptape.utils.import_utils import import_optional_dependency
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import SpanProcessor
+
+    from griptape.common.observable import Observable
+
+
+@define
+class PrometheusObservabilityDriver(OpenTelemetryObservabilityDriver):
+    span_processor: SpanProcessor = field(kw_only=True)
+    request_count: Counter = field(init=False)
+    request_duration: Histogram = field(init=False)
+
+    @span_processor.validator
+    def validate_span_processor(self, _: Attribute, span_processor: SpanProcessor) -> None:
+        if span_processor is None:
+            raise ValueError("span_processor must be provided.")
+
+    def __attrs_post_init__(self) -> None:
+        # Initialize the Prometheus metrics
+        self.request_count = Counter(
+            f"{self.service_name}_request_count",
+            "Total number of requests",
+            labelnames=['method'],
+        )
+        self.request_duration = Histogram(
+            f"{self.service_name}_request_duration_seconds",
+            "Duration of requests in seconds",
+            labelnames=['method'],
+        )
+        super().__attrs_post_init__()  # Call to parent class initializer
+
+    def observe(self, call: Observable.Call) -> Any:
+        func = call.func
+        instance = call.instance
+
+        class_name = f"{instance.__class__.__name__}." if instance else ""
+        method_name = f"{class_name}{func.__name__}()"
+
+        # Start timing
+        with self.request_duration.labels(method=method_name).time():
+            # Increment the request count
+            self.request_count.labels(method=method_name).inc()
+            try:
+                return call()
+            except Exception as e:
+                # Handle exceptions as needed
+                raise e
+
+    def get_span_id(self) -> Optional[str]:
+        opentelemetry_trace = import_optional_dependency("opentelemetry.trace")
+        span = opentelemetry_trace.get_current_span()
+        if span is opentelemetry_trace.INVALID_SPAN:
+            return None
+        return str(span.get_span_context().span_id)  # Simple span ID formatting

--- a/griptape/drivers/observability/prometheus_observability_driver.py
+++ b/griptape/drivers/observability/prometheus_observability_driver.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Any, Optional
 
-from attrs import Attribute, Factory, define, field
+from attrs import Attribute, define, field
 from prometheus_client import Counter, Histogram
 
 from griptape.drivers.observability.open_telemetry_observability_driver import OpenTelemetryObservabilityDriver

--- a/poetry.lock
+++ b/poetry.lock
@@ -7246,4 +7246,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "89d915ab7f7cf7849b39a97c965485c5eddd9a7410b4503ebb9e8160348b33f2"
+content-hash = "816a925736967c12b42ffddce1e48909348d11e7d341127d5e9e1224b44ba00e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7211,6 +7211,7 @@ drivers-memory-conversation-redis = ["redis"]
 drivers-observability-datadog = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation", "opentelemetry-instrumentation-threading", "opentelemetry-sdk"]
 drivers-observability-griptape-cloud = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation", "opentelemetry-instrumentation-threading", "opentelemetry-sdk"]
 drivers-observability-opentelemetry = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation", "opentelemetry-instrumentation-threading", "opentelemetry-sdk"]
+drivers-observability-prometheus = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation", "opentelemetry-instrumentation-threading", "opentelemetry-sdk"]
 drivers-prompt-amazon-bedrock = ["anthropic", "boto3"]
 drivers-prompt-amazon-sagemaker = ["boto3", "transformers"]
 drivers-prompt-anthropic = ["anthropic"]
@@ -7246,4 +7247,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "816a925736967c12b42ffddce1e48909348d11e7d341127d5e9e1224b44ba00e"
+content-hash = "83ce2a8a23b6aff56e8a6dc40f848a4693ed3697f8199b33d6afe420b732026d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,13 @@ drivers-observability-datadog = [
     "opentelemetry-instrumentation-threading",
     "opentelemetry-exporter-otlp-proto-http",
 ]
+drivers-observability-prometheus = [
+    "opentelemetry-sdk",
+    "opentelemetry-api",
+    "opentelemetry-instrumentation",
+    "opentelemetry-instrumentation-threading",
+    "opentelemetry-exporter-otlp-proto-http",
+]
 
 drivers-image-generation-huggingface = ["diffusers", "pillow"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requests = "^2.32.0"
 filetype = "^1.2"
 
 # drivers
-cohere = { version = "~5.11.2", optional = true }
+cohere = { version = "^5.11.2", optional = true }
 anthropic = { version = "^0.37.1", optional = true }
 transformers = { version = "^4.41.1", optional = true}
 huggingface-hub = { version = "^0.26.2", optional = true }

--- a/tests/unit/drivers/observability/test_prometheus_observability_driver.py
+++ b/tests/unit/drivers/observability/test_prometheus_observability_driver.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from itertools import groupby
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from prometheus_client import CollectorRegistry, generate_latest
+
+from griptape.common.observable import Observable
+from griptape.drivers.observability.prometheus_observability_driver import PrometheusObservabilityDriver
+
+
+def validate_call_count(driver):
+    # Assuming collected_metrics is obtained from driver.request_count.collect()
+    collected_metrics = list(driver.request_count.collect())
+
+    # Group samples by name and method
+    grouped_samples = groupby(sorted(collected_metrics[0].samples, key=lambda s: (s.name, s.labels['method'])), key=lambda s: (s.name, s.labels['method']))
+
+    # Assert that each group has a count of 1
+    for (name, method), group in grouped_samples:
+        sample_count = len(list(group))  # Count the number of samples in this group
+        assert sample_count == 1, f"Expected 1 sample for {name} with method {method}, but got {sample_count}"
+
+class TestPrometheusObservabilityDriver:
+    @pytest.fixture()
+    def driver(self):
+        # Mock the span processor for Prometheus driver
+        mock_span_processor = MagicMock()
+        def get_driver(service_name):
+            # generate singleton around the tests service name to avoid name clash
+            return PrometheusObservabilityDriver(
+                service_name=service_name,
+                span_processor=mock_span_processor
+            )
+        return get_driver
+
+    @pytest.fixture()
+    def metrics(self):
+        # Create a fresh registry for each test
+        return CollectorRegistry()
+
+
+
+    def test_observe(self, driver, metrics):
+        driver = driver('test_observe')
+        # Register metrics to the custom registry
+        metrics.register(driver.request_count)
+        metrics.register(driver.request_duration)
+
+        def foo_append(word: str):
+            return word + " foo"
+
+        class TestKlass:
+            def bazqux_append(self, word: str):
+                return word + " bazqux"
+
+        instance = TestKlass()
+
+        with driver:
+            assert driver.observe(Observable.Call(func=foo_append, instance=None, args=["hello"])) == "hello foo"
+            assert driver.observe(Observable.Call(func=instance.bazqux_append, instance=instance, args=["WORLD"])) == "WORLD bazqux"
+        validate_call_count(driver)
+
+    def test_metrics_exposure(self, driver, metrics):
+        driver = driver('test_metrics_exposure')
+
+        # Test if the metrics can be exposed
+        metrics.register(driver.request_count)
+        metrics.register(driver.request_duration)
+
+        def foo_append(word: str):
+            return word + " foo"
+
+        with driver:
+            driver.observe(Observable.Call(func=foo_append, instance=None, args=["hello"]))
+
+        # Generate metrics
+        metric_output = generate_latest(metrics)
+
+        # Check that the metrics output contains the expected information
+        assert b'test_metrics_exposure_request_count' in metric_output
+        assert b'test_metrics_exposure_request_duration_seconds' in metric_output
+
+    def test_get_span_id(self, driver):
+        driver = driver('test_get_span_id')
+        assert driver.get_span_id() is None
+        with driver:
+            span_id = driver.get_span_id()
+            assert span_id is not None
+            assert isinstance(span_id, str)
+
+    def test_context_manager_observe(self, driver, metrics):
+        driver = driver('test_context_manager_observe')
+        metrics.register(driver.request_count)
+        metrics.register(driver.request_duration)
+
+        def qux_append(word: str):
+            return word + " qux"
+
+        class TestKlass:
+            def quux_append(self, word: str):
+                return word + " quux"
+
+        instance = TestKlass()
+
+        with driver:
+            assert driver.observe(Observable.Call(func=qux_append, instance=None, args=["Greetings"])) == "Greetings qux"
+            assert driver.observe(Observable.Call(func=instance.quux_append, instance=instance, args=["Farewell"])) == "Farewell quux"
+
+        validate_call_count(driver)
+
+    def test_context_manager_observe_exception(self, driver, metrics):
+        driver = driver('test_context_manager_observe_exception')
+        metrics.register(driver.request_count)
+        metrics.register(driver.request_duration)
+
+        def func(word: str):
+            raise Exception("Error in function")
+
+        with pytest.raises(Exception, match="Error in function"), driver:
+            driver.observe(Observable.Call(func=func, instance=None, args=["test"]))
+
+        # Ensure metrics are still updated despite the exception
+        validate_call_count(driver)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

Adds tests, and driver for prometheus observability

## Issue ticket number and link

NA

Example usage:

```
    observability_driver = PrometheusObservabilityDriver(
        service_name="get_experts", span_processor=BatchSpanProcessor(ConsoleSpanExporter())
    )

    with Observability(observability_driver=observability_driver):
        # Build the workflow
        workflow = Workflow(...)
        # add tasks
        workflow.run()
```




