### PR TITLE
Fix kwarg injection default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MarqoVectorStoreDriver.query` failing when `include_metadata` is `True`.
 - `with_contextvars` not properly wrapping functions in some cases.
 - Crash when calling `ToolkitTask.run()` directly.
-- Support default values using kwarg injection on `@activity` methods.
+- `@activity` decorator overwriting injected kwargs with default values as `None`.
 
 ## [0.34.3] - 2024-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MarqoVectorStoreDriver.query` failing when `include_metadata` is `True`.
 - `with_contextvars` not properly wrapping functions in some cases.
 - Crash when calling `ToolkitTask.run()` directly.
+- Support default values using kwarg injection on `@activity` methods.
 
 ## [0.34.3] - 2024-11-13
 

--- a/griptape/utils/decorators.py
+++ b/griptape/utils/decorators.py
@@ -83,8 +83,8 @@ def _build_kwargs(func: Callable, params: dict) -> dict:
         kwargs["values"] = params.get("values")
 
     # set any missing parameters to None
-    for param_name in func_params:
-        if param_name not in kwargs:
+    for param_name, param in func_params.items():
+        if param_name not in kwargs and param.default == inspect.Parameter.empty:
             kwargs[param_name] = None
 
     return kwargs

--- a/tests/mocks/mock_tool_kwargs/tool.py
+++ b/tests/mocks/mock_tool_kwargs/tool.py
@@ -13,7 +13,9 @@ class MockToolKwargs(BaseTool):
             "schema": Schema({Literal("test_kwarg"): str}, description="Test input"),
         }
     )
-    def test_with_kwargs(self, params: dict, test_kwarg: str, test_kwarg_none: None, **kwargs) -> str:
+    def test_with_kwargs(
+        self, params: dict, test_kwarg: str, test_kwarg_none: None, default_str_param: str = "default", **kwargs
+    ) -> str:
         if test_kwarg_none is not None:
             raise ValueError("test_kwarg_none should be None")
         if "test_kwarg_kwargs" not in kwargs:
@@ -22,4 +24,6 @@ class MockToolKwargs(BaseTool):
             raise ValueError("values not in params")
         if "test_kwarg" not in params["values"]:
             raise ValueError("test_kwarg not in params")
+        if default_str_param != "default":
+            raise ValueError("default_str_param not default")
         return f"ack {test_kwarg}"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
the activity decorator currently overwrites default values with `None` if they are not passed to the activity.
context from below:

currently if you defined a schema with 3 params: `foo` , `bar`, `baz`, and your activity method was defined as:
```
@activity(...)
def activity_method(foo: str, bar: str, baz: str = "default"): ...
```
and the input looked like:
```
{
  "values": {
    "foo": "some_foo",
    "bar": "some_bar"
  },
}
```
the decorator would set `baz=None` rather than keeping the default that was defined on the method signature

## Issue ticket number and link
