### PR TITLE
Narrow Types, Use Generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PromptTask.output_schema` for setting an output schema to be used with Structured Output.
 - `Agent.output_schema` for setting an output schema to be used on the Agent's Prompt Task.
 - `BasePromptDriver.structured_output_strategy` for changing the Structured Output strategy between `native`, `tool`, and `rule`.
+- Better type support to all Tasks.
 
 ### Changed
 - Task bitshift operators can now take a list of Tasks.

--- a/griptape/artifacts/generic_artifact.py
+++ b/griptape/artifacts/generic_artifact.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Generic, TypeVar
 
 from attrs import define, field
 
 from griptape.artifacts import BaseArtifact
 
+T = TypeVar("T")
+
 
 @define
-class GenericArtifact(BaseArtifact):
+class GenericArtifact(BaseArtifact, Generic[T]):
     """Serves as an escape hatch for artifacts that don't fit into any other category.
 
     Attributes:
         value: The value of the Artifact.
     """
 
-    value: Any = field(metadata={"serializable": True})
+    value: T = field(metadata={"serializable": True})
 
     def to_text(self) -> str:
         return str(self.value)

--- a/griptape/drivers/assistant/base_assistant_driver.py
+++ b/griptape/drivers/assistant/base_assistant_driver.py
@@ -6,15 +6,15 @@ from typing import TYPE_CHECKING
 from attrs import define
 
 if TYPE_CHECKING:
-    from griptape.artifacts import BaseArtifact
+    from griptape.artifacts import BaseArtifact, TextArtifact
 
 
 @define
 class BaseAssistantDriver(ABC):
     """Base class for AssistantDrivers."""
 
-    def run(self, *args: BaseArtifact) -> BaseArtifact:
+    def run(self, *args: BaseArtifact) -> TextArtifact:
         return self.try_run(*args)
 
     @abstractmethod
-    def try_run(self, *args: BaseArtifact) -> BaseArtifact: ...
+    def try_run(self, *args: BaseArtifact) -> TextArtifact: ...

--- a/griptape/drivers/assistant/openai_assistant_driver.py
+++ b/griptape/drivers/assistant/openai_assistant_driver.py
@@ -7,7 +7,7 @@ from attrs import Factory, define, field
 from openai import AssistantEventHandler
 from typing_extensions import override
 
-from griptape.artifacts import BaseArtifact, InfoArtifact, TextArtifact
+from griptape.artifacts import BaseArtifact, TextArtifact
 from griptape.drivers.assistant import BaseAssistantDriver
 from griptape.events import EventBus, TextChunkEvent
 from griptape.utils.decorators import lazy_property
@@ -56,7 +56,7 @@ class OpenAiAssistantDriver(BaseAssistantDriver):
             organization=self.organization,
         )
 
-    def try_run(self, *args: BaseArtifact) -> BaseArtifact | InfoArtifact:
+    def try_run(self, *args: BaseArtifact) -> TextArtifact:
         if self.thread_id is None and self.auto_create_thread:
             self.thread_id = self.client.beta.threads.create().id
         response = self._create_run(*args)

--- a/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
+++ b/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 from attrs import Factory, define, field
 
 from griptape.artifacts import BaseArtifact, InfoArtifact
+from griptape.artifacts.text_artifact import TextArtifact
 from griptape.drivers.structure_run.base_structure_run_driver import BaseStructureRunDriver
 
 
@@ -23,7 +24,7 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
     structure_run_max_wait_time_attempts: int = field(default=20, kw_only=True)
     async_run: bool = field(default=False, kw_only=True)
 
-    def try_run(self, *args: BaseArtifact) -> BaseArtifact | InfoArtifact:
+    def try_run(self, *args: BaseArtifact) -> TextArtifact | InfoArtifact:
         from requests import Response, post
 
         url = urljoin(self.base_url.strip("/"), f"/api/structures/{self.structure_id}/runs")
@@ -43,7 +44,7 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
         else:
             return self._get_structure_run_result(response_json["structure_run_id"])
 
-    def _get_structure_run_result(self, structure_run_id: str) -> BaseArtifact | InfoArtifact:
+    def _get_structure_run_result(self, structure_run_id: str) -> TextArtifact | InfoArtifact:
         url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{structure_run_id}")
 
         result = self._get_structure_run_result_attempt(url)
@@ -67,7 +68,7 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
             raise Exception(f"Run failed with status: {status}")
 
         if "output" in result:
-            return BaseArtifact.from_dict(result["output"])
+            return TextArtifact.from_dict(result["output"])
         else:
             return InfoArtifact("No output found in response")
 

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -58,11 +58,15 @@ class BaseSchema(Schema):
 
         field_class, args, optional = cls._get_field_type_info(field_type)
 
+        if field_class is None:
+            return fields.Constant(None, allow_none=True)
+
         # Resolve TypeVars to their bound type
         if isinstance(field_class, TypeVar):
             field_class = field_class.__bound__
-        if field_class is None:
-            return fields.Constant(None, allow_none=True)
+            if field_class is None:
+                return fields.Raw(allow_none=optional)
+
         if cls._is_union(field_type):
             return cls._handle_union(field_type, optional=optional)
         elif attrs.has(field_class):

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(Defaults.logging_config.logger_name)
 
 
 @define
-class ActionsSubtask(BaseTask):
+class ActionsSubtask(BaseTask[Union[ListArtifact, ErrorArtifact]]):
     THOUGHT_PATTERN = r"(?s)^Thought:\s*(.*?)$"
     ACTIONS_PATTERN = r"(?s)Actions:[^\[]*(\[.*\])"
     ANSWER_PATTERN = r"(?s)^Answer:\s?([\s\S]*)$"
@@ -122,7 +122,7 @@ class ActionsSubtask(BaseTask):
         ]
         logger.info("".join(parts))
 
-    def try_run(self) -> BaseArtifact:
+    def try_run(self) -> ListArtifact | ErrorArtifact:
         try:
             if any(isinstance(a.output, ErrorArtifact) for a in self.actions):
                 errors = [a.output.value for a in self.actions if isinstance(a.output, ErrorArtifact)]

--- a/griptape/tasks/assistant_task.py
+++ b/griptape/tasks/assistant_task.py
@@ -4,15 +4,15 @@ from typing import TYPE_CHECKING
 
 from attrs import define, field
 
+from griptape.artifacts.text_artifact import TextArtifact
 from griptape.tasks import BaseTextInputTask
 
 if TYPE_CHECKING:
-    from griptape.artifacts import BaseArtifact
     from griptape.drivers.assistant import BaseAssistantDriver
 
 
 @define
-class AssistantTask(BaseTextInputTask):
+class AssistantTask(BaseTextInputTask[TextArtifact]):
     """Task to run an Assistant.
 
     Attributes:
@@ -21,5 +21,5 @@ class AssistantTask(BaseTextInputTask):
 
     assistant_driver: BaseAssistantDriver = field(kw_only=True)
 
-    def try_run(self) -> BaseArtifact:
+    def try_run(self) -> TextArtifact:
         return self.assistant_driver.run(self.input)

--- a/griptape/tasks/audio_transcription_task.py
+++ b/griptape/tasks/audio_transcription_task.py
@@ -4,16 +4,16 @@ from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
+from griptape.artifacts import TextArtifact
 from griptape.configs.defaults_config import Defaults
 from griptape.tasks.base_audio_input_task import BaseAudioInputTask
 
 if TYPE_CHECKING:
-    from griptape.artifacts import TextArtifact
     from griptape.drivers.audio_transcription import BaseAudioTranscriptionDriver
 
 
 @define
-class AudioTranscriptionTask(BaseAudioInputTask):
+class AudioTranscriptionTask(BaseAudioInputTask[TextArtifact]):
     audio_transcription_driver: BaseAudioTranscriptionDriver = field(
         default=Factory(lambda: Defaults.drivers_config.audio_transcription_driver),
         kw_only=True,

--- a/griptape/tasks/base_audio_generation_task.py
+++ b/griptape/tasks/base_audio_generation_task.py
@@ -5,6 +5,7 @@ from abc import ABC
 
 from attrs import define
 
+from griptape.artifacts.audio_artifact import AudioArtifact
 from griptape.configs import Defaults
 from griptape.mixins.artifact_file_output_mixin import ArtifactFileOutputMixin
 from griptape.mixins.rule_mixin import RuleMixin
@@ -14,7 +15,7 @@ logger = logging.getLogger(Defaults.logging_config.logger_name)
 
 
 @define
-class BaseAudioGenerationTask(ArtifactFileOutputMixin, RuleMixin, BaseTask, ABC):
+class BaseAudioGenerationTask(ArtifactFileOutputMixin, RuleMixin, BaseTask[AudioArtifact], ABC):
     def before_run(self) -> None:
         super().before_run()
 

--- a/griptape/tasks/base_audio_input_task.py
+++ b/griptape/tasks/base_audio_input_task.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from typing import Callable, Union
+from typing import Callable, TypeVar, Union
 
 from attrs import define, field
 
-from griptape.artifacts.audio_artifact import AudioArtifact
+from griptape.artifacts import AudioArtifact, BaseArtifact
 from griptape.configs import Defaults
 from griptape.mixins.rule_mixin import RuleMixin
 from griptape.tasks import BaseTask
 
 logger = logging.getLogger(Defaults.logging_config.logger_name)
 
+T = TypeVar("T", bound=BaseArtifact)
+
 
 @define
-class BaseAudioInputTask(RuleMixin, BaseTask, ABC):
+class BaseAudioInputTask(RuleMixin, BaseTask[T], ABC):
     _input: Union[AudioArtifact, Callable[[BaseTask], AudioArtifact]] = field(alias="input")
 
     @property

--- a/griptape/tasks/base_image_generation_task.py
+++ b/griptape/tasks/base_image_generation_task.py
@@ -8,15 +8,13 @@ from typing import TYPE_CHECKING
 
 from attrs import Factory, define, field
 
+from griptape.artifacts import ImageArtifact
 from griptape.configs import Defaults
 from griptape.loaders import ImageLoader
 from griptape.mixins.artifact_file_output_mixin import ArtifactFileOutputMixin
 from griptape.mixins.rule_mixin import RuleMixin
 from griptape.rules import Rule, Ruleset
 from griptape.tasks import BaseTask
-
-if TYPE_CHECKING:
-    from griptape.artifacts import ImageArtifact
 
 logger = logging.getLogger(Defaults.logging_config.logger_name)
 
@@ -26,7 +24,7 @@ if TYPE_CHECKING:
 
 
 @define
-class BaseImageGenerationTask(ArtifactFileOutputMixin, RuleMixin, BaseTask, ABC):
+class BaseImageGenerationTask(ArtifactFileOutputMixin, RuleMixin, BaseTask[ImageArtifact], ABC):
     """Provides a base class for image generation-related tasks.
 
     Attributes:

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC
-from typing import Callable, Union
+from typing import Callable, TypeVar, Union
 
 from attrs import define, field
 
-from griptape.artifacts import TextArtifact
+from griptape.artifacts import BaseArtifact, TextArtifact
 from griptape.configs import Defaults
 from griptape.mixins.rule_mixin import RuleMixin
 from griptape.tasks import BaseTask
@@ -14,9 +14,11 @@ from griptape.utils import J2
 
 logger = logging.getLogger(Defaults.logging_config.logger_name)
 
+T = TypeVar("T", bound=BaseArtifact)
+
 
 @define
-class BaseTextInputTask(RuleMixin, BaseTask, ABC):
+class BaseTextInputTask(RuleMixin, BaseTask[T], ABC):
     DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
 
     _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(

--- a/griptape/tasks/branch_task.py
+++ b/griptape/tasks/branch_task.py
@@ -9,7 +9,7 @@ from griptape.tasks import BaseTask, CodeExecutionTask
 
 
 @define
-class BranchTask(CodeExecutionTask):
+class BranchTask(CodeExecutionTask[Union[InfoArtifact, ListArtifact[InfoArtifact]]]):
     on_run: Callable[[BranchTask], Union[InfoArtifact, ListArtifact[InfoArtifact]]] = field(kw_only=True)
 
     def try_run(self) -> InfoArtifact | ListArtifact[InfoArtifact]:

--- a/griptape/tasks/code_execution_task.py
+++ b/griptape/tasks/code_execution_task.py
@@ -1,18 +1,34 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import Callable, TypeVar, Union
 
 from attrs import define, field
 
-from griptape.tasks import BaseTextInputTask
+from griptape.artifacts import BaseArtifact, TextArtifact
+from griptape.tasks.base_task import BaseTask
+from griptape.utils import J2, deprecation_warn
 
-if TYPE_CHECKING:
-    from griptape.artifacts import BaseArtifact
+T = TypeVar("T", bound=BaseArtifact)  # Return type of task
 
 
 @define
-class CodeExecutionTask(BaseTextInputTask):
-    on_run: Callable[[CodeExecutionTask], BaseArtifact] = field(kw_only=True)
+class CodeExecutionTask(BaseTask[T]):
+    DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
+    _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(
+        default=DEFAULT_INPUT_TEMPLATE,
+        alias="input",
+    )
+    on_run: Callable[[CodeExecutionTask[T]], T] = field(kw_only=True)
 
-    def try_run(self) -> BaseArtifact:
+    @property
+    def input(self) -> TextArtifact:
+        deprecation_warn("CodeExecutionTask.input is deprecated and will be removed in a future release.")
+        if isinstance(self._input, TextArtifact):
+            return self._input
+        elif callable(self._input):
+            return self._input(self)
+        else:
+            return TextArtifact(J2().render_from_string(self._input, **self.full_context))
+
+    def try_run(self) -> T:
         return self.on_run(self)

--- a/griptape/tasks/extraction_task.py
+++ b/griptape/tasks/extraction_task.py
@@ -8,14 +8,13 @@ from griptape.artifacts import ListArtifact
 from griptape.tasks import BaseTextInputTask
 
 if TYPE_CHECKING:
-    from griptape.artifacts import ErrorArtifact
     from griptape.engines import BaseExtractionEngine
 
 
 @define
-class ExtractionTask(BaseTextInputTask):
+class ExtractionTask(BaseTextInputTask[ListArtifact]):
     extraction_engine: BaseExtractionEngine = field(kw_only=True)
     args: dict = field(kw_only=True, factory=dict)
 
-    def try_run(self) -> ListArtifact | ErrorArtifact:
+    def try_run(self) -> ListArtifact:
         return self.extraction_engine.extract_artifacts(ListArtifact([self.input]), rulesets=self.rulesets, **self.args)

--- a/griptape/tasks/rag_task.py
+++ b/griptape/tasks/rag_task.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+from typing import Union
+
 from attrs import Factory, define, field
 
-from griptape.artifacts import BaseArtifact, ErrorArtifact, ListArtifact
+from griptape.artifacts import ErrorArtifact, ListArtifact
 from griptape.engines.rag import RagEngine
 from griptape.tasks import BaseTextInputTask
 
 
 @define
-class RagTask(BaseTextInputTask):
+class RagTask(BaseTextInputTask[Union[ListArtifact, ErrorArtifact]]):
     rag_engine: RagEngine = field(kw_only=True, default=Factory(lambda: RagEngine()))
 
-    def try_run(self) -> BaseArtifact:
+    def try_run(self) -> ListArtifact | ErrorArtifact:
         outputs = self.rag_engine.process_query(self.input.to_text()).outputs
 
         if len(outputs) > 0:

--- a/griptape/tasks/structure_run_task.py
+++ b/griptape/tasks/structure_run_task.py
@@ -1,24 +1,36 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Union
 
 from attrs import define, field
 
-from griptape.artifacts.list_artifact import ListArtifact
-from griptape.tasks.prompt_task import PromptTask
+from griptape.artifacts import BaseArtifact, ListArtifact, TextArtifact
+from griptape.tasks.base_task import BaseTask
+from griptape.utils import J2
 
 if TYPE_CHECKING:
-    from griptape.artifacts import BaseArtifact
     from griptape.drivers.structure_run.base_structure_run_driver import BaseStructureRunDriver
 
 
 @define
-class StructureRunTask(PromptTask):
+class StructureRunTask(BaseTask):
     """Task to run a Structure.
 
     Attributes:
         structure_run_driver: Driver to run the Structure.
     """
+
+    _input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
+        default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
+    )
+
+    @property
+    def input(self) -> BaseArtifact:
+        return self._process_task_input(self._input)
+
+    @input.setter
+    def input(self, value: str | list | tuple | BaseArtifact | Callable[[BaseTask], BaseArtifact]) -> None:
+        self._input = value
 
     structure_run_driver: BaseStructureRunDriver = field(kw_only=True)
 
@@ -27,3 +39,22 @@ class StructureRunTask(PromptTask):
             return self.structure_run_driver.run(*self.input.value)
         else:
             return self.structure_run_driver.run(self.input)
+
+    def _process_task_input(
+        self,
+        task_input: str | tuple | list | BaseArtifact | Callable[[BaseTask], BaseArtifact],
+    ) -> BaseArtifact:
+        if isinstance(task_input, TextArtifact):
+            task_input.value = J2().render_from_string(task_input.value, **self.full_context)
+
+            return task_input
+        elif isinstance(task_input, Callable):
+            return self._process_task_input(task_input(self))
+        elif isinstance(task_input, ListArtifact):
+            return ListArtifact([self._process_task_input(elem) for elem in task_input.value])
+        elif isinstance(task_input, BaseArtifact):
+            return task_input
+        elif isinstance(task_input, (list, tuple)):
+            return ListArtifact([self._process_task_input(elem) for elem in task_input])
+        else:
+            return self._process_task_input(TextArtifact(task_input))

--- a/griptape/tasks/text_summary_task.py
+++ b/griptape/tasks/text_summary_task.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @define
-class TextSummaryTask(BaseTextInputTask):
+class TextSummaryTask(BaseTextInputTask[TextArtifact]):
     summary_engine: BaseSummaryEngine = field(default=Factory(lambda: PromptSummaryEngine()), kw_only=True)
 
     def try_run(self) -> TextArtifact:

--- a/griptape/tasks/toolkit_task.py
+++ b/griptape/tasks/toolkit_task.py
@@ -8,12 +8,12 @@ from attrs import define
 from griptape.tasks import PromptTask
 
 if TYPE_CHECKING:
-    from griptape.artifacts import BaseArtifact
+    from griptape.artifacts import ErrorArtifact, JsonArtifact, ListArtifact, TextArtifact
 
 
 @define
 class ToolkitTask(PromptTask):
-    def try_run(self) -> BaseArtifact:
+    def try_run(self) -> ListArtifact | TextArtifact | JsonArtifact | ErrorArtifact:
         warnings.warn(
             "`ToolkitTask` is deprecated and will be removed in a future release. `PromptTask` is a drop-in replacement.",
             DeprecationWarning,

--- a/tests/unit/schemas/test_base_schema.py
+++ b/tests/unit/schemas/test_base_schema.py
@@ -154,11 +154,6 @@ class TestBaseSchema:
     def test_handle_unsupported_type(self):
         assert isinstance(BaseSchema._get_field_for_type(UnsupportedType), fields.Raw)
 
-    def test_handle_none_list_field(self):
-        # Test that _handle_list raises a ValueError for list elements that are None
-        with pytest.raises(ValueError, match="List elements cannot be None: None"):
-            BaseSchema._handle_list(list[None], optional=False)
-
     def test_handle_union_exception(self):
         with pytest.raises(ValueError, match="Unsupported UnionType field: <class 'NoneType'>"):
             BaseSchema._handle_union(Union[None], optional=False)


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Narrows types on many Tasks and add generics to allow for matching return types on `run`/`try_run`.

Before:
![image](https://github.com/user-attachments/assets/4ca3f812-6baf-4473-804b-3e182cef781c)

After:
![image](https://github.com/user-attachments/assets/f308cb4e-252a-44d0-8836-3a10a3219670)

## Issue ticket number and link
https://github.com/griptape-ai/griptape/issues/1588