### PR TITLE
feat(drivers-azure): bump api_version in Azure Prompt/Embedding Drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved mime type detection in `FileManagerTool`.
 - Improve `SqlDriver.get_table_schema` speed.
 - Cache `SqlDriver.get_table_schema` results.
+- Updated Azure Drivers to use the latest Azure OpenAI API version, `2024-10-21`.
 
 ### Deprecated
 

--- a/griptape/drivers/embedding/azure_openai_embedding_driver.py
+++ b/griptape/drivers/embedding/azure_openai_embedding_driver.py
@@ -36,7 +36,7 @@ class AzureOpenAiEmbeddingDriver(OpenAiEmbeddingDriver):
         default=None,
         metadata={"serializable": False},
     )
-    api_version: str = field(default="2023-05-15", kw_only=True, metadata={"serializable": True})
+    api_version: str = field(default="2024-10-21", kw_only=True, metadata={"serializable": True})
     tokenizer: OpenAiTokenizer = field(
         default=Factory(lambda self: OpenAiTokenizer(model=self.model), takes_self=True),
         kw_only=True,

--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -37,7 +37,7 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
         default=None,
         metadata={"serializable": False},
     )
-    api_version: str = field(default="2023-05-15", kw_only=True, metadata={"serializable": True})
+    api_version: str = field(default="2024-10-21", kw_only=True, metadata={"serializable": True})
     _client: openai.AzureOpenAI = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
@@ -54,13 +54,11 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         params = super()._base_params(prompt_stack)
-        # TODO: Add `seed` parameter once Azure supports it.
-        if "seed" in params:
+        if self.api_version < "2024-02-01" and "seed" in params:
             del params["seed"]
-        # TODO: Add `stream_options` parameter once Azure supports it.
-        if "stream_options" in params:
-            del params["stream_options"]
-        # TODO: Add `parallel_tool_calls` parameter once Azure supports it.
-        if "parallel_tool_calls" in params:
-            del params["parallel_tool_calls"]
+        if self.api_version < "2024-10-21":
+            if "stream_options" in params:
+                del params["stream_options"]
+            if "parallel_tool_calls" in params:
+                del params["parallel_tool_calls"]
         return params

--- a/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
+++ b/tests/unit/configs/drivers/test_azure_openai_drivers_config.py
@@ -26,7 +26,7 @@ class TestAzureOpenAiDriversConfig:
                 "model": "gpt-4o",
                 "azure_deployment": "gpt-4o",
                 "azure_endpoint": "http://localhost:8080",
-                "api_version": "2023-05-15",
+                "api_version": "2024-10-21",
                 "organization": None,
                 "parallel_tool_calls": True,
                 "reasoning_effort": "medium",
@@ -47,7 +47,7 @@ class TestAzureOpenAiDriversConfig:
             "embedding_driver": {
                 "base_url": None,
                 "model": "text-embedding-3-small",
-                "api_version": "2023-05-15",
+                "api_version": "2024-10-21",
                 "azure_deployment": "text-embedding-3-small",
                 "azure_endpoint": "http://localhost:8080",
                 "organization": None,
@@ -70,7 +70,7 @@ class TestAzureOpenAiDriversConfig:
                 "embedding_driver": {
                     "base_url": None,
                     "model": "text-embedding-3-small",
-                    "api_version": "2023-05-15",
+                    "api_version": "2024-10-21",
                     "azure_deployment": "text-embedding-3-small",
                     "azure_endpoint": "http://localhost:8080",
                     "organization": None,


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Changed
- Updated Azure Drivers to use the latest Azure OpenAI API version, `2024-10-21`.

## Issue ticket number and link
Closes https://github.com/orgs/griptape-ai/discussions/1631, #1640