### PR TITLE
Reintroduce image/audio artifact naming

### DIFF
--- a/griptape/artifacts/audio_artifact.py
+++ b/griptape/artifacts/audio_artifact.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import random
+import string
+import time
+
 from attrs import define, field
 
 from griptape.artifacts import BlobArtifact
@@ -15,6 +19,12 @@ class AudioArtifact(BlobArtifact):
 
     format: str = field(kw_only=True, metadata={"serializable": True})
 
+    def __attrs_post_init__(self) -> None:
+        # Generating the name string requires attributes set by child classes.
+        # This waits until all attributes are available before generating a name.
+        if self.name == self.id:
+            self.name = self.make_name()
+
     @property
     def mime_type(self) -> str:
         return f"audio/{self.format}"
@@ -24,3 +34,9 @@ class AudioArtifact(BlobArtifact):
 
     def to_text(self) -> str:
         return f"Audio, format: {self.format}, size: {len(self.value)} bytes"
+
+    def make_name(self) -> str:
+        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
+
+        return f"audio_artifact_{fmt_time}_{entropy}.{self.format}"

--- a/griptape/artifacts/image_artifact.py
+++ b/griptape/artifacts/image_artifact.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import random
+import string
+import time
+
 from attrs import define, field
 
 from griptape.artifacts import BlobArtifact
@@ -19,6 +23,12 @@ class ImageArtifact(BlobArtifact):
     width: int = field(kw_only=True, metadata={"serializable": True})
     height: int = field(kw_only=True, metadata={"serializable": True})
 
+    def __attrs_post_init__(self) -> None:
+        # Generating the name string requires attributes set by child classes.
+        # This waits until all attributes are available before generating a name.
+        if self.name == self.id:
+            self.name = self.make_name()
+
     @property
     def mime_type(self) -> str:
         return f"image/{self.format}"
@@ -28,3 +38,9 @@ class ImageArtifact(BlobArtifact):
 
     def to_text(self) -> str:
         return f"Image, format: {self.format}, size: {len(self.value)} bytes"
+
+    def make_name(self) -> str:
+        entropy = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        fmt_time = time.strftime("%y%m%d%H%M%S", time.localtime())
+
+        return f"image_artifact_{fmt_time}_{entropy}.{self.format}"

--- a/tests/unit/artifacts/test_audio_artifact.py
+++ b/tests/unit/artifacts/test_audio_artifact.py
@@ -35,3 +35,7 @@ class TestAudioArtifact:
         assert deserialized_artifact.format == "pcm"
         assert deserialized_artifact.meta["model"] == "provider/model"
         assert deserialized_artifact.meta["prompt"] == "two words"
+
+    def test_name(self, audio_artifact):
+        assert audio_artifact.name.startswith("audio_artifact_")
+        assert audio_artifact.name.endswith(audio_artifact.format)

--- a/tests/unit/artifacts/test_image_artifact.py
+++ b/tests/unit/artifacts/test_image_artifact.py
@@ -40,3 +40,7 @@ class TestImageArtifact:
         assert deserialized_artifact.height == 512
         assert deserialized_artifact.meta["model"] == "openai/dalle2"
         assert deserialized_artifact.meta["prompt"] == "a cute cat"
+
+    def test_name(self, image_artifact):
+        assert image_artifact.name.startswith("image_artifact_")
+        assert image_artifact.name.endswith(image_artifact.format)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Re-introduce the default behavior in which image and audio artifacts are given a human-readable name (with format file extension).

## Issue ticket number and link
#1307 
