### PR TITLE
Clean up Agent initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `GenericMessageContent` in `AnthropicPromptDriver` and `AmazonBedrockPromptDriver`.
 - Validators to `Agent` initialization.
 
-
 ### Changed
 
 - Rulesets can now be serialized and deserialized.
@@ -38,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing `ActionCallDeltaMessageContent`s with empty string `partial_input`s.
 - `Stream` util not properly propagating thread contextvars.
 - `ValueError` with `DuckDuckGoWebSearchDriver`.
+- `Agent.stream` overriding `Agent.prompt_driver.stream` even when `Agent.prompt_driver` is explicitly provided.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BaseFileLoader.save()` method for saving an Artifact to a destination.
 - `Structure.run_stream()` for streaming Events from a Structure as an iterator.
 - Support for `GenericMessageContent` in `AnthropicPromptDriver` and `AmazonBedrockPromptDriver`.
+- Validators to `Agent` initialization.
+
 
 ### Changed
 

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -286,10 +286,6 @@ class TestAgent:
         assert agent.tasks[0].prompt_driver.stream is False
         assert agent.tasks[0].prompt_driver is not prompt_driver
 
-    def test_validate_stream(self):
-        with pytest.warns(UserWarning, match="`Agent.stream` is set, but `Agent.prompt_driver` was provided."):
-            Agent(stream=True, prompt_driver=MockPromptDriver())
-
     def test_validate_prompt_driver(self):
         with pytest.warns(UserWarning, match="`Agent.prompt_driver` is set, but `Agent.stream` was provided."):
             Agent(stream=True, prompt_driver=MockPromptDriver())
@@ -298,17 +294,20 @@ class TestAgent:
         with pytest.warns(UserWarning, match="`Agent.tasks` is set, but `Agent.prompt_driver` was provided."):
             Agent(prompt_driver=MockPromptDriver(), tasks=[PromptTask()])
 
-    def test_sugar_fields(self):
+    def test_field_hierarchy(self):
+        # Test that stream on its own propagates to the task.
         agent = Agent(stream=True)
 
         assert isinstance(agent.tasks[0], PromptTask)
         assert agent.tasks[0].prompt_driver.stream is True
 
+        # Test that stream does not propagate to the prompt driver if explicitly provided
         agent = Agent(stream=True, prompt_driver=MockPromptDriver())
 
         assert isinstance(agent.tasks[0], PromptTask)
         assert agent.tasks[0].prompt_driver.stream is False
 
+        # Test that neither stream nor prompt driver propagate to the task if explicitly provided
         agent = Agent(
             stream=False,
             prompt_driver=MockPromptDriver(stream=False),

--- a/tests/unit/utils/test_stream.py
+++ b/tests/unit/utils/test_stream.py
@@ -10,27 +10,35 @@ from tests.mocks.mock_tool.tool import MockTool
 
 
 class TestStream:
-    @pytest.fixture(params=[True, False])
-    def agent(self, request):
-        driver = MockPromptDriver(
-            use_native_tools=request.param,
-        )
-        return Agent(stream=request.param, tools=[MockTool()], prompt_driver=driver)
-
-    def test_init(self, agent):
+    @pytest.mark.parametrize("stream", [True, False])
+    @pytest.mark.parametrize("use_native_tools", [True, False])
+    def test_init(self, stream, use_native_tools):
+        prompt_driver = MockPromptDriver(use_native_tools=use_native_tools, stream=stream)
+        agent = Agent(tools=[MockTool()], prompt_driver=prompt_driver)
         chat_stream = Stream(agent)
-        if agent.stream:
-            assert chat_stream.structure == agent
-            chat_stream_run = chat_stream.run()
-            assert isinstance(chat_stream_run, Iterator)
-            assert next(chat_stream_run).value == "MockTool.mock-tag (test)"
-            assert next(chat_stream_run).value == json.dumps({"values": {"test": "test-value"}}, indent=2)
-            next(chat_stream_run)
-            assert next(chat_stream_run).value == "Answer: mock output"
-            next(chat_stream_run)
-            with pytest.raises(StopIteration):
+
+        chat_stream_run = chat_stream.run()
+        assert chat_stream.structure == agent
+        assert isinstance(chat_stream_run, Iterator)
+        if prompt_driver.stream:
+            if use_native_tools:
+                assert next(chat_stream_run).value == "MockTool.mock-tag (test)"
+                assert next(chat_stream_run).value == json.dumps({"values": {"test": "test-value"}}, indent=2)
                 next(chat_stream_run)
+                assert next(chat_stream_run).value == "Answer: mock output"
+                next(chat_stream_run)
+                with pytest.raises(StopIteration):
+                    next(chat_stream_run)
+            else:
+                assert next(chat_stream_run).value == "mock output"
         else:
-            assert next(chat_stream.run()).value == "\n"
-            with pytest.raises(StopIteration):
-                next(chat_stream.run())
+            # MockPromptDriver produces some extra events because it simulates CoT when using native tools.
+            if use_native_tools:
+                assert next(chat_stream_run).value == "\n"
+                assert next(chat_stream_run).value == "\n"
+                with pytest.raises(StopIteration):
+                    next(chat_stream_run)
+            else:
+                assert next(chat_stream_run).value == "\n"
+                with pytest.raises(StopIteration):
+                    next(chat_stream_run)


### PR DESCRIPTION
- [x] I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes
### Added
- Validators to `Agent` initialization.
### Fixed
- `Agent.stream` overriding `Agent.prompt_driver.stream` even when `Agent.prompt_driver` is explicitly provided.

## Issue ticket number and link
Closes #1490 