### PR TITLE
Automatically create Thread in Griptape Cloud Assistant Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Task bitshift operators can now take a list of Tasks.
+- `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now automatically create a new Thread if one is not provided. Can be disabled with `auto_create_thread=False`.
+- `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now return metadata (`thread_id`) on the response Artifact.
+- `GriptapeCloudAssistantDriver` now accepts a `thread_alias` parameter for fetching a Thread by alias, creating one if it doesn't exist.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now automatically create a new Thread if one is not provided. Can be disabled with `auto_create_thread=False`.
 - `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now return metadata (`thread_id`) on the response Artifact.
 - `GriptapeCloudAssistantDriver` now accepts a `thread_alias` parameter for fetching a Thread by alias, creating one if it doesn't exist.
+- `EvalEngine` to use structured output when generating evaluation steps.
+- `GriptapeCloudVectorStoreDriver.query()` updated to non-deprecated Griptape Cloud API shape.
 
 ### Fixed
 
@@ -37,10 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `FuturesExecutorMixin.futures_executor`. Use `FuturesExecutorMixin.create_futures_executor` instead.
-### Changed
-
-- `EvalEngine` to use structured output when generating evaluation steps.
-- `GriptapeCloudVectorStoreDriver.query()` updated to non-deprecated Griptape Cloud API shape.
 
 ## [1.1.1] - 2025-01-03
 

--- a/tests/unit/drivers/assistant/test_griptape_cloud_assistant_driver.py
+++ b/tests/unit/drivers/assistant/test_griptape_cloud_assistant_driver.py
@@ -1,6 +1,7 @@
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import pytest
+import requests
 
 from griptape.artifacts import TextArtifact
 from griptape.drivers import GriptapeCloudAssistantDriver
@@ -9,60 +10,109 @@ from griptape.drivers import GriptapeCloudAssistantDriver
 class TestGriptapeCloudAssistantDriver:
     @pytest.fixture(autouse=True)
     def mock_requests_post(self, mocker):
-        mock_response = mocker.Mock()
-        mock_response.json.return_value = {"assistant_run_id": 1}
+        def request(*args, **kwargs):
+            if "runs" in args[0]:
+                mock_response = mocker.Mock()
+                mock_response.json.return_value = {"assistant_run_id": "1"}
 
-        return mocker.patch("requests.post", return_value=mock_response)
+                return mock_response
+            elif "threads" in args[0]:
+                mock_response = mocker.Mock()
+                if "alias" in kwargs["json"] and kwargs["json"]["alias"] in (
+                    "already_exists",
+                    "gone_and_then_exists",
+                ):
+                    mock_response.raise_for_status.side_effect = requests.HTTPError(
+                        response=mocker.Mock(status_code=400)
+                    )
+                else:
+                    mock_response.json.return_value = {"thread_id": "1"}
+                return mock_response
+            else:
+                return mocker.Mock(
+                    raise_for_status=lambda: None,
+                )
 
-    @pytest.fixture()
+        return mocker.patch(
+            "requests.post",
+            side_effect=request,
+        )
+
+    @pytest.fixture(autouse=True)
     def mock_requests_get(self, mocker):
-        mock_response = mocker.Mock()
-        mock_response.json.return_value = {
-            "events": [
-                {
-                    "origin": "ASSISTANT",
-                    "type": "FooBarEvent",
-                    "payload": {
-                        "type": "FooBarEvent",
-                    },
-                },
-                {
-                    "origin": "ASSISTANT",
-                    "type": "FinishStructureRunEvent",
-                    "payload": {
-                        "type": "FinishStructureRunEvent",
-                        "output_task_input": {
-                            "type": "TextArtifact",
-                            "value": "foo bar",
+        def request(*args, **kwargs):
+            if "events" in args[0]:
+                mock_response = mocker.Mock()
+                mock_response.json.return_value = {
+                    "events": [
+                        {
+                            "origin": "ASSISTANT",
+                            "type": "FooBarEvent",
+                            "payload": {
+                                "type": "FooBarEvent",
+                            },
                         },
-                        "output_task_output": {
-                            "type": "TextArtifact",
-                            "value": "foo bar",
+                        {
+                            "origin": "ASSISTANT",
+                            "type": "FinishStructureRunEvent",
+                            "payload": {
+                                "type": "FinishStructureRunEvent",
+                                "output_task_input": {
+                                    "type": "TextArtifact",
+                                    "value": "foo bar",
+                                },
+                                "output_task_output": {
+                                    "type": "TextArtifact",
+                                    "value": "foo bar",
+                                },
+                            },
                         },
-                    },
-                },
-                {
-                    "origin": "ASSISTANT",
-                    "type": "FOO",
-                    "payload": {
-                        "type": "FinishStructureRunEvent",
-                        "output_task_input": {
-                            "type": "TextArtifact",
-                            "value": "foo bar",
+                        {
+                            "origin": "ASSISTANT",
+                            "type": "FOO",
+                            "payload": {
+                                "type": "FinishStructureRunEvent",
+                                "output_task_input": {
+                                    "type": "TextArtifact",
+                                    "value": "foo bar",
+                                },
+                                "output_task_output": {
+                                    "type": "TextArtifact",
+                                    "value": "foo bar",
+                                },
+                            },
                         },
-                        "output_task_output": {
-                            "type": "TextArtifact",
-                            "value": "foo bar",
+                        {
+                            "origin": "FOO",
                         },
-                    },
-                },
-                {
-                    "origin": "FOO",
-                },
-            ],
-            "next_offset": 0,
-        }
-        return mocker.patch("requests.get", return_value=mock_response)
+                    ],
+                    "next_offset": 0,
+                }
+
+                return mock_response
+            elif "threads" in args[0]:
+                mock_response = mocker.Mock()
+                if "alias" in kwargs["params"] and kwargs["params"]["alias"] in ("gone_and_then_exists"):
+                    mock_response.json.return_value = {"threads": []}
+                else:
+                    mock_response.json.return_value = {
+                        "threads": [
+                            {
+                                "thread_id": "1",
+                                "alias": kwargs["params"]["alias"],
+                            }
+                        ]
+                    }
+                return mock_response
+            else:
+                return mocker.Mock(
+                    raise_for_status=lambda: None,
+                )
+
+        return mocker.patch(
+            "requests.get",
+            side_effect=request,
+        )
 
     @pytest.fixture()
     def mock_requests_get_empty(self, mocker):
@@ -81,44 +131,80 @@ class TestGriptapeCloudAssistantDriver:
             assistant_id="1",
         )
 
-    def test_run(self, driver, mock_requests_post, mock_requests_get):
-        result = driver.run(TextArtifact("foo bar"))
-        assert isinstance(result, TextArtifact)
-        assert result.value == "foo bar"
-        mock_requests_post.assert_called_once_with(
-            "https://cloud-foo.griptape.ai/api/assistants/1/runs",
-            json={
-                "args": ["foo bar"],
-                "stream": False,
-                "thread_id": None,
-                "input": None,
-                "additional_ruleset_ids": [],
-                "additional_knowledge_base_ids": [],
-                "additional_structure_ids": [],
-                "additional_tool_ids": [],
-            },
-            headers={"Authorization": "Bearer foo bar"},
-        )
+    @pytest.mark.parametrize("thread_id", ["1", None])
+    @pytest.mark.parametrize("autocreate_thread", [True, False])
+    @pytest.mark.parametrize("thread_alias", ["foo", "already_exists", "gone_and_then_exists", None])
+    @pytest.mark.parametrize("stream", [True, False])
+    def test_run(
+        self, driver, mock_requests_get, mock_requests_post, thread_id, autocreate_thread, thread_alias, stream
+    ):
+        driver.thread_id = thread_id
+        driver.auto_create_thread = autocreate_thread
+        driver.stream = stream
+        driver.thread_alias = thread_alias
 
-    def test_stream_run(self, driver, mock_requests_post, mock_requests_get):
-        driver.stream = True
-        result = driver.run(TextArtifact("foo bar"))
-        assert isinstance(result, TextArtifact)
-        assert result.value == "foo bar"
-        mock_requests_post.assert_called_once_with(
-            "https://cloud-foo.griptape.ai/api/assistants/1/runs",
-            json={
+        # A thread that is missing on the query call and then exists on the second call
+        if thread_id is None and autocreate_thread and thread_alias == "gone_and_then_exists":
+            with pytest.raises(requests.HTTPError):
+                driver.run(TextArtifact("foo bar"))
+        else:
+            result = driver.run(TextArtifact("foo bar"))
+            assert isinstance(result, TextArtifact)
+            assert result.value == "foo bar"
+            assert result.meta == {
+                "assistant_id": driver.assistant_id,
+                "assistant_run_id": "1",
+                "thread_id": driver.thread_id,
+            }
+
+        # Create or find thread
+        if thread_id is None and autocreate_thread:
+            if thread_alias is None:
+                # Assert that a non-aliased Thread was created
+                call_1 = mock_requests_post.call_args_list[0]
+                assert "threads" in call_1.args[0]
+                if thread_alias is None:
+                    assert call_1.kwargs["json"] == {"name": ANY}
+                else:
+                    assert call_1.kwargs["json"] == {"name": ANY, "alias": driver.thread_alias}
+            else:
+                # Assert that we tried to find the Thread by alias
+                call_1 = mock_requests_get.call_args_list[0]
+                assert "threads" in call_1.args[0]
+                assert call_1.kwargs["params"] == {"alias": driver.thread_alias}
+
+                # If no thread was found, create a new one
+                if thread_alias in ("gone_and_then_exists"):
+                    # Assert that we tried to create a new Thread
+                    call_2 = mock_requests_post.call_args_list[0]
+                    assert "threads" in call_2.args[0]
+                    assert call_2.kwargs["json"] == {"alias": driver.thread_alias, "name": ANY}
+                else:
+                    call_2 = mock_requests_post.call_args_list[0]
+                    assert "runs" in call_2.args[0]
+                    assert call_2.kwargs["json"] == {
+                        "args": ["foo bar"],
+                        "stream": stream,
+                        "thread_id": driver.thread_id,
+                        "input": None,
+                        "additional_ruleset_ids": [],
+                        "additional_knowledge_base_ids": [],
+                        "additional_structure_ids": [],
+                        "additional_tool_ids": [],
+                    }
+        else:
+            call_1 = mock_requests_post.call_args_list[0]
+            assert "runs" in call_1.args[0]
+            assert call_1.kwargs["json"] == {
                 "args": ["foo bar"],
-                "stream": True,
-                "thread_id": None,
+                "stream": stream,
+                "thread_id": thread_id,
                 "input": None,
                 "additional_ruleset_ids": [],
                 "additional_knowledge_base_ids": [],
                 "additional_structure_ids": [],
                 "additional_tool_ids": [],
-            },
-            headers={"Authorization": "Bearer foo bar"},
-        )
+            }
 
     def test_timeout_run(self, driver, mocker):
         mock_response = mocker.Mock()

--- a/tests/unit/drivers/assistant/test_openai_assistant_driver.py
+++ b/tests/unit/drivers/assistant/test_openai_assistant_driver.py
@@ -30,6 +30,7 @@ class TestOpenAiAssistantDriver:
         mock_client_instance = mock_client.return_value
 
         mock_client_instance.beta.threads.messages.create = Mock()
+        mock_client_instance.beta.threads.create.return_value = Mock(id="thread_id")
 
         mock_chat_stream = mock_client_instance.beta.threads.runs.stream
         mock_chat_stream_enter = mock_chat_stream.return_value.__enter__
@@ -71,9 +72,11 @@ class TestOpenAiAssistantDriver:
             assistant_id="assistant_id",
         )
 
-    def test_run(self, driver, mock_openai_client, mock_event_handler):
+    @pytest.mark.parametrize("thread_id", ["thread_id", None])
+    def test_run(self, driver, mock_openai_client, mock_event_handler, thread_id):
         mock_event_listener_handler = Mock()
         EventBus.add_event_listener(EventListener(mock_event_listener_handler))
+        driver.thread_id = thread_id
         driver.event_handler = mock_event_handler
         result = driver.run(TextArtifact("foo bar"), TextArtifact("fizz buzz"))
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Changed
- `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now automatically creates a new Thread if one is not provided. Can be disabled with `auto_create_thread=False`.
- `GriptapeCloudAssistantDriver` and `OpenAiAssistantDriver` now return metadata (`thread_id`) on the response Artifact.
- `GriptapeCloudAssistantDriver` now accepts a `thread_alias` parameter for fetching a Thread by alias, creating one if it doesn't exist.

## Issue ticket number and link
Closes #1581 