### PR TITLE
Fix chunker dropping suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LocalVectorStoreDriver` returned Entries not containing the namespace.
 - References being lost on Artifacts during chunking.
 - `FootnotePromptResponseRagModule`'s system prompt causing it to not answer even with relevant chunks. 
+- Chunker occasionally dropping suffix chunk separators.
 
 ### Deprecated
 

--- a/tests/unit/chunkers/test_text_chunker.py
+++ b/tests/unit/chunkers/test_text_chunker.py
@@ -114,8 +114,8 @@ class TestTextChunker:
             TextChunker(max_tokens=-1)
 
     def test_tiny_max_tokens(self, chunker):
-        max_tokens = 10
-        chunker.separators = [ChunkSeparator(" ")]
+        max_tokens = 11
+        chunker.separators = [ChunkSeparator(".")]
         chunker.max_tokens = max_tokens
         text = "This is a paragraph of text. I'll count to three: one, two three."
         chunks = chunker.chunk(text)
@@ -123,6 +123,7 @@ class TestTextChunker:
         assert len(chunks) == 2
         for chunk in chunks:
             assert chunker.tokenizer.count_tokens(chunk.value) <= max_tokens
+        assert chunks[-1].value.endswith("one, two three.")
 
     def test_artifact_reference(self, chunker):
         from griptape.common.reference import Reference


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- Chunker occasionally dropping suffix chunk separators.

Whew that was painful. The issue boiled down to `subchunks = list(filter(None, chunk.split(separator.value)))` not re-assembling nicely during `separator.value.join(subchunks)` because we've filtered out some information. However for _very specific_ texts, it is important that we filter out the empty subchunks before proceeding.
## Issue ticket number and link
Closes #1544