### PR TITLE
Render StructureRunTasks in StructureVisualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OpenAiAssistantDriver` for interacting with OpenAI's Assistant API.
 - `GriptapeCloudToolTool` for running Griptape Cloud hosted Tools.
 - `JsonLoader` for loading and parsing JSON files.
+- `StructureVisualizer.build_node_id` field for customizing the node ID.
 
 ### Changed
 
@@ -84,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TrafilaturaWebScraperDriver` no longer sets `no_ssl` to `True` by default.
 - `AmazonBedrockPromptDriver` not working without setting `max_tokens`.
 - `BaseImageGenerationTask` no longer prevents setting `negative_rulesets` _and_ `negative_rules` at the same time.
+- `StructureVisualizer` now renders `StructureRunTask`s with a `LocalStructureRunDriver`.
+- `StructureVisualizer` to titlecase the node IDs to avoid Mermaid.js reserved keywords.
 
 ### Fixed
 

--- a/tests/unit/utils/test_structure_visualizer.py
+++ b/tests/unit/utils/test_structure_visualizer.py
@@ -1,5 +1,6 @@
+from griptape.drivers import LocalStructureRunDriver
 from griptape.structures import Agent, Pipeline, Workflow
-from griptape.tasks import PromptTask
+from griptape.tasks import PromptTask, StructureRunTask
 from griptape.utils import StructureVisualizer
 
 
@@ -10,7 +11,7 @@ class TestStructureVisualizer:
         visualizer = StructureVisualizer(agent)
         result = visualizer.to_url()
 
-        assert result == "https://mermaid.ink/svg/Z3JhcGggVEQ7CgljYzVkYWYyNih0YXNrMSk7"
+        assert result == "https://mermaid.ink/svg/Z3JhcGggVEQ7CglUYXNrMTs="
 
     def test_pipeline(self):
         pipeline = Pipeline(
@@ -27,7 +28,7 @@ class TestStructureVisualizer:
 
         assert (
             result
-            == "https://mermaid.ink/svg/Z3JhcGggVEQ7CgljYzVkYWYyNih0YXNrMSktLT4gYWE1ZGU4N2UodGFzazIpOwoJYWE1ZGU4N2UodGFzazIpLS0+IDUxZmViYjIxKHRhc2szKTsKCTUxZmViYjIxKHRhc2szKS0tPiBhN2JlMzY4Yih0YXNrNCk7CglhN2JlMzY4Yih0YXNrNCk7"
+            == "https://mermaid.ink/svg/Z3JhcGggVEQ7CglUYXNrMS0tPiBUYXNrMjsKCVRhc2syLS0+IFRhc2szOwoJVGFzazMtLT4gVGFzazQ7CglUYXNrNDs="
         )
 
     def test_workflow(self):
@@ -45,5 +46,36 @@ class TestStructureVisualizer:
 
         assert (
             result
-            == "https://mermaid.ink/svg/Z3JhcGggVEQ7CgljYzVkYWYyNih0YXNrMSktLT4gYWE1ZGU4N2UodGFzazIpICYgNTFmZWJiMjEodGFzazMpOwoJYWE1ZGU4N2UodGFzazIpLS0+IGE3YmUzNjhiKHRhc2s0KTsKCTUxZmViYjIxKHRhc2szKS0tPiBhN2JlMzY4Yih0YXNrNCk7CglhN2JlMzY4Yih0YXNrNCk7"
+            == "https://mermaid.ink/svg/Z3JhcGggVEQ7CglUYXNrMS0tPiBUYXNrMiAmIFRhc2szOwoJVGFzazItLT4gVGFzazQ7CglUYXNrMy0tPiBUYXNrNDsKCVRhc2s0Ow=="
         )
+
+    def test_structure_run_task(self):
+        pipeline = Pipeline(
+            tasks=[
+                PromptTask("test1", id="task1"),
+                StructureRunTask(
+                    "test2",
+                    structure_run_driver=LocalStructureRunDriver(
+                        create_structure=lambda: Pipeline(
+                            tasks=[
+                                PromptTask("test2a", id="task2a"),
+                                PromptTask("test2b", id="task2b"),
+                            ],
+                        )
+                    ),
+                    id="task2",
+                ),
+                PromptTask("test3", id="task3"),
+            ],
+        )
+
+        visualizer = StructureVisualizer(pipeline)
+        result = visualizer.to_url()
+
+        assert (
+            result
+            == "https://mermaid.ink/svg/Z3JhcGggVEQ7CglUYXNrMS0tPiBUYXNrMjsKCVRhc2syLS0+IFRhc2szOwoJc3ViZ3JhcGggVGFzazIKCVRhc2syQS0tPiBUYXNrMkI7CglUYXNrMkI7CgllbmQKCVRhc2szOw=="
+        )
+
+    def test_build_node_id(self):
+        assert StructureVisualizer(Pipeline()).build_node_id(PromptTask("test1", id="test1")) == "Test1"


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- `StructureVisualizer.build_node_id` field for customizing the node ID.
### Changed
- `StructureVisualizer` now renders `StructureRunTask`s with a `LocalStructureRunDriver`.
- `StructureVisualizer` to titlecase the node IDs to avoid Mermaid.js reserved keywords.

Slightly changes the implementation of https://github.com/griptape-ai/griptape/pull/936 since this caused issues with subgraphs. 

## Issue ticket number and link
NA

---
Example (and sneak peak of upcoming feature 👀) 
![Z3JhcGggVEQ7CglHZXRfSW5pdGlhbF9JbnB1dC0tPiBBZ2VudDsKCUdldF9JbnB1dC0tPiBQcm9jZXNzX0lucHV0OwoJUHJvY2Vzc19JbnB1dC0tPiBBZ2VudCAmIEVuZDsKCUFnZW50LS0+IEdldF9JbnB1dDsKCXN1YmdyYXBoIEFnZW50CglSZXNwb25kLS0+IFJld29yZDsKCVJld29yZDsKCWVuZAoJRW5kOw==](https://github.com/user-attachments/assets/196c7381-0028-46c4-809b-c5a149e76e3c)