### PR TITLE
fix(drivers-prompt-openai): conditionally add modalities/reasoning_effort based on model

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -169,7 +169,11 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             "user": self.user,
             "seed": self.seed,
             **({"modalities": self.modalities} if self.modalities and not self.is_reasoning_model else {}),
-            **({"reasoning_effort": self.reasoning_effort} if self.model in ("o1", "o3-mini") else {}),
+            **(
+                {"reasoning_effort": self.reasoning_effort}
+                if self.is_reasoning_model and self.model != "o1-mini"
+                else {}
+            ),
             **({"temperature": self.temperature} if not self.is_reasoning_model else {}),
             **({"audio": self.audio} if "audio" in self.modalities else {}),
             **({"stop": self.tokenizer.stop_sequences} if self.tokenizer.stop_sequences else {}),

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -169,7 +169,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             "user": self.user,
             "seed": self.seed,
             **({"modalities": self.modalities} if self.modalities and not self.is_reasoning_model else {}),
-            **({"reasoning_effort": self.reasoning_effort} if self.is_reasoning_model else {}),
+            **({"reasoning_effort": self.reasoning_effort} if self.model in ("o1", "o3-mini") else {}),
             **({"temperature": self.temperature} if not self.is_reasoning_model else {}),
             **({"audio": self.audio} if "audio" in self.modalities else {}),
             **({"stop": self.tokenizer.stop_sequences} if self.tokenizer.stop_sequences else {}),

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -168,7 +168,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             "model": self.model,
             "user": self.user,
             "seed": self.seed,
-            "modalities": self.modalities,
+            **({"modalities": self.modalities} if self.modalities and not self.is_reasoning_model else {}),
             **({"reasoning_effort": self.reasoning_effort} if self.is_reasoning_model else {}),
             **({"temperature": self.temperature} if not self.is_reasoning_model else {}),
             **({"audio": self.audio} if "audio" in self.modalities else {}),

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -483,7 +483,11 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             user=driver.user,
             messages=reasoning_messages if driver.is_reasoning_model else messages,
             seed=driver.seed,
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
             **{
                 "audio": driver.audio,
             }

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -452,7 +452,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
-    @pytest.mark.parametrize("model", ["gpt-4o", "o1", "o3"])
+    @pytest.mark.parametrize("model", ["gpt-4o", "o1", "o3", "o3-mini"])
     @pytest.mark.parametrize("modalities", [["text"], ["text", "audio"], ["audio"]])
     def test_try_run(
         self,
@@ -496,7 +496,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             **{
                 "reasoning_effort": driver.reasoning_effort,
             }
-            if driver.model in ("o1", "o3-mini")
+            if driver.is_reasoning_model and model != "o1-mini"
             else {},
             **{
                 "temperature": driver.temperature,
@@ -631,7 +631,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
-    @pytest.mark.parametrize("model", ["gpt-4o", "o1", "o3"])
+    @pytest.mark.parametrize("model", ["gpt-4o", "o1", "o3", "o3-mini"])
     @pytest.mark.parametrize("modalities", [["text"], ["text", "audio"], ["audio"]])
     def test_try_stream_run(
         self,
@@ -671,16 +671,8 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            **{
-                "modalities": driver.modalities,
-            }
-            if not driver.is_reasoning_model
-            else {},
-            **{
-                "reasoning_effort": driver.reasoning_effort,
-            }
-            if driver.model in ("o1", "o3-mini")
-            else {},
+            **{"modalities": driver.modalities} if not driver.is_reasoning_model else {},
+            **{"reasoning_effort": driver.reasoning_effort} if driver.is_reasoning_model and model != "o1-mini" else {},
             **{
                 "temperature": driver.temperature,
             }

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -496,7 +496,7 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             **{
                 "reasoning_effort": driver.reasoning_effort,
             }
-            if driver.is_reasoning_model
+            if driver.model in ("o1", "o3-mini")
             else {},
             **{
                 "temperature": driver.temperature,
@@ -563,7 +563,11 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
             response_format={"type": "json_object"},
         )
         assert message.value[0].value == "model-output"
@@ -600,7 +604,11 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
             response_format={
                 "json_schema": {
                     "schema": {
@@ -663,11 +671,15 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
             **{
                 "reasoning_effort": driver.reasoning_effort,
             }
-            if driver.is_reasoning_model
+            if driver.model in ("o1", "o3-mini")
             else {},
             **{
                 "temperature": driver.temperature,
@@ -751,7 +763,11 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
         )
         assert event.value[0].value == "model-output"
 
@@ -792,7 +808,11 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
+            **{
+                "modalities": driver.modalities,
+            }
+            if not driver.is_reasoning_model
+            else {},
             max_tokens=1,
         )
         assert event.value[0].value == "model-output"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Fix driver for reasoning models

```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Unknown parameter: 'modalities'.", 'type': 'invalid_request_error', 'param':        
                             'modalities', 'code': 'unknown_parameter'}}     
```

## Issue ticket number and link
