### PR TITLE
Remove `docker` and `stringcase` from core dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: Removed `stringcase` and `docker` from core dependencies. `ComputerTool` will now install these on the fly.
 - **BREAKING**: Renamed `BaseTask.State.EXECUTING` to `BaseTask.State.RUNNING`.
 - **BREAKING**: Renamed `BaseTask.is_executing()` to `BaseTask.is_running()`.
 - **BREAKING**: Renamed `Structure.is_executing()` to `Structure.is_running()`.

--- a/griptape/tools/computer/requirements.txt
+++ b/griptape/tools/computer/requirements.txt
@@ -1,0 +1,2 @@
+docker
+stringcase

--- a/griptape/tools/computer/tool.py
+++ b/griptape/tools/computer/tool.py
@@ -8,10 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import docker
-import stringcase
 from attrs import Attribute, Factory, define, field
-from docker.errors import NotFound
-from docker.models.containers import Container
 from schema import Literal, Schema
 
 from griptape.artifacts import BaseArtifact, ErrorArtifact, TextArtifact
@@ -97,6 +94,8 @@ class ComputerTool(BaseTool):
         return self.execute_command_in_container(command)
 
     def execute_command_in_container(self, command: str) -> BaseArtifact:
+        from docker.models.containers import Container
+
         try:
             binds = {self.local_workdir: {"bind": self.container_workdir, "mode": "rw"}} if self.local_workdir else None
 
@@ -160,12 +159,19 @@ class ComputerTool(BaseTool):
             return None
 
     def image_name(self, tool: BaseTool) -> str:
+        import stringcase  # pyright: ignore[reportMissingImports]
+
         return f"{stringcase.snakecase(tool.name)}_image"
 
     def container_name(self, tool: BaseTool) -> str:
+        import stringcase  # pyright: ignore[reportMissingImports]
+
         return f"{stringcase.snakecase(tool.name)}_container"
 
     def remove_existing_container(self, name: str) -> None:
+        from docker.errors import NotFound
+        from docker.models.containers import Container
+
         try:
             existing_container = self.docker_client.containers.get(name)
             if isinstance(existing_container, Container):

--- a/poetry.lock
+++ b/poetry.lock
@@ -5992,16 +5992,6 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
-name = "stringcase"
-version = "1.2.0"
-description = "String case converter."
-optional = false
-python-versions = "*"
-files = [
-    {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
-]
-
-[[package]]
 name = "sympy"
 version = "1.13.1"
 description = "Computer algebra system (CAS) in Python"
@@ -7093,4 +7083,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ec4a058717301471b98146fbc8476a2582497559c4791a602158e78b5201027d"
+content-hash = "12fa32281c210fcd8ba7bc48e3ba18ec4f36bfc798b81076cc3dc07ac19d8d8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ schema = "^0.7.7"
 pyyaml = "^6.0.1"
 tenacity = "^8.5.0"
 numpy = "^1.26.4"
-stringcase = "^1.2.0"
-docker = "^7.1.0"
 requests = "^2.32.0"
 filetype = "^1.2"
 

--- a/tests/unit/tools/test_computer.py
+++ b/tests/unit/tools/test_computer.py
@@ -7,7 +7,7 @@ from tests.mocks.docker.fake_api_client import make_fake_client
 class TestComputer:
     @pytest.fixture()
     def computer(self):
-        return ComputerTool(docker_client=make_fake_client(), install_dependencies_on_init=False)
+        return ComputerTool(docker_client=make_fake_client())
 
     def test_execute_code(self, computer):
         assert computer.execute_code({"values": {"code": "print(1)", "filename": "foo.py"}}).value == "hello world"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- **BREAKING**: Removed `stringcase` and `docker` from core dependencies. `ComputerTool` will now install this on the fly.
## Issue ticket number and link
NA