### PR TITLE
Update path logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Removed `ImageQueryTask`, use `PromptTask` instead.
 - **BREAKING**: Updated `ImageQueryTool.image_query_driver` to `ImageQueryTool.prompt_driver`.
 - **BREAKING**: Updated `numpy` to `~2.0.2` and `pandas` to `^2.2`.
+- File Manager Driver path logic has been improved.
+  - `LocalFileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with the current working directory.
+  - `AmazonS3FileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with `/`.
+  - `GriptapeCloudFileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with `/`.
+  - Paths passed to `LocalFileManagerDriver` can now be relative or absolute. Absolute paths will be used as-is.
 - `BasePromptDriver.run` can now accept an Artifact in addition to a Prompt Stack.
 - Improved `CsvExtractionEngine` prompts.
 - Tweaked `PromptResponseRagModule` system prompt to yield answers more consistently.

--- a/griptape/drivers/file_manager/base_file_manager_driver.py
+++ b/griptape/drivers/file_manager/base_file_manager_driver.py
@@ -17,8 +17,16 @@ class BaseFileManagerDriver(ABC):
         loaders: Dictionary of file extension specific loaders to use for loading file contents into artifacts.
     """
 
-    workdir: str = field(kw_only=True)
+    _workdir: str = field(kw_only=True, alias="workdir")
     encoding: Optional[str] = field(default=None, kw_only=True)
+
+    @property
+    @abstractmethod
+    def workdir(self) -> str: ...
+
+    @workdir.setter
+    @abstractmethod
+    def workdir(self, value: str) -> None: ...
 
     def list_files(self, path: str) -> TextArtifact:
         entries = self.try_list_files(path)

--- a/griptape/loaders/base_file_loader.py
+++ b/griptape/loaders/base_file_loader.py
@@ -16,7 +16,7 @@ A = TypeVar("A", bound=BaseArtifact)
 @define
 class BaseFileLoader(BaseLoader[Union[str, PathLike], bytes, A], ABC):
     file_manager_driver: BaseFileManagerDriver = field(
-        default=Factory(lambda: LocalFileManagerDriver(workdir=None)),
+        default=Factory(lambda: LocalFileManagerDriver()),
         kw_only=True,
     )
     encoding: str = field(default="utf-8", kw_only=True)

--- a/tests/unit/drivers/file_manager/test_amazon_s3_file_manager_driver.py
+++ b/tests/unit/drivers/file_manager/test_amazon_s3_file_manager_driver.py
@@ -78,11 +78,6 @@ class TestAmazonS3FileManagerDriver:
 
         return _get_s3_value
 
-    @pytest.mark.parametrize("workdir", ["", ".", "foo", "foo/bar"])
-    def test_validate_workdir(self, workdir, session, bucket):
-        with pytest.raises(ValueError):
-            AmazonS3FileManagerDriver(session=session, bucket=bucket, workdir=workdir)
-
     @pytest.mark.parametrize(
         ("workdir", "path", "expected"),
         [
@@ -265,3 +260,10 @@ class TestAmazonS3FileManagerDriver:
 
         assert isinstance(result, TextArtifact)
         assert result.encoding == "ascii"
+
+    def test_workdir(self, driver):
+        assert driver.workdir == "/"
+        driver.workdir = "/new"
+        assert driver.workdir == "/new"
+        driver.workdir = "new"
+        assert driver.workdir == "/new"

--- a/tests/unit/drivers/file_manager/test_base_file_manager_driver.py
+++ b/tests/unit/drivers/file_manager/test_base_file_manager_driver.py
@@ -7,6 +7,14 @@ from griptape.drivers import BaseFileManagerDriver
 
 
 class MockFileManagerDriver(BaseFileManagerDriver):
+    @property
+    def workdir(self) -> str:
+        return self._workdir
+
+    @workdir.setter
+    def workdir(self, value: str) -> None:
+        self._workdir = value
+
     def try_list_files(self, path: str) -> list[str]:
         return ["foo", "bar"]
 
@@ -36,3 +44,8 @@ class TestBaseFileManagerDriver:
         response = driver.save_artifact("foo", TextArtifact(value="value"))
 
         assert response.value == "Successfully saved artifact at: mock_save_location"
+
+    def test_workir(self, driver):
+        assert driver.workdir == "/"
+        driver.workdir = "/new"
+        assert driver.workdir == "/new"

--- a/tests/unit/drivers/file_manager/test_griptape_cloud_file_manager_driver.py
+++ b/tests/unit/drivers/file_manager/test_griptape_cloud_file_manager_driver.py
@@ -16,6 +16,15 @@ class TestGriptapeCloudFileManagerDriver:
 
         return GriptapeCloudFileManagerDriver(base_url="https://api.griptape.ai", api_key="foo bar", bucket_id="1")
 
+    def test_workdir(self, driver):
+        assert driver.workdir == "/"
+
+        driver.workdir = "/new"
+        assert driver.workdir == "/new"
+
+        driver.workdir = "new"
+        assert driver.workdir == "/new"
+
     def test_instantiate_bucket_id(self, mocker):
         from griptape.drivers import GriptapeCloudFileManagerDriver
 
@@ -53,15 +62,6 @@ class TestGriptapeCloudFileManagerDriver:
 
         with pytest.raises(ValueError, match="GriptapeCloudFileManagerDriver requires an API key"):
             GriptapeCloudFileManagerDriver(bucket_id="1")
-
-    def test_instantiate_invalid_work_dir(self):
-        from griptape.drivers import GriptapeCloudFileManagerDriver
-
-        with pytest.raises(
-            ValueError,
-            match="GriptapeCloudFileManagerDriver requires 'workdir' to be an absolute path, starting with `/`",
-        ):
-            GriptapeCloudFileManagerDriver(api_key="foo bar", bucket_id="1", workdir="no_slash")
 
     def test_try_list_files(self, mocker, driver):
         mock_response = mocker.Mock()


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- File Manager Driver path logic has been improved.
  - `LocalFileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with the current working directory.
  - `AmazonS3FileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with `/`.
  - `GriptapeCloudFileManagerDriver.workdir` can now be a relative path or absolute path. Relative paths will be prefixed with `/`.
  - Paths passed to `LocalFileManagerDriver` can now be relative or absolute. Absolute paths will be used as-is.

## Issue ticket number and link
Closes #1351 