### PR TITLE
feat(tasks): accept args in `BaseTask.run()`

### DIFF
--- a/tests/unit/tasks/test_base_task.py
+++ b/tests/unit/tasks/test_base_task.py
@@ -231,6 +231,13 @@ class TestBaseTask:
         task.structure._execution_args = ("foo", "bar")
 
         assert task.full_context == {"args": ("foo", "bar"), "structure": task.structure}
+        assert task.structure.execution_args == ("foo", "bar")
+
+        task.structure = None
+        task._execution_args = ("foo", "bar")
+
+        assert task.full_context == {"args": ("foo", "bar")}
+        assert task.execution_args == ("foo", "bar")
 
     def test_is_pending(self, task):
         task.state = task.State.PENDING
@@ -249,3 +256,15 @@ class TestBaseTask:
         assert str(task) == "foobar"
         task.output = None
         assert str(task) == ""
+
+    def test_run_args(self, task):
+        task.run("foo", "bar")
+
+        assert task._execution_args == ("foo", "bar")
+
+    def test_args_full_context(self):
+        task = MockTask()
+        task.context = {"foo": "buzz"}
+        task.run("foo", "bar")
+
+        assert task.full_context["args"] == ("foo", "bar")

--- a/tests/unit/tasks/test_base_text_input_task.py
+++ b/tests/unit/tasks/test_base_text_input_task.py
@@ -31,9 +31,13 @@ class TestBaseTextInputTask:
         subtask = MockTextInputTask("test", context={"foo": "bar"})
         child = MockTextInputTask("child")
 
-        assert parent.full_context == {}
-        assert subtask.full_context == {"foo": "bar"}
-        assert child.full_context == {}
+        assert parent.full_context == {
+            "args": (),
+        }
+        assert subtask.full_context == {"args": (), "foo": "bar"}
+        assert child.full_context == {
+            "args": (),
+        }
 
         pipeline = Pipeline()
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
`BaseTask.run()` now accepts `args` just like `Structure.run()`. Decided against adding kwargs support in this PR since there is a future opportunity for special kwargs like `context=`. Having a blackhole `kwargs` that is dumped into context makes it challenging to add kwargs that shouldn't go in context.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1597

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1598.org.readthedocs.build//1598/

<!-- readthedocs-preview griptape end -->