### PR TITLE
fix(drivers): don't make assumptions about what tool delta will contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Answer:` being trimmed from LLM's final answer even when using native tool calling. 
 - `NotADirectoryError` being raised for valid list operations in `FileManagerTool`.
 - `GriptapeCloudFileManagerDriver` list operation using wrong method when listing assets in a bucket.
+- Structured output with `tool` strategy not working with certain OpenAI-compatible Prompt Drivers during streaming.
 
 
 ## [1.2.0] - 2025-01-21

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -319,16 +319,14 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                 index = tool_call.index
 
                 if tool_call.function is not None:
-                    # Tool call delta either contains the function header or the partial input.
-                    if tool_call.id is not None and tool_call.function.name is not None:
-                        return ActionCallDeltaMessageContent(
-                            index=index,
-                            tag=tool_call.id,
-                            name=ToolAction.from_native_tool_name(tool_call.function.name)[0],
-                            path=ToolAction.from_native_tool_name(tool_call.function.name)[1],
-                        )
-                    else:
-                        return ActionCallDeltaMessageContent(index=index, partial_input=tool_call.function.arguments)
+                    function_name = tool_call.function.name
+                    return ActionCallDeltaMessageContent(
+                        index=index,
+                        tag=tool_call.id,
+                        name=ToolAction.from_native_tool_name(function_name)[0] if function_name else None,
+                        path=ToolAction.from_native_tool_name(function_name)[1] if function_name else None,
+                        partial_input=tool_call.function.arguments,
+                    )
                 else:
                     raise ValueError(f"Unsupported tool call delta: {tool_call}")
             else:


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- Structured output with `tool` strategy not working with certain OpenAI-compatible Prompt Drivers during streaming.

OpenAi returns either a function id + name or function arguments. Some OpenAi compatible providers (groq) don't follow this same behavior.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1642