### PR TITLE
Remove `parallel_tool_calls` in AzureOpenAiPromptDriver

### DIFF
--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -60,5 +60,7 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
         # TODO: Add `stream_options` parameter once Azure supports it.
         if "stream_options" in params:
             del params["stream_options"]
-
+        # TODO: Add `parallel_tool_calls` parameter once Azure supports it.
+        if "parallel_tool_calls" in params:
+            del params["parallel_tool_calls"]
         return params

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -89,7 +89,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             **{
                 "tools": self.OPENAI_TOOLS,
                 "tool_choice": driver.tool_choice,
-                "parallel_tool_calls": driver.parallel_tool_calls,
             }
             if use_native_tools
             else {},
@@ -129,7 +128,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             **{
                 "tools": self.OPENAI_TOOLS,
                 "tool_choice": driver.tool_choice,
-                "parallel_tool_calls": driver.parallel_tool_calls,
             }
             if use_native_tools
             else {},


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
remove parallel_tool_calls from the api call

## Issue ticket number and link
https://github.com/Azure/azure-rest-api-specs/issues/29545