### PR TITLE
fix(stream): check that structure id is self before ending stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GriptapeCloudAssistantDriver` not initializing `thread_id` when providing a `thread_alias` and `auto_create_thread=True`.
 - Default Rulesets being duplicated when serializing `PromptTask`.
 - Structured output with `tool` strategy not working with certain OpenAI-compatible Prompt Drivers during streaming.
+- `Stream` cutting off early when running multiple Structures.
 
 
 ## [1.2.0] - 2025-01-21

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -220,7 +220,7 @@ class Structure(RuleMixin, SerializableMixin, RunnableMixin["Structure"], ABC):
 
             while True:
                 event = self._event_queue.get()
-                if isinstance(event, FinishStructureRunEvent):
+                if isinstance(event, FinishStructureRunEvent) and event.structure_id == self.id:
                     break
                 else:
                     yield event

--- a/griptape/utils/stream.py
+++ b/griptape/utils/stream.py
@@ -35,9 +35,7 @@ class Stream:
         for event in self.structure.run_stream(
             *args, event_types=[TextChunkEvent, ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent]
         ):
-            if isinstance(event, FinishStructureRunEvent):
-                break
-            elif isinstance(event, FinishPromptEvent):
+            if isinstance(event, FinishPromptEvent):
                 yield TextArtifact(value="\n")
             elif isinstance(event, TextChunkEvent):
                 yield TextArtifact(value=event.token)


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Fixed
- `Stream` cutting off early when running multiple Structures.

## Issue ticket number and link
Closes #1659