### PR TITLE
Fix subtask before/after run methods running twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `ActionsSubtask.before_run` and `ActionsSubtask.after_run` being called twice in `ToolkitTask` and `Tooltask`.
+
 ## \[0.34.2\] - 2024-11-07
 
 ### Fixed
 
-- Restore human-friendly default `ImageArtifact` and `AudioArtifact` names with file type extension. 
+- Restore human-friendly default `ImageArtifact` and `AudioArtifact` names with file type extension.
 
 ## \[0.34.1\] - 2024-11-05
 

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -79,9 +79,7 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
         try:
             subtask = self.add_subtask(ActionsSubtask(subtask_input))
 
-            subtask.before_run()
             subtask.run()
-            subtask.after_run()
 
             if isinstance(subtask.output, ListArtifact):
                 first_artifact = subtask.output[0]

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -181,9 +181,7 @@ class ToolkitTask(PromptTask, ActionsSubtaskOriginMixin):
                 if len(self.subtasks) >= self.max_subtasks:
                     subtask.output = ErrorArtifact(f"Exceeded tool limit of {self.max_subtasks} subtasks per task")
                 else:
-                    subtask.before_run()
                     subtask.run()
-                    subtask.after_run()
 
                     result = self.prompt_driver.run(prompt_stack=self.prompt_stack)
                     subtask = self.add_subtask(ActionsSubtask(result.to_artifact()))


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
`BaseTask.run` calls these methods now.

### Fixed
- `ActionsSubtask.before_run` and `ActionsSubtask.after_run` being called twice in `ToolkitTask` and `Tooltask`.

## Issue ticket number and link
NA