### PR TITLE
ci: configure release-please for backporting on release branches

### DIFF
--- a/.github/workflows/release-backport.yml
+++ b/.github/workflows/release-backport.yml
@@ -1,0 +1,17 @@
+name: Release Backport
+on:
+  push:
+    branches:
+      - release/*
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Release
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: python
+          versioning-strategy: always-bump-patch

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,20 +1,17 @@
-name: Release
-
+name: Release Main
 on:
   push:
     branches:
       - main
-
 jobs:
   release:
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
       pull-requests: write
-
     steps:
       - name: Release
         uses: googleapis/release-please-action@v4
         with:
-          release-type: simple
+          release-type: python
+          versioning-strategy: default


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Configures release-please to run on [release branches](https://trunkbaseddevelopment.com/branch-for-release/). 
Sources:
- https://github.com/googleapis/release-please/issues/1821#issuecomment-1423384825
- https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies
TBH I'm still not sure this is what we want. This workflow does not seem well documented like it is in [semantic-release](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches).
## Issue ticket number and link
NA