### PR TITLE
Update task state enum to reflect new naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: Renamed `BaseTask.State.EXECUTING` to `BaseTask.State.RUNNING`.
+- **BREAKING**: Renamed `BaseTask.is_executing()` to `BaseTask.is_running()`.
+- **BREAKING**: Renamed `Structure.is_executing()` to `Structure.is_running()`.
 - Removed `azure-core` and `azure-storage-blob` dependencies.
 - `GriptapeCloudFileManagerDriver` no longer requires `drivers-file-manager-griptape-cloud` extra.
 

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -88,8 +88,8 @@ class Structure(RuleMixin, SerializableMixin, RunnableMixin["Structure"], ABC):
     def is_finished(self) -> bool:
         return all(s.is_finished() for s in self.tasks)
 
-    def is_executing(self) -> bool:
-        return any(s for s in self.tasks if s.is_executing())
+    def is_running(self) -> bool:
+        return any(s for s in self.tasks if s.is_running())
 
     def find_task(self, task_id: str) -> BaseTask:
         if (task := self.try_find_task(task_id)) is not None:

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(Defaults.logging_config.logger_name)
 class BaseTask(FuturesExecutorMixin, SerializableMixin, RunnableMixin["BaseTask"], ABC):
     class State(Enum):
         PENDING = 1
-        EXECUTING = 2
+        RUNNING = 2
         FINISHED = 3
 
     id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True, metadata={"serializable": True})
@@ -133,8 +133,8 @@ class BaseTask(FuturesExecutorMixin, SerializableMixin, RunnableMixin["BaseTask"
     def is_finished(self) -> bool:
         return self.state == BaseTask.State.FINISHED
 
-    def is_executing(self) -> bool:
-        return self.state == BaseTask.State.EXECUTING
+    def is_running(self) -> bool:
+        return self.state == BaseTask.State.RUNNING
 
     def before_run(self) -> None:
         super().before_run()
@@ -151,7 +151,7 @@ class BaseTask(FuturesExecutorMixin, SerializableMixin, RunnableMixin["BaseTask"
 
     def run(self) -> BaseArtifact:
         try:
-            self.state = BaseTask.State.EXECUTING
+            self.state = BaseTask.State.RUNNING
 
             self.before_run()
 

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -309,3 +309,14 @@ class TestAgent:
 
         mock_on_before_run.assert_called_once_with(agent)
         mock_after_run.assert_called_once_with(agent)
+
+    def test_is_running(self):
+        task = PromptTask("test prompt")
+        agent = Agent(prompt_driver=MockPromptDriver())
+        agent.add_task(task)
+
+        assert not agent.is_running()
+
+        task.state = BaseTask.State.RUNNING
+
+        assert agent.is_running()

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -207,3 +207,15 @@ class TestBaseTask:
         task.structure._execution_args = ("foo", "bar")
 
         assert task.full_context == {"args": ("foo", "bar"), "structure": task.structure}
+
+    def test_is_pending(self, task):
+        task.state = task.State.PENDING
+        assert task.is_pending()
+
+    def test_is_running(self, task):
+        task.state = task.State.RUNNING
+        assert task.is_running()
+
+    def test_is_finished(self, task):
+        task.state = task.State.FINISHED
+        assert task.is_finished()


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- **BREAKING**: Renamed `BaseTask.State.EXECUTING` to `BaseTask.State.RUNNING`.
## Issue ticket number and link
Offline discussion