### PR TITLE
ci: always bump minor on main

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -14,4 +14,4 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           release-type: python
-          versioning-strategy: default
+          versioning-strategy: always-bump-minor


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Don't want main release PR to patch bump. That's the role of the backport PR.
## Issue ticket number and link
https://github.com/griptape-ai/griptape/pull/1680