### PR TITLE
Loosen `numpy`s version constraint to `>=1.26.4`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ToolkitTask` now serializes its `tools` field.
 - `PromptTask.prompt_driver` is now serialized.
 - `PromptTask` can now do everything a `ToolkitTask` can do.
+- Loosten `numpy`s version constraint to `>=1.26.4,<3`.
 
 ### Fixed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7209,4 +7209,4 @@ loaders-sql = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "479cade7f680bd843ad7f34b670af18852964b47556749a2e157c0f518fc4112"
+content-hash = "1841e2589572c62261db2eaf398929efdea7f85da062202c3a1ceaf587b2b78e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ rich = "^13.7.1"
 schema = "^0.7.7"
 pyyaml = "^6.0.1"
 tenacity = "^8.5.0"
-numpy = "~2.0.2"
+numpy = ">=1.26.4,<3"
 requests = "^2.32.0"
 filetype = "^1.2"
 urllib3 = ">=1.25.4,!=2.2.0,<3" # Version constraint required for botocore https://github.com/boto/botocore/pull/3141


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Changed
- Loosen `numpy`s version constraint to `>=1.26.4,<3`.
## Issue ticket number and link
Closes #1482 