### PR TITLE
Tag with v in front of semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ version: ## Bump version and push to release branch.
 
 .PHONY: publish
 publish: ## Push git tag and publish version to PyPI.
-	@git tag $$(poetry version -s)
+	@git tag v$$(poetry version -s)
 	@git push --tags
 	@poetry build
 	@poetry publish


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
Reverts https://github.com/griptape-ai/griptape/pull/879 since [RTD now supports a v prefix](https://docs.readthedocs.io/en/stable/versions.html#versions-are-git-tags-and-branches), and semver [suggests it](https://semver.org/#is-v123-a-semantic-version) for git tags.

Already went through old tags and updated them to have a `v` (weird release notifications).
## Issue ticket number and link
NA