### PR TITLE
fix(drivers-prompt-azure-openai): fix AzureOpenAiChatPromptDriver by removing unsupported "modalities"

### DIFF
--- a/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/azure_openai_chat_prompt_driver.py
@@ -61,4 +61,8 @@ class AzureOpenAiChatPromptDriver(OpenAiChatPromptDriver):
                 del params["stream_options"]
             if "parallel_tool_calls" in params:
                 del params["parallel_tool_calls"]
+
+        # TODO: Add once Azure supports modalities
+        if "modalities" in params:
+            del params["modalities"]
         return params

--- a/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_azure_openai_chat_prompt_driver.py
@@ -143,7 +143,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             model="gpt-4",
             use_native_tools=use_native_tools,
             structured_output_strategy=structured_output_strategy,
-            modalities=modalities,
             extra_params={"foo": "bar"},
             api_version=api_version,
         )
@@ -157,7 +156,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             temperature=driver.temperature,
             user=driver.user,
             messages=messages,
-            modalities=driver.modalities,
             **{
                 "audio": driver.audio,
             }
@@ -231,7 +229,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             stream=True,
             use_native_tools=use_native_tools,
             structured_output_strategy=structured_output_strategy,
-            modalities=modalities,
             extra_params={"foo": "bar"},
             api_version=api_version,
         )
@@ -250,7 +247,6 @@ class TestAzureOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
             }
             if "audio" in driver.modalities
             else {},
-            modalities=driver.modalities,
             stream=True,
             messages=messages,
             **{


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Unclear how this got missed by integration tests..
## Issue ticket number and link
Closes #1693 