### PR TITLE
feat(drivers-sql): cache SqlDriver.get_table_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GriptapeCloudStructureRunDriver` now publishes its events to the global event bus.
 - Changed log level of Tool execution errors from `EXCEPTION` to `DEBUG`
 - Improved mime type detection in `FileManagerTool`.
+- Improve `SqlDriver.get_table_schema` speed.
+- Cache `SqlDriver.get_table_schema` results.
 
 ### Deprecated
 

--- a/tests/unit/drivers/sql/test_sql_driver.py
+++ b/tests/unit/drivers/sql/test_sql_driver.py
@@ -29,5 +29,10 @@ class TestSqlDriver:
             driver.get_table_schema("test_table")
             == "[('id', INTEGER()), ('name', TEXT()), ('age', INTEGER()), ('city', TEXT())]"
         )
+        # Calling twice to ensure that lru_cache is hit
+        assert (
+            driver.get_table_schema("test_table")
+            == "[('id', INTEGER()), ('name', TEXT()), ('age', INTEGER()), ('city', TEXT())]"
+        )
 
         assert driver.get_table_schema("doesnt-exist") is None


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Changed
- Improve `SqlDriver.get_table_schema` speed.
- Cache `SqlDriver.get_table_schema` results.
Multiple calls to SqlTool are very slow.
## Issue ticket number and link
NA