### PR TITLE
Add missing namespace in query entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Occasional crash during `FuturesExecutorMixin` cleanup.
 - `BaseChunker` chunking more than necessary.
 - `BaseLoader.reference` not being set when using `BaseLoader.parse` directly.
+- `LocalVectorStoreDriver` returned Entries not containing the namespace.
 
 ### Deprecated
 

--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -99,7 +99,9 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         entries_and_relatednesses.sort(key=operator.itemgetter(1), reverse=True)
 
         result = [
-            BaseVectorStoreDriver.Entry(id=er[0].id, vector=er[0].vector, score=er[1], meta=er[0].meta)
+            BaseVectorStoreDriver.Entry(
+                id=er[0].id, vector=er[0].vector, score=er[1], meta=er[0].meta, namespace=er[0].namespace
+            )
             for er in entries_and_relatednesses
         ][:count]
 

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -35,3 +35,15 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert len(driver.query("foo", namespace="test1")) == 1000
         assert len(driver.query("foo", namespace="test2")) == 1000
         assert len(driver.query("foo", namespace="test3")) == 1000
+
+    def test_query_vector(self, driver):
+        driver.upsert_text_artifacts({"foo": [TextArtifact("foo bar")]})
+
+        result = driver.query_vector([1.0, 1.0], count=1, include_vectors=True)
+
+        assert len(result) == 1
+        assert result[0].to_artifact().value == "foo bar"
+        assert result[0].id is not None
+        assert result[0].vector == [0, 1]
+        assert result[0].score is not None
+        assert result[0].namespace == "foo"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- `LocalVectorStoreDriver` returned Entries not containing the namespace.
## Issue ticket number and link
Closes #1549 