### PR TITLE
Fixing incorrect headings reported in issue #1505

### DIFF
--- a/docs/griptape-framework/structures/agents.md
+++ b/docs/griptape-framework/structures/agents.md
@@ -11,7 +11,7 @@ directly, which the agent uses to add a [Prompt Task](./tasks.md#prompt-task).
 
 You can access the final output of the Agent by using the [output](../../reference/griptape/structures/structure.md#griptape.structures.structure.Structure.output) attribute.
 
-### Agent Input
+### Agent Tools
 
 ```python
 --8<-- "docs/griptape-framework/structures/src/agents_2.py"
@@ -26,7 +26,7 @@ You can access the final output of the Agent by using the [output](../../referen
                              In binary, we ignite.
 ```
 
-### Agent Tools
+### Agent Input
 
 ```python
 --8<-- "docs/griptape-framework/structures/src/agents_1.py"


### PR DESCRIPTION
☑️ I have read and agree to the contributing guidelines for [submitting new pull requests](https://github.com/griptape-ai/griptape?tab=readme-ov-file#submitting-pull-requests).

## Describe your changes

Switched the headings so they correctly reflect the sample code underneath each heading. They were previously transposed.

## Issue ticket number and link

Closes #1505 


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1506.org.readthedocs.build//1506/

<!-- readthedocs-preview griptape end -->