### PR TITLE
Clarify that a separate structure config file is required for each structure that you want to deploy

### DIFF
--- a/docs/griptape-cloud/structures/create-structure.md
+++ b/docs/griptape-cloud/structures/create-structure.md
@@ -7,7 +7,7 @@ Structures are a primary component in Griptape for organizing and executing Task
 1. [Connect Your GitHub Account in your Griptape Cloud account](https://cloud.griptape.ai/account)
 1. Install the [Griptape Cloud GitHub app to your GitHub account or organization](https://github.com/apps/griptape-cloud/installations/new/)
    - Be sure to allow the app access to `All Repositories` or select the specific repositories you need
-1. Ensure your repository has a Structure Config YAML file
+1. Ensure your repository has a Structure Config YAML file. If your repository contains multiple Structures, each Structure must have a separate Structure Config YAML file.
    - To learn more see [Structure Config YAML](structure-config.md)
 
 You can now [create a Structure in the Griptape Cloud console](https://cloud.griptape.ai/structures/create) by providing your GitHub repository information.


### PR DESCRIPTION
☑️ I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

Recreating the earlier pull request for the docs update, clarifies that a separate structure config file is required for each structure that you want to deploy - covering the case where you have multiple structures in a single Github repo. This time i ran `make format`

## Issue ticket number and link


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1604.org.readthedocs.build//1604/

<!-- readthedocs-preview griptape end -->