### PR TITLE
Don't pop off "query" from params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when calling `ToolkitTask.run()` directly.
 - `@activity` decorator overwriting injected kwargs with default values as `None`.
 - Multiple calls to `RuleMixin.rulesets` resulting in duplicate Rulesets.
+- `WebSearchTool` popping off `query` from its parameters.
 
 ## [0.34.3] - 2024-11-13
 

--- a/griptape/tools/web_search/tool.py
+++ b/griptape/tools/web_search/tool.py
@@ -31,7 +31,7 @@ class WebSearchTool(BaseTool):
         },
     )
     def search(self, values: dict) -> ListArtifact | ErrorArtifact:
-        query = values.pop("query")
+        query = values["query"]
 
         try:
             return self.web_search_driver.search(query, **values)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Fixed
- `WebSearchTool` popping off `query` from its parameters.
## Issue ticket number and link
https://discord.com/channels/1096466116672487547/1105169591619027055/1312928454613799024