### PR TITLE
feat(serialization): add support for new serialization metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool streaming support to `OllamaPromptDriver`.
 - `DateTimeTool.add_timedelta` and `DateTimeTool.get_datetime_diff` for basic datetime arithmetic.
 - Support for `pydantic.BaseModel`s anywhere `schema.Schema` is supported.
+- Support for new serialization metadata, `serialization_key` and `deserialization_key` for more granular control over serialization. 
 
 ### Changed
 
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NotADirectoryError` being raised for valid list operations in `FileManagerTool`.
 - `GriptapeCloudFileManagerDriver` list operation using wrong method when listing assets in a bucket.
 - `GriptapeCloudAssistantDriver` not initializing `thread_id` when providing a `thread_alias` and `auto_create_thread=True`.
+- Default Rulesets being duplicated when serializing `PromptTask`.
 
 
 ## [1.2.0] - 2025-01-21

--- a/griptape/mixins/rule_mixin.py
+++ b/griptape/mixins/rule_mixin.py
@@ -12,8 +12,15 @@ from griptape.rules import BaseRule, Ruleset
 class RuleMixin(SerializableMixin):
     DEFAULT_RULESET_NAME = "Default Ruleset"
 
-    _rulesets: list[Ruleset] = field(factory=list, kw_only=True, alias="rulesets", metadata={"serializable": True})
-    rules: list[BaseRule] = field(factory=list, kw_only=True)
+    _rulesets: list[Ruleset] = field(
+        factory=list,
+        kw_only=True,
+        alias="rulesets",
+        metadata={"serializable": True, "serialization_key": "_rulesets", "deserialization_key": "rulesets"},
+    )
+    rules: list[BaseRule] = field(
+        factory=list, kw_only=True, metadata={"serializable": True, "deserialization_key": "rules"}
+    )
     _default_ruleset_name: str = field(default=Factory(lambda: RuleMixin.DEFAULT_RULESET_NAME), kw_only=True)
     _default_ruleset_id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True)
 

--- a/tests/unit/mixins/test_rule_mixin.py
+++ b/tests/unit/mixins/test_rule_mixin.py
@@ -68,22 +68,16 @@ class TestRuleMixin:
                     "rules": [{"type": "Rule", "value": "baz"}],
                     "type": "Ruleset",
                 },
+            ],
+            "rules": [
+                {"type": "Rule", "value": "foo"},
                 {
-                    "name": "Default Ruleset",
-                    "id": mixin.rulesets[1].id,
-                    "meta": {},
-                    "rules": [
-                        {"type": "Rule", "value": "foo"},
-                        {
-                            "type": "JsonSchemaRule",
-                            "value": {
-                                "properties": {"foo": {"type": "string"}},
-                                "required": ["foo"],
-                                "type": "object",
-                            },
-                        },
-                    ],
-                    "type": "Ruleset",
+                    "type": "JsonSchemaRule",
+                    "value": {
+                        "properties": {"foo": {"type": "string"}},
+                        "required": ["foo"],
+                        "type": "object",
+                    },
                 },
             ],
             "type": "RuleMixin",

--- a/tests/unit/structures/test_structure.py
+++ b/tests/unit/structures/test_structure.py
@@ -74,6 +74,7 @@ class TestStructure:
                     "max_meta_memory_entries": agent.tasks[0].max_meta_memory_entries,
                     "context": agent.tasks[0].context,
                     "rulesets": [],
+                    "rules": [],
                     "max_subtasks": 20,
                     "tools": [],
                     "prompt_driver": {
@@ -88,6 +89,7 @@ class TestStructure:
                 }
             ],
             "rulesets": [],
+            "rules": [],
             "conversation_memory": {
                 "type": agent.conversation_memory.type,
                 "runs": agent.conversation_memory.runs,

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -251,6 +251,7 @@ class TestToolTask:
             "max_meta_memory_entries": task.max_meta_memory_entries,
             "context": task.context,
             "rulesets": [],
+            "rules": [],
             "prompt_driver": {
                 "extra_params": {},
                 "max_tokens": None,

--- a/tests/unit/tasks/test_toolkit_task.py
+++ b/tests/unit/tasks/test_toolkit_task.py
@@ -396,6 +396,7 @@ class TestToolkitSubtask:
             "max_meta_memory_entries": 20,
             "context": {},
             "rulesets": [],
+            "rules": [],
             "prompt_driver": {
                 "extra_params": {},
                 "max_tokens": None,


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Added
- Support for new serialization metadata, `serialization_key` and `deserialization_key` for more granular control over serialization. 
### Fixed
- Default Rulesets being duplicated when serializing `PromptTask`.
- 
`serialization_key`: the field to pull the data from.
`deserialization_key`: the field name to serialize back into

## Issue ticket number and link
Closes #1536, #1465 