### PR TITLE
Preserve decorated function's return type hint

### DIFF
--- a/griptape/common/decorators.py
+++ b/griptape/common/decorators.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar, cast
 
 import wrapt
 
+T = TypeVar("T")
 
-def observable(*dargs: Any, **dkwargs: Any) -> Any:
+
+def observable(*dargs: Any, **dkwargs: Any) -> Callable:
     @wrapt.decorator
-    def decorator(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
+    def decorator(wrapped: Callable[..., T], instance: Any, args: Any, kwargs: Any) -> T:
         from griptape.common.observable import Observable
         from griptape.observability.observability import Observability
 
-        return Observability.observe(
-            Observable.Call(
-                func=wrapped,
-                instance=instance,
-                args=args,
-                kwargs=kwargs,
-                decorator_args=dargs,
-                decorator_kwargs=dkwargs,
-            )
+        return cast(
+            T,
+            Observability.observe(
+                Observable.Call(
+                    func=wrapped,
+                    instance=instance,
+                    args=args,
+                    kwargs=kwargs,
+                    decorator_args=dargs,
+                    decorator_kwargs=dkwargs,
+                )
+            ),
         )
 
     # Check if it's being called as @observable or @observable(...)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Given:
![image](https://github.com/user-attachments/assets/f8fd0965-1ac1-4878-9f06-725edef4be61)

Before:
![image](https://github.com/user-attachments/assets/68a49d74-b6d3-42f5-9ee4-6b489f3cf93e)
After:
![image](https://github.com/user-attachments/assets/a671a818-74a1-462b-9b07-8254f05e3dc9)

## Issue ticket number and link
NA