### PR TITLE
Fix Prompt Task Conversation Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - References being lost on Artifacts during chunking.
 - `FootnotePromptResponseRagModule`'s system prompt causing it to not answer even with relevant chunks. 
 - Chunker occasionally dropping suffix chunk separators.
+- `PromptTask.conversation_memory` not working when set without a Structure.
 
 ### Deprecated
 

--- a/docs/griptape-framework/structures/conversation-memory.md
+++ b/docs/griptape-framework/structures/conversation-memory.md
@@ -57,7 +57,7 @@ Now, each _Task_ creates a Conversation Memory Run when it runs. This eliminates
 To blend the two approaches, you can disable Conversation Memory on individual tasks by setting [PromptTask.conversation_memory](../../reference/griptape/tasks/prompt_task.md#griptape.tasks.prompt_task.PromptTask.conversation_memory) to `None`.
 
 ```python
---8<-- "docs/griptape-framework/structures/src/conversation_memory_per_task_with_none.py"
+--8<-- "docs/griptape-framework/structures/src/conversation_memory_per_task_with_disabled.py"
 ```
 
 ## Types of Memory

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -43,8 +43,8 @@ class PromptTask(BaseTask, RuleMixin, ActionsSubtaskOriginMixin):
         default=Factory(lambda self: self.default_generate_system_template, takes_self=True),
         kw_only=True,
     )
-    conversation_memory: Union[Optional[BaseConversationMemory], NothingType] = field(
-        default=Factory(lambda: NOTHING), kw_only=True
+    _conversation_memory: Union[Optional[BaseConversationMemory], NothingType] = field(
+        default=Factory(lambda: NOTHING), kw_only=True, alias="conversation_memory"
     )
     _input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
@@ -89,9 +89,23 @@ class PromptTask(BaseTask, RuleMixin, ActionsSubtaskOriginMixin):
         self._input = value
 
     @property
+    def conversation_memory(self) -> Optional[BaseConversationMemory]:
+        if self._conversation_memory is NOTHING:
+            if self.structure is None:
+                return None
+            else:
+                return self.structure.conversation_memory
+        else:
+            return self._conversation_memory
+
+    @conversation_memory.setter
+    def conversation_memory(self, value: Optional[BaseConversationMemory]) -> None:
+        self._conversation_memory = value
+
+    @property
     def prompt_stack(self) -> PromptStack:
         stack = PromptStack(tools=self.tools, output_schema=self.output_schema)
-        memory = self.structure.conversation_memory if self.structure is not None else None
+        memory = self.conversation_memory
 
         system_template = self.generate_system_template(self)
         if system_template:
@@ -151,10 +165,10 @@ class PromptTask(BaseTask, RuleMixin, ActionsSubtaskOriginMixin):
             self.output.to_text() if self.output is not None else "",
         )
         conversation_memory = self.conversation_memory
+        structure = self.structure
         if (
-            (self.structure is None or self.structure.conversation_memory_strategy == "per_task")
+            (structure is None or structure.conversation_memory_strategy == "per_task")
             and conversation_memory is not None
-            and conversation_memory is not NOTHING
             and self.output is not None
         ):
             run = Run(input=self.input, output=self.output)
@@ -196,12 +210,6 @@ class PromptTask(BaseTask, RuleMixin, ActionsSubtaskOriginMixin):
 
     def preprocess(self, structure: Structure) -> BaseTask:
         super().preprocess(structure)
-
-        if self.conversation_memory is NOTHING:
-            if structure.conversation_memory is not None:
-                self.conversation_memory = structure.conversation_memory
-            else:
-                self.conversation_memory = None
 
         if self.task_memory is None and structure.task_memory:
             self.set_default_tools_memory(structure.task_memory)

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -165,9 +165,8 @@ class PromptTask(BaseTask, RuleMixin, ActionsSubtaskOriginMixin):
             self.output.to_text() if self.output is not None else "",
         )
         conversation_memory = self.conversation_memory
-        structure = self.structure
         if (
-            (structure is None or structure.conversation_memory_strategy == "per_task")
+            (self.structure is None or self.structure.conversation_memory_strategy == "per_task")
             and conversation_memory is not None
             and self.output is not None
         ):

--- a/tests/unit/tasks/test_prompt_task.py
+++ b/tests/unit/tasks/test_prompt_task.py
@@ -212,6 +212,7 @@ class TestPromptTask:
         task.run()
 
         assert len(conversation_memory.runs) == 0
+        assert len(task.prompt_stack.messages) == 2
 
         task.conversation_memory = conversation_memory
 
@@ -219,6 +220,7 @@ class TestPromptTask:
         task.run()
 
         assert len(conversation_memory.runs) == 2
+        assert len(task.prompt_stack.messages) == 6
 
         task.conversation_memory = None
 
@@ -226,6 +228,7 @@ class TestPromptTask:
         task.run()
 
         assert len(conversation_memory.runs) == 2
+        assert len(task.prompt_stack.messages) == 2
 
     def test_subtasks(self):
         task = PromptTask(


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- `PromptTask.conversation_memory` not working when set without a Structure.

Entries were going into Conversation Memory, but they weren't making it into the Prompt Stack. Refactored things so that this happens.

## Issue ticket number and link
Closes #1573 

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1574.org.readthedocs.build//1574/

<!-- readthedocs-preview griptape end -->