### PR TITLE
Refactor ActionsSubtask for more precise initialization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Error when serializing `RagContext`.
+- `Answer:` being trimmed from LLM's final answer even when using native tool calling. 
 
 
 ## [1.2.0] - 2025-01-21

--- a/griptape/common/prompt_stack/messages/message.py
+++ b/griptape/common/prompt_stack/messages/message.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 from attrs import define, field
 
@@ -45,8 +45,13 @@ class Message(BaseMessage):
             [content.artifact.to_text() for content in self.content if isinstance(content, TextMessageContent)],
         )
 
-    def to_artifact(self) -> BaseArtifact:
+    def to_artifact(self, meta: Optional[dict] = None) -> BaseArtifact:
+        if meta is None:
+            meta = {}
         if len(self.content) == 1:
-            return self.content[0].artifact
+            artifact = self.content[0].artifact
         else:
-            return ListArtifact([content.artifact for content in self.content])
+            artifact = ListArtifact([content.artifact for content in self.content])
+
+        artifact.meta.update(meta)
+        return artifact

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -67,7 +67,7 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
         result = self.prompt_driver.run(self.prompt_stack)
 
         if self.prompt_driver.use_native_tools:
-            subtask_input = result.to_artifact()
+            subtask_input = result.to_artifact(meta={"is_react_prompt": False})
         else:
             action_matches = re.findall(self.ACTION_PATTERN, result.to_text(), re.DOTALL)
 
@@ -77,7 +77,10 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
             action_dict = json.loads(data)
 
             action_dict["tag"] = self.tool.name
-            subtask_input = J2("tasks/tool_task/subtask.j2").render(action_json=json.dumps(action_dict))
+            subtask_input = TextArtifact(
+                J2("tasks/tool_task/subtask.j2").render(action_json=json.dumps(action_dict)),
+                meta={"is_react_prompt": True},
+            )
 
         try:
             subtask = self.add_subtask(ActionsSubtask(subtask_input))

--- a/tests/mocks/mock_prompt_driver.py
+++ b/tests/mocks/mock_prompt_driver.py
@@ -43,7 +43,7 @@ class MockPromptDriver(BasePromptDriver):
             ]
             if any(action_messages):
                 return Message(
-                    content=[TextMessageContent(TextArtifact(f"Answer: {output}"))],
+                    content=[TextMessageContent(TextArtifact(output))],
                     role=Message.ASSISTANT_ROLE,
                     usage=Message.Usage(input_tokens=100, output_tokens=100),
                 )
@@ -90,7 +90,7 @@ class MockPromptDriver(BasePromptDriver):
                 message for message in prompt_stack.messages if message.has_any_content_type(ActionCallMessageContent)
             ]
             if any(action_messages):
-                yield DeltaMessage(content=TextDeltaMessageContent(f"Answer: {output}"))
+                yield DeltaMessage(content=TextDeltaMessageContent(output))
                 yield DeltaMessage(usage=DeltaMessage.Usage(input_tokens=100, output_tokens=100))
             else:
                 if self.structured_output_strategy == "tool":

--- a/tests/unit/events/test_finish_actions_subtask_event.py
+++ b/tests/unit/events/test_finish_actions_subtask_event.py
@@ -1,5 +1,6 @@
 import pytest
 
+from griptape.artifacts import TextArtifact
 from griptape.events import FinishActionsSubtaskEvent
 from griptape.structures import Agent
 from griptape.tasks import ActionsSubtask, PromptTask
@@ -9,11 +10,12 @@ from tests.mocks.mock_tool.tool import MockTool
 class TestFinishActionsSubtaskEvent:
     @pytest.fixture()
     def finish_subtask_event(self):
-        valid_input = (
+        valid_input = TextArtifact(
             "Thought: need to test\n"
             'Actions: [{"tag": "foo", "name": "MockTool", "path": "test", "input": {"values": {"test": "test input"}}}]\n'
             "<|Response|>: test observation\n"
-            "Answer: test output"
+            "Answer: test output",
+            meta={"is_react_prompt": True},
         )
         task = PromptTask(tools=[MockTool()])
         agent = Agent()

--- a/tests/unit/events/test_start_actions_subtask_event.py
+++ b/tests/unit/events/test_start_actions_subtask_event.py
@@ -1,5 +1,6 @@
 import pytest
 
+from griptape.artifacts import TextArtifact
 from griptape.events import StartActionsSubtaskEvent
 from griptape.structures import Agent
 from griptape.tasks import ActionsSubtask, PromptTask
@@ -9,11 +10,12 @@ from tests.mocks.mock_tool.tool import MockTool
 class TestStartActionsSubtaskEvent:
     @pytest.fixture()
     def start_subtask_event(self):
-        valid_input = (
+        valid_input = TextArtifact(
             "Thought: need to test\n"
             'Actions: [{"tag": "foo", "name": "MockTool", "path": "test", "input": {"values": {"test": "test input"}}}]\n'
             "<|Response|>: test observation\n"
-            "Answer: test output"
+            "Answer: test output",
+            meta={"is_react_prompt": True},
         )
         task = PromptTask(tools=[MockTool()])
         agent = Agent()

--- a/tests/unit/tasks/test_toolkit_task.py
+++ b/tests/unit/tasks/test_toolkit_task.py
@@ -239,11 +239,12 @@ class TestToolkitSubtask:
         assert result.output_task.output.to_text() == "foo bar"
 
     def test_init_from_prompt_1(self):
-        valid_input = (
+        valid_input = TextArtifact(
             "Thought: need to test\n"
             'Actions: [{"tag": "foo", "name": "Tool1", "path": "test", "input": {"values": {"test": "value"}}}]\n'
             "<|Response|>: test observation\n"
-            "Answer: test output"
+            "Answer: test output",
+            meta={"is_react_prompt": True},
         )
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
 
@@ -259,8 +260,11 @@ class TestToolkitSubtask:
         assert subtask.output is None
 
     def test_init_from_prompt_2(self):
-        valid_input = """Thought: need to test\nObservation: test
-        observation\nAnswer: test output"""
+        valid_input = TextArtifact(
+            """Thought: need to test\nObservation: test
+        observation\nAnswer: test output""",
+            meta={"is_react_prompt": True},
+        )
         task = ToolkitTask("test", tools=[MockTool(name="Tool1")])
 
         Agent().add_task(task)

--- a/tests/unit/utils/test_stream.py
+++ b/tests/unit/utils/test_stream.py
@@ -25,7 +25,7 @@ class TestStream:
                 assert next(chat_stream_run).value == "MockTool.mock-tag (test)"
                 assert next(chat_stream_run).value == json.dumps({"values": {"test": "test-value"}}, indent=2)
                 next(chat_stream_run)
-                assert next(chat_stream_run).value == "Answer: mock output"
+                assert next(chat_stream_run).value == "mock output"
                 next(chat_stream_run)
                 with pytest.raises(StopIteration):
                     next(chat_stream_run)


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- `Answer:` being trimmed from LLM's final answer even when using native tool calling.

This PR changes the logic of `ActionsSubtask` to be more precise about how it parses the input Actions. Previously, it followed the decision tree of:
- if TextArtifact: Parse ReAct prompt generated from Prompt Driver with `use_native_tools=False`.
- else: Parse Artifact generated from Prompt Driver with `use_native_tools=True`.

The problem is that even Prompt Driver with `use_native_tools=True` eventually generates a TextArtifact. Now the decision tree looks like:
- if TextArtifact **and** the TextArtifact has been explicitly marked as a ReAct Prompt: Parse ReAct prompt generated from Prompt Driver with `use_native_tools=False`.
- else: Parse Artifact generated from Prompt Driver with `use_native_tools=True`.

The way ReAct Artifacts are "marked" is via a metadata field, `is_react_prompt`. Technically this change of behavior is a breaking change but I highly doubt anyone is passing inputs into `ActionsSubtask` directly.

## Issue ticket number and link
NA