### PR TITLE
Griptape Cloud Structure Run Driver Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `DateTime.get_relative_datetime` to `DateTimeTool.denylist`. May be removed in a future release.
 - Changed log level of `ActionsSubtask` errors from `EXCEPTION` to `DEBUG`.
+- `GriptapeCloudStructureRunDriver` now publishes its events to the global event bus.
 
 ### Deprecated
 

--- a/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
+++ b/griptape/drivers/structure_run/griptape_cloud_structure_run_driver.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import logging
 import time
-from typing import Any
 from urllib.parse import urljoin
 
+import requests
 from attrs import Factory, define, field
 
-from griptape.artifacts import BaseArtifact, InfoArtifact
-from griptape.artifacts.text_artifact import TextArtifact
-from griptape.drivers.structure_run.base_structure_run_driver import BaseStructureRunDriver
+from griptape.artifacts import BaseArtifact, ErrorArtifact, InfoArtifact
+from griptape.configs.defaults_config import Defaults
+from griptape.drivers.structure_run import BaseStructureRunDriver
+from griptape.events import BaseEvent, EventBus
+
+logger = logging.getLogger(Defaults.logging_config.logger_name)
 
 
 @define
@@ -24,14 +28,20 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
     structure_run_max_wait_time_attempts: int = field(default=20, kw_only=True)
     async_run: bool = field(default=False, kw_only=True)
 
-    def try_run(self, *args: BaseArtifact) -> TextArtifact | InfoArtifact:
-        from requests import Response, post
+    def try_run(self, *args: BaseArtifact) -> BaseArtifact | InfoArtifact:
+        structure_run_id = self._create_run(*args)
 
+        if self.async_run:
+            return InfoArtifact("Run started successfully")
+        else:
+            return self._get_run_result(structure_run_id)
+
+    def _create_run(self, *args: BaseArtifact) -> str:
         url = urljoin(self.base_url.strip("/"), f"/api/structures/{self.structure_id}/runs")
 
         env_vars = [{"name": key, "value": value, "source": "manual"} for key, value in self.env.items()]
 
-        response: Response = post(
+        response = requests.post(
             url,
             json={"args": [arg.value for arg in args], "env_vars": env_vars},
             headers=self.headers,
@@ -39,43 +49,46 @@ class GriptapeCloudStructureRunDriver(BaseStructureRunDriver):
         response.raise_for_status()
         response_json = response.json()
 
-        if self.async_run:
-            return InfoArtifact("Run started successfully")
-        else:
-            return self._get_structure_run_result(response_json["structure_run_id"])
+        return response_json["structure_run_id"]
 
-    def _get_structure_run_result(self, structure_run_id: str) -> TextArtifact | InfoArtifact:
-        url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{structure_run_id}")
+    def _get_run_result(self, structure_run_id: str) -> BaseArtifact | InfoArtifact:
+        events, next_offset = self._get_run_events(structure_run_id)
+        attempts = 0
+        output = None
 
-        result = self._get_structure_run_result_attempt(url)
-        status = result["status"]
+        while output is None and attempts < self.structure_run_max_wait_time_attempts:
+            for event in events:
+                event_type = event["type"]
+                event_payload = event.get("payload", {})
+                if event["origin"] == "USER":
+                    try:
+                        EventBus.publish_event(BaseEvent.from_dict(event_payload))
+                    except ValueError as e:
+                        logger.warning("Failed to deserialize event: %s", e)
+                    if event["type"] == "FinishStructureRunEvent":
+                        output = BaseArtifact.from_dict(event_payload["output_task_output"])
+                elif event["origin"] == "SYSTEM":
+                    if event_type == "StructureRunError":
+                        output = ErrorArtifact(event_payload["status_detail"]["error"])
 
-        wait_attempts = 0
-        while (
-            status not in ("SUCCEEDED", "FAILED", "ERROR", "CANCELLED")
-            and wait_attempts < self.structure_run_max_wait_time_attempts
-        ):
-            # wait
-            time.sleep(self.structure_run_wait_time_interval)
-            wait_attempts += 1
-            result = self._get_structure_run_result_attempt(url)
-            status = result["status"]
+            if output is None and not events:
+                time.sleep(self.structure_run_wait_time_interval)
+                attempts += 1
+            events, next_offset = self._get_run_events(structure_run_id, offset=next_offset)
 
-        if wait_attempts >= self.structure_run_max_wait_time_attempts:
-            raise Exception(f"Failed to get Run result after {self.structure_run_max_wait_time_attempts} attempts.")
+        if output is None:
+            raise TimeoutError("The structure run did not finish in time.")
 
-        if status != "SUCCEEDED":
-            raise Exception(f"Run failed with status: {status}")
+        return output
 
-        if "output" in result:
-            return TextArtifact.from_dict(result["output"])
-        else:
-            return InfoArtifact("No output found in response")
-
-    def _get_structure_run_result_attempt(self, structure_run_url: str) -> Any:
-        from requests import Response, get
-
-        response: Response = get(structure_run_url, headers=self.headers)
+    def _get_run_events(self, structure_run_id: str, offset: int = 0) -> tuple[list[dict], int]:
+        url = urljoin(self.base_url.strip("/"), f"/api/structure-runs/{structure_run_id}/events")
+        response = requests.get(url, headers=self.headers, params={"offset": offset})
         response.raise_for_status()
 
-        return response.json()
+        response_json = response.json()
+
+        events = response_json.get("events", [])
+        next_offset = response_json.get("next_offset", 0)
+
+        return events, next_offset

--- a/tests/unit/drivers/structure_run/test_griptape_cloud_structure_run_driver.py
+++ b/tests/unit/drivers/structure_run/test_griptape_cloud_structure_run_driver.py
@@ -1,26 +1,73 @@
+from unittest.mock import Mock
+
 import pytest
 
 from griptape.artifacts import InfoArtifact, TextArtifact
+from griptape.artifacts.error_artifact import ErrorArtifact
+from griptape.drivers.structure_run.griptape_cloud import GriptapeCloudStructureRunDriver
+from griptape.events import EventBus
+from griptape.events.event_listener import EventListener
 
 
 class TestGriptapeCloudStructureRunDriver:
-    @pytest.fixture()
+    @pytest.fixture(autouse=True)
+    def mock_requests_get(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {
+            "events": [
+                {
+                    "origin": "USER",
+                    "type": "FooBarEvent",
+                    "payload": {
+                        "type": "FooBarEvent",
+                    },
+                },
+                {
+                    "origin": "USER",
+                    "type": "FinishStructureRunEvent",
+                    "payload": {
+                        "type": "FinishStructureRunEvent",
+                        "output_task_input": {
+                            "type": "TextArtifact",
+                            "value": "foo bar",
+                        },
+                        "output_task_output": {
+                            "type": "TextArtifact",
+                            "value": "foo bar",
+                        },
+                    },
+                },
+                {"origin": "FOO", "type": "BAR"},
+                {
+                    "origin": "SYSTEM",
+                    "type": "StructureRunError",
+                    "payload": {
+                        "status_detail": {
+                            "error": "foo bar",
+                        },
+                    },
+                },
+            ],
+            "next_offset": 0,
+        }
+
+        return mocker.patch(
+            "requests.get",
+            return_value=mock_response,
+        )
+
+    @pytest.fixture(autouse=True)
     def mock_requests_post(self, mocker):
         mock_response = mocker.Mock()
-        mock_response.json.return_value = {"structure_run_id": 1}
-        return mocker.patch("requests.post", return_value=mock_response)
+        mock_response.json.return_value = {"structure_run_id": "1"}
+
+        return mocker.patch(
+            "requests.post",
+            return_value=mock_response,
+        )
 
     @pytest.fixture()
-    def driver(self, mocker, mock_requests_post):
-        from griptape.drivers.structure_run.griptape_cloud import GriptapeCloudStructureRunDriver
-
-        mock_response = mocker.Mock()
-        mock_response.json.side_effect = [
-            {"description": "fizz buzz", "status": "RUNNING"},
-            {"description": "fizz buzz", "output": TextArtifact("foo bar").to_dict(), "status": "SUCCEEDED"},
-        ]
-        mocker.patch("requests.get", return_value=mock_response)
-
+    def driver(self):
         return GriptapeCloudStructureRunDriver(
             base_url="https://cloud-foo.griptape.ai",
             api_key="foo bar",
@@ -29,18 +76,35 @@ class TestGriptapeCloudStructureRunDriver:
             structure_run_wait_time_interval=0,
         )
 
-    def test_run(self, driver, mock_requests_post):
+    def test_run(self, driver):
+        mock_on_event = Mock()
+        EventBus.add_event_listener(EventListener(on_event=mock_on_event))
         result = driver.run(TextArtifact("foo bar"))
-        assert isinstance(result, TextArtifact)
+
+        events = mock_on_event.call_args[0]
+        assert len(events) == 1
+        assert events[0].type == "FinishStructureRunEvent"
+
+        assert isinstance(result, ErrorArtifact)
         assert result.value == "foo bar"
-        mock_requests_post.assert_called_once_with(
-            "https://cloud-foo.griptape.ai/api/structures/1/runs",
-            json={"args": ["foo bar"], "env_vars": [{"name": "key", "value": "value", "source": "manual"}]},
-            headers={"Authorization": "Bearer foo bar"},
-        )
 
     def test_async_run(self, driver):
         driver.async_run = True
         result = driver.run(TextArtifact("foo bar"))
         assert isinstance(result, InfoArtifact)
         assert result.value == "Run started successfully"
+
+    def test_run_timeout(self, driver, mocker):
+        mocker.patch(
+            "requests.get",
+            return_value=Mock(
+                json=Mock(
+                    return_value={
+                        "events": [],
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(TimeoutError):
+            driver.run(TextArtifact("foo bar"))


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Changed
- `GriptapeCloudStructureRunDriver` now publishes its events to the global event bus.
## Issue ticket number and link
Closes #1613 