### PR TITLE
Update CHANGELOG.md to fix link to the aws extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `GoogleDocsTool`
   - `GoogleDriveTool`
   - `GoogleGmailTool`
-- **BREAKING**: Moved the following AWS Tools to the [Griptape AWS Extension](https://github.com/griptape-ai/griptape-google):
+- **BREAKING**: Moved the following AWS Tools to the [Griptape AWS Extension](https://github.com/griptape-ai/griptape-aws):
   - `AwsCliTool`
   - `AwsIamTool`
   - `AwsPricingTool`


### PR DESCRIPTION
This was incorrectly pointing at the Google Cloud extension

☑️ I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

the link was incorrectly pointing at the google cloud extension

## Issue ticket number and link
