### PR TITLE
Fix `with_contextvars` not properly wrapping functions in some cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error when serializing `JsonArtifact`s.
 - `GriptapeCloudVectorStoreDriver` not pulling `api_key` from `GT_CLOUD_API_KEY` environment variable.
 - `MarqoVectorStoreDriver.query` failing when `include_metadata` is `True`.
+- `with_contextvars` not properly wrapping functions in some cases.
 
 ## [0.34.3] - 2024-11-13
 

--- a/griptape/utils/contextvars_utils.py
+++ b/griptape/utils/contextvars_utils.py
@@ -1,9 +1,11 @@
 import contextvars
-import functools
-from typing import Callable
+from typing import Any, Callable
 
 
 def with_contextvars(wrapped: Callable) -> Callable:
     ctx = contextvars.copy_context()
 
-    return functools.partial(ctx.run, wrapped)
+    def wrapper(*args, **kwargs) -> Any:
+        return ctx.run(wrapped, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Fixed
- `with_contextvars` not properly wrapping functions in some cases.

The old implementation had some issues with wrapping some gradio functions, presumably because `functools.partial` fixes the arguments. This new implementation has a bit less magic and fixes the issue.

While it strongly resembles a decorator, that is a whole rabbit hole I don't want to go back down.
## Issue ticket number and link
Closes upcoming issue