### PR TITLE
fix(utils): wrap primitives with more specific artifact types

### DIFF
--- a/tests/unit/utils/test_griptape_cloud.py
+++ b/tests/unit/utils/test_griptape_cloud.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from griptape.artifacts.text_artifact import TextArtifact
+from griptape.artifacts import BooleanArtifact, JsonArtifact, TextArtifact
 from griptape.drivers.event_listener.griptape_cloud import GriptapeCloudEventListenerDriver
 from griptape.events import EventListener
 from griptape.events.event_bus import EventBus
@@ -53,7 +53,16 @@ class TestGriptapeCloudUtils:
             event_listener=EventListener(event_listener_driver=MockEventListenerDriver())
         ) as context:
             context.output = "foo"
+            assert isinstance(context.output, TextArtifact)
             assert context.output.value == "foo"
+
+            context.output = True
+            assert isinstance(context.output, BooleanArtifact)
+            assert context.output.value is True
+
+            context.output = {"foo": "bar"}
+            assert isinstance(context.output, JsonArtifact)
+            assert context.output.value == {"foo": "bar"}
 
             output = TextArtifact("bar")
             context.output = output

--- a/tests/unit/utils/test_griptape_cloud.py
+++ b/tests/unit/utils/test_griptape_cloud.py
@@ -1,8 +1,9 @@
 import os
+from unittest.mock import Mock
 
 import pytest
 
-from griptape.artifacts import BooleanArtifact, JsonArtifact, TextArtifact
+from griptape.artifacts import BlobArtifact, BooleanArtifact, GenericArtifact, JsonArtifact, ListArtifact, TextArtifact
 from griptape.drivers.event_listener.griptape_cloud import GriptapeCloudEventListenerDriver
 from griptape.events import EventListener
 from griptape.events.event_bus import EventBus
@@ -64,6 +65,21 @@ class TestGriptapeCloudUtils:
             assert isinstance(context.output, JsonArtifact)
             assert context.output.value == {"foo": "bar"}
 
+            context.output = b"foo"
+            assert isinstance(context.output, BlobArtifact)
+            assert context.output.value == b"foo"
+
+            context.output = ["foo", b"bar"]
+            assert isinstance(context.output, ListArtifact)
+            assert isinstance(context.output.value[0], TextArtifact)
+            assert context.output.value[0].value == "foo"
+            assert isinstance(context.output.value[1], BlobArtifact)
+            assert context.output.value[1].value == b"bar"
+
             output = TextArtifact("bar")
             context.output = output
             assert context.output is output
+
+            context.output = Mock(foo="bar")
+            assert isinstance(context.output, GenericArtifact)
+            assert context.output.value.foo == "bar"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Certain Cloud features look for specific Artifact types. This makes the `output` property take advantage of those more specific types.
## Issue ticket number and link
NA