### PR TITLE
fix(schema): declare all artifacts for deserialization

### DIFF
--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -195,7 +195,20 @@ class BaseSchema(Schema):
         from pydantic import BaseModel
         from schema import Schema
 
-        from griptape.artifacts import BaseArtifact, TextArtifact
+        from griptape.artifacts import (
+            ActionArtifact,
+            AudioArtifact,
+            BaseArtifact,
+            BlobArtifact,
+            BooleanArtifact,
+            ErrorArtifact,
+            GenericArtifact,
+            ImageArtifact,
+            InfoArtifact,
+            JsonArtifact,
+            ListArtifact,
+            TextArtifact,
+        )
         from griptape.common import (
             BaseDeltaMessageContent,
             BaseMessageContent,
@@ -249,6 +262,16 @@ class BaseSchema(Schema):
                 "BaseTool": BaseTool,
                 "BaseTask": BaseTask,
                 "TextArtifact": TextArtifact,
+                "ImageArtifact": ImageArtifact,
+                "ErrorArtifact": ErrorArtifact,
+                "InfoArtifact": InfoArtifact,
+                "JsonArtifact": JsonArtifact,
+                "BlobArtifact": BlobArtifact,
+                "BooleanArtifact": BooleanArtifact,
+                "ListArtifact": ListArtifact,
+                "AudioArtifact": AudioArtifact,
+                "ActionArtifact": ActionArtifact,
+                "GenericArtifact": GenericArtifact,
                 "Usage": Message.Usage,
                 "Structure": Structure,
                 "BaseTokenizer": BaseTokenizer,


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
```
name 'ImageArtifact' is not defined

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/griptape/tasks/base_task.py", line 172, in run
    self.output = self.try_run()
  File "/usr/local/lib/python3.12/site-packages/griptape/tasks/prompt_task.py", line 191, in try_run
    output = self.prompt_driver.run(self.prompt_stack).to_artifact()
  File "/usr/local/lib/python3.12/site-packages/griptape/common/decorators.py", line 18, in decorator
    Observability.observe(
  File "/usr/local/lib/python3.12/site-packages/griptape/observability/observability.py", line 39, in observe
    return driver.observe(call)
  File "/usr/local/lib/python3.12/site-packages/griptape/drivers/observability/no_op_observability_driver.py", line 16, in observe
    return call()
  File "/usr/local/lib/python3.12/site-packages/griptape/common/observable.py", line 19, in __call__
    return self.func(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.12/site-packages/griptape/drivers/prompt/base_prompt_driver.py", line 91, in run
    for attempt in self.retrying():
  File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py", line 443, in __iter__
    do = self.iter(retry_state=retry_state)
  File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py", line 376, in iter
    result = action(retry_state)
  File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py", line 418, in exc_check
    raise retry_exc.reraise()
  File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py", line 185, in reraise
    raise self.last_attempt.result()
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.12/site-packages/griptape/drivers/prompt/base_prompt_driver.py", line 93, in run
    self.before_run(prompt_stack)
  File "/usr/local/lib/python3.12/site-packages/griptape/drivers/prompt/base_prompt_driver.py", line 72, in before_run
    EventBus.publish_event(StartPromptEvent(model=self.model, prompt_stack=prompt_stack))
  File "/usr/local/lib/python3.12/site-packages/griptape/events/event_bus.py", line 53, in publish_event
    event_listener.publish_event(event, flush=flush)
  File "/usr/local/lib/python3.12/site-packages/griptape/events/event_listener.py", line 54, in publish_event
    self.event_listener_driver.publish_event(handled_event)
  File "/usr/local/lib/python3.12/site-packages/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py", line 58, in publish_event
    event_payload = event.to_dict() if isinstance(event, BaseEvent) else event
  File "/usr/local/lib/python3.12/site-packages/griptape/mixins/serializable_mixin.py", line 69, in to_dict
    return dict(schema().dump(self))
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 621, in dump
    result = self._serialize(processed_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 589, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 348, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 656, in _serialize
    return schema.dump(nested_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 621, in dump
    result = self._serialize(processed_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 589, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 348, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 799, in _serialize
    return [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 656, in _serialize
    return schema.dump(nested_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 621, in dump
    result = self._serialize(processed_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/schema.py", line 589, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 348, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 799, in _serialize
    return [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
  File "/usr/local/lib/python3.12/site-packages/marshmallow/fields.py", line 656, in _serialize
    return schema.dump(nested_obj, many=many)
  File "/usr/local/lib/python3.12/site-packages/griptape/schemas/polymorphic_schema.py", line 36, in dump
    result = result_data = self._dump(obj, **kwargs)
  File "/usr/local/lib/python3.12/site-packages/griptape/schemas/polymorphic_schema.py", line 61, in _dump
    type_schema = BaseSchema.from_attrs_cls(obj.__class__)
  File "/usr/local/lib/python3.12/site-packages/griptape/schemas/base_schema.py", line 46, in from_attrs_cls
    cls._resolve_types(attrs_cls)
  File "/usr/local/lib/python3.12/site-packages/griptape/schemas/base_schema.py", line 230, in _resolve_types
    attrs.resolve_types(
  File "/usr/local/lib/python3.12/site-packages/attr/_funcs.py", line 458, in resolve_types
    hints = typing.get_type_hints(cls, **kwargs)
  File "/usr/local/lib/python3.12/typing.py", line 2272, in get_type_hints
    value = _eval_type(value, base_globals, base_locals, base.__type_params__)
  File "/usr/local/lib/python3.12/typing.py", line 415, in _eval_type
    return t._evaluate(globalns, localns, type_params, recursive_guard=recursive_guard)
  File "/usr/local/lib/python3.12/typing.py", line 947, in _evaluate
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
NameError: name 'ImageArtifact' is not defined. Did you mean: 'BaseArtifact'?
```

## Issue ticket number and link
#1587 