### PR TITLE
Add converstion memory per task run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `PromptTask.conversation_memory` for setting the Conversation Memory on a Prompt Task.
+- `Structure.conversation_memory_strategy` for setting whether Conversation Memory Runs should be created on a per-Structure or per-Task basis. Default is `Structure.ConversationMemoryStrategy.PER_STRUCTURE`.
+
 ## [1.0.0] - 2024-12-09
 
 ### Added

--- a/docs/griptape-framework/structures/conversation-memory.md
+++ b/docs/griptape-framework/structures/conversation-memory.md
@@ -32,6 +32,34 @@ You can disable conversation memory in any structure by setting it to `None`:
 --8<-- "docs/griptape-framework/structures/src/conversation_memory_2.py"
 ```
 
+### Interaction With Structures
+
+#### Per Structure
+
+By default, Conversation Memory [Runs](../../reference/griptape/memory/structure/run.md) are created for each run of the structure. Griptape takes the Structure's [input_task](../../reference/griptape/structures/structure.md#griptape.structures.Structure.input_task)'s input and the [output_task](../../reference/griptape/structures/structure.md#griptape.structures.Structure.output_task)'s output, storing them in the Run. Tasks that are neither the input task nor the output task are not stored in the Run.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/conversation_memory_per_structure.py"
+```
+
+In this example, the `improve` Task is "forgotten" after the Structure's run is finished. This approach allows you to perform intermediary work within a Structure without it being stored in, and potentially cluttering, Conversation Memory.
+
+#### Per Task
+
+You can change when Conversation Memory Runs are created by modifying [Structure.conversation_memory_strategy](../../reference/griptape/structures/structure.md#griptape.structures.Structure.conversation_memory_strategy) from the default [PER_STRUCTURE](../../reference/griptape/structures/structure.md#griptape.structures.structure.ConversationMemoryStrategy.PER_STRUCTURE) to [PER_TASK](../../reference/griptape/structures/structure.md#griptape.structures.structure.ConversationMemoryStrategy.PER_TASK).
+
+```python
+--8<-- "docs/griptape-framework/structures/src/conversation_memory_per_task.py"
+```
+
+Now, each _Task_ creates a Conversation Memory Run when it runs. This eliminates the need to feed the output of Tasks into each other using context variables like `{{ parent_output }}` since the output of the previous Task is stored in Conversation Memory and loaded when the next Task runs.
+
+To blend the two approaches, you can disable Conversation Memory on individual tasks by setting [PromptTask.conversation_memory](../../reference/griptape/tasks/prompt_task.md#griptape.tasks.PromptTask.conversation_memory) to `None`.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/conversation_memory_per_task_with_none.py"
+```
+
 ## Types of Memory
 
 Griptape provides several types of Conversation Memory to fit various use-cases.

--- a/docs/griptape-framework/structures/src/conversation_memory_per_structure.py
+++ b/docs/griptape-framework/structures/src/conversation_memory_per_structure.py
@@ -1,0 +1,18 @@
+from griptape.structures import Pipeline
+from griptape.tasks import PromptTask
+
+pipeline = Pipeline(
+    tasks=[
+        PromptTask("Respond to this request: {{ args[0] }}", id="input"),
+        PromptTask("Improve the writing of this: {{ parent_output }}", id="improve"),
+        PromptTask("Output this as a pirate: {{ parent_output }}", id="output"),
+    ]
+)
+
+pipeline.run("My favorite animal is a Liger.")
+
+if pipeline.conversation_memory is not None:
+    for run in pipeline.conversation_memory.runs:
+        print("Input", run.input.value)
+        print("Output", run.output.value)
+        print("\n\n")

--- a/docs/griptape-framework/structures/src/conversation_memory_per_task.py
+++ b/docs/griptape-framework/structures/src/conversation_memory_per_task.py
@@ -1,0 +1,19 @@
+from griptape.structures import Pipeline
+from griptape.tasks import PromptTask
+
+pipeline = Pipeline(
+    conversation_memory_strategy=Pipeline.ConversationMemoryStrategy.PER_TASK,
+    tasks=[
+        PromptTask("Respond to this request: {{ args[0] }}", id="input"),
+        PromptTask("Improve the writing", id="improve"),
+        PromptTask("Respond as a pirate", id="output"),
+    ],
+)
+
+pipeline.run("My favorite animal is a Liger.")
+
+if pipeline.conversation_memory is not None:
+    for run in pipeline.conversation_memory.runs:
+        print("Input", run.input.value)
+        print("Output", run.output.value)
+        print("\n\n")

--- a/docs/griptape-framework/structures/src/conversation_memory_per_task_with_disabled.py
+++ b/docs/griptape-framework/structures/src/conversation_memory_per_task_with_disabled.py
@@ -1,0 +1,19 @@
+from griptape.structures import Pipeline
+from griptape.tasks import PromptTask
+
+pipeline = Pipeline(
+    conversation_memory_strategy=Pipeline.ConversationMemoryStrategy.PER_TASK,
+    tasks=[
+        PromptTask("Respond to this request: {{ args[0] }}", id="input"),
+        PromptTask("Improve the writing of this: {{ parent_output }}", id="improve", conversation_memory=None),
+        PromptTask("Respond as a pirate", id="output"),
+    ],
+)
+
+pipeline.run("My favorite animal is a Liger.")
+
+if pipeline.conversation_memory is not None:
+    for run in pipeline.conversation_memory.runs:
+        print("Input", run.input.value)
+        print("Output", run.output.value)
+        print("\n\n")

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -208,6 +208,7 @@ class BaseSchema(Schema):
                 "Sequence": Sequence,
                 "TaskMemory": TaskMemory,
                 "State": BaseTask.State,
+                "ConversationMemoryStrategy": Structure.ConversationMemoryStrategy,
                 "BaseConversationMemory": BaseConversationMemory,
                 "BaseArtifactStorage": BaseArtifactStorage,
                 # Third party modules

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -279,6 +279,7 @@ class TestAgent:
                 "meta": agent.conversation_memory.meta,
                 "max_runs": agent.conversation_memory.max_runs,
             },
+            "conversation_memory_strategy": str(agent.conversation_memory_strategy),
         }
         assert agent.to_dict() == expected_agent_dict
 

--- a/tests/unit/structures/test_pipeline.py
+++ b/tests/unit/structures/test_pipeline.py
@@ -436,6 +436,7 @@ class TestPipeline:
                 "meta": pipeline.conversation_memory.meta,
                 "max_runs": pipeline.conversation_memory.max_runs,
             },
+            "conversation_memory_strategy": str(pipeline.conversation_memory_strategy),
             "fail_fast": pipeline.fail_fast,
         }
         assert pipeline.to_dict() == expected_pipeline_dict

--- a/tests/unit/structures/test_structure.py
+++ b/tests/unit/structures/test_structure.py
@@ -1,6 +1,7 @@
 import pytest
 
-from griptape.structures import Agent, Pipeline
+from griptape.structures import Agent, Pipeline, Structure
+from griptape.tasks import PromptTask
 
 
 class TestStructure:
@@ -16,3 +17,40 @@ class TestStructure:
             ValueError, match="Structure's output Task has no output. Run the Structure to generate output."
         ):
             assert agent.output
+
+    def test_conversation_mode_per_structure(self):
+        pipeline = Pipeline(
+            conversation_memory_strategy=Structure.ConversationMemoryStrategy.PER_STRUCTURE,
+            tasks=[PromptTask("1"), PromptTask("2")],
+        )
+
+        pipeline.run()
+        assert pipeline.conversation_memory is not None
+        assert len(pipeline.conversation_memory.runs) == 1
+        assert pipeline.conversation_memory.runs[0].input.value == "1"
+        assert pipeline.conversation_memory.runs[0].output.value == "mock output"
+
+    def test_conversation_mode_per_task(self):
+        pipeline = Pipeline(
+            conversation_memory_strategy=Structure.ConversationMemoryStrategy.PER_TASK,
+            tasks=[PromptTask("1"), PromptTask("2")],
+        )
+
+        pipeline.run()
+        assert pipeline.conversation_memory is not None
+        assert len(pipeline.conversation_memory.runs) == 2
+        assert pipeline.conversation_memory.runs[0].input.value == "1"
+        assert pipeline.conversation_memory.runs[0].output.value == "mock output"
+        assert pipeline.conversation_memory.runs[1].input.value == "2"
+        assert pipeline.conversation_memory.runs[1].output.value == "mock output"
+
+    def test_conversation_mode_per_task_no_memory(self):
+        pipeline = Pipeline(
+            conversation_memory_strategy=Structure.ConversationMemoryStrategy.PER_TASK,
+            tasks=[PromptTask(conversation_memory=None), PromptTask("2")],
+        )
+
+        pipeline.run()
+        assert pipeline.conversation_memory is not None
+        assert len(pipeline.conversation_memory.runs) == 1
+        assert pipeline.conversation_memory.runs[0].input.value == "2"

--- a/tests/unit/structures/test_workflow.py
+++ b/tests/unit/structures/test_workflow.py
@@ -1004,6 +1004,7 @@ class TestWorkflow:
                 "meta": workflow.conversation_memory.meta,
                 "max_runs": workflow.conversation_memory.max_runs,
             },
+            "conversation_memory_strategy": str(workflow.conversation_memory_strategy),
             "fail_fast": workflow.fail_fast,
         }
         assert workflow.to_dict() == expected_workflow_dict


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `PromptTask.conversation_memory` for setting the Conversation Memory on a Prompt Task.

## Issue ticket number and link
NA