### PR TITLE
ci: configure release-please manifests

### DIFF
--- a/.github/workflows/release.backport.yml
+++ b/.github/workflows/release.backport.yml
@@ -2,7 +2,7 @@ name: Release Backport
 on:
   push:
     branches:
-      - release/*
+      - releases/*
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -11,8 +11,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v3
         with:
           release-type: python
-          versioning: always-bump-patch
-          target-branch: ${{ github.ref_name }}
+          versioning-strategy: always-bump-patch
+          default-branch: ${{ github.ref_name }} 

--- a/.github/workflows/release.main.yml
+++ b/.github/workflows/release.main.yml
@@ -11,8 +11,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v3
         with:
           release-type: python
-          versioning: always-bump-minor
-          target-branch: ${{ github.ref_name }}
+          versioning-strategy: always-bump-minor
+          default-branch: ${{ github.ref_name }} 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Action v4 requires configuring [certain parameters](https://github.com/googleapis/release-please-action?tab=readme-ov-file#package-options) in a manifest. This is annoying and I couldn't get it working. Good ol v3 works great.
## Issue ticket number and link
NA