### PR TITLE
Support specifying multiple tasks when using bitshift operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Agent.output_schema` for setting an output schema to be used on the Agent's Prompt Task.
 - `BasePromptDriver.structured_output_strategy` for changing the Structured Output strategy between `native`, `tool`, and `rule`.
 
+### Changed
+- Task bitshift operators can now take a list of Tasks.
+
 ### Fixed
 
 - Occasional crash during `FuturesExecutorMixin` cleanup.

--- a/docs/griptape-framework/structures/workflows.md
+++ b/docs/griptape-framework/structures/workflows.md
@@ -208,7 +208,7 @@ output:
 
 ### Bitshift Composition
 
-Task relationships can also be set up with the Python bitshift operators `>>` and `<<`. The following four statements are all functionally equivalent:
+Task relationships can also be set up with the Python bitshift operators `>>` and `<<`. The following statements are all functionally equivalent:
 
 ```python
 task1 >> task2
@@ -216,6 +216,9 @@ task1.add_child(task2)
 
 task2 << task1
 task2.add_parent(task1)
+
+task3 >> [task4, task5]
+task3.add_children([task4, task5])
 ```
 
 When using the bitshift to compose operators, the relationship is set in the direction that the bitshift operator points.

--- a/griptape/tasks/base_task.py
+++ b/griptape/tasks/base_task.py
@@ -41,13 +41,19 @@ class BaseTask(FuturesExecutorMixin, SerializableMixin, RunnableMixin["BaseTask"
     output: Optional[BaseArtifact] = field(default=None, init=False)
     context: dict[str, Any] = field(factory=dict, kw_only=True, metadata={"serializable": True})
 
-    def __rshift__(self, other: BaseTask) -> BaseTask:
-        self.add_child(other)
+    def __rshift__(self, other: BaseTask | list[BaseTask]) -> BaseTask | list[BaseTask]:
+        if isinstance(other, list):
+            self.add_children(other)
+        else:
+            self.add_child(other)
 
         return other
 
-    def __lshift__(self, other: BaseTask) -> BaseTask:
-        self.add_parent(other)
+    def __lshift__(self, other: BaseTask | list[BaseTask]) -> BaseTask | list[BaseTask]:
+        if isinstance(other, list):
+            self.add_parents(other)
+        else:
+            self.add_parent(other)
 
         return other
 

--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -151,6 +151,18 @@ class TestBaseTask:
         assert task.id in parent.child_ids
         assert added_task == parent
 
+    def test_add_multiple_parent_bitshift(self, task):
+        parent_1 = MockTask("parent foobar", id="parent_1_foobar")
+        parent_2 = MockTask("parent foobar", id="parent_2_foobar")
+
+        added_tasks = task << [parent_1, parent_2]
+
+        assert parent_1.id in task.parent_ids
+        assert parent_2.id in task.parent_ids
+        assert task.id in parent_1.child_ids
+        assert task.id in parent_2.child_ids
+        assert added_tasks == [parent_1, parent_2]
+
     def test_add_child_bitshift(self, task):
         child = MockTask("child foobar", id="child_foobar")
 
@@ -159,6 +171,18 @@ class TestBaseTask:
         assert child.id in task.child_ids
         assert task.id in child.parent_ids
         assert added_task == child
+
+    def test_add_multiple_child_bitshift(self, task):
+        child_1 = MockTask("child foobar", id="child_1_foobar")
+        child_2 = MockTask("child foobar", id="child_2_foobar")
+
+        added_tasks = task >> [child_1, child_2]
+
+        assert child_1.id in task.child_ids
+        assert child_2.id in task.child_ids
+        assert task.id in child_1.parent_ids
+        assert task.id in child_2.parent_ids
+        assert added_tasks == [child_1, child_2]
 
     def test_to_dict(self, task):
         expected_task_dict = {


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Changed
- Task bitshift operators can now take a list of Tasks.
## Issue ticket number and link
Closes #1567 

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1568.org.readthedocs.build//1568/

<!-- readthedocs-preview griptape end -->