### PR TITLE
Fix Duplicate Rulesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `with_contextvars` not properly wrapping functions in some cases.
 - Crash when calling `ToolkitTask.run()` directly.
 - `@activity` decorator overwriting injected kwargs with default values as `None`.
+- Multiple calls to `RuleMixin.rulesets` resulting in duplicate Rulesets.
 
 ## [0.34.3] - 2024-11-13
 

--- a/griptape/mixins/rule_mixin.py
+++ b/griptape/mixins/rule_mixin.py
@@ -14,7 +14,7 @@ class RuleMixin:
 
     @property
     def rulesets(self) -> list[Ruleset]:
-        rulesets = self._rulesets
+        rulesets = self._rulesets.copy()
 
         if self.rules:
             rulesets.append(Ruleset(name=self.DEFAULT_RULESET_NAME, rules=self.rules))

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -36,7 +36,7 @@ class PromptTask(RuleMixin, BaseTask):
     @property
     def rulesets(self) -> list:
         default_rules = self.rules
-        rulesets = self._rulesets
+        rulesets = self._rulesets.copy()
 
         if self.structure is not None:
             if self.structure._rulesets:

--- a/tests/unit/mixins/test_rule_mixin.py
+++ b/tests/unit/mixins/test_rule_mixin.py
@@ -19,6 +19,8 @@ class TestRuleMixin:
         mixin = RuleMixin(rulesets=[ruleset])
 
         assert mixin.rulesets == [ruleset]
+        mixin.rulesets.append(Ruleset("baz", [Rule("qux")]))
+        assert mixin.rulesets == [ruleset]
 
     def test_rules_and_rulesets(self):
         mixin = RuleMixin(rules=[Rule("foo")], rulesets=[Ruleset("bar", [Rule("baz")])])

--- a/tests/unit/tasks/test_prompt_task.py
+++ b/tests/unit/tasks/test_prompt_task.py
@@ -4,6 +4,7 @@ from griptape.artifacts.text_artifact import TextArtifact
 from griptape.memory.structure import ConversationMemory
 from griptape.memory.structure.run import Run
 from griptape.rules import Rule
+from griptape.rules.ruleset import Ruleset
 from griptape.structures import Pipeline
 from griptape.tasks import PromptTask
 from tests.mocks.mock_prompt_driver import MockPromptDriver
@@ -169,3 +170,22 @@ class TestPromptTask:
         assert task.prompt_stack.messages[1].to_text() == "output"
         assert task.prompt_stack.messages[2].is_user()
         assert task.prompt_stack.messages[2].to_text() == "test value"
+
+    def test_rulesets(self):
+        pipeline = Pipeline(
+            rulesets=[Ruleset("Pipeline Ruleset")],
+            rules=[Rule("Pipeline Rule")],
+        )
+        task = PromptTask(rulesets=[Ruleset("Task Ruleset")], rules=[Rule("Task Rule")])
+
+        pipeline.add_task(task)
+
+        assert len(task.rulesets) == 3
+        assert task.rulesets[0].name == "Pipeline Ruleset"
+        assert task.rulesets[1].name == "Task Ruleset"
+        assert task.rulesets[2].name == "Default Ruleset"
+
+        assert len(task.rulesets[0].rules) == 0
+        assert len(task.rulesets[1].rules) == 0
+        assert task.rulesets[2].rules[0].value == "Pipeline Rule"
+        assert task.rulesets[2].rules[1].value == "Task Rule"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Fixed
- Multiple calls to `RuleMixin.rulesets` resulting in duplicate Rulesets.
## Issue ticket number and link
NA