### PR TITLE
fix(tasks): remove deprecation warning on CodeExecutionTask.input

### DIFF
--- a/griptape/tasks/code_execution_task.py
+++ b/griptape/tasks/code_execution_task.py
@@ -6,7 +6,7 @@ from attrs import define, field
 
 from griptape.artifacts import BaseArtifact, TextArtifact
 from griptape.tasks.base_task import BaseTask
-from griptape.utils import J2, deprecation_warn
+from griptape.utils import J2
 
 T = TypeVar("T", bound=BaseArtifact)  # Return type of task
 
@@ -22,7 +22,6 @@ class CodeExecutionTask(BaseTask[T]):
 
     @property
     def input(self) -> TextArtifact:
-        deprecation_warn("CodeExecutionTask.input is deprecated and will be removed in a future release.")
         if isinstance(self._input, TextArtifact):
             return self._input
         elif callable(self._input):


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
May still be deprecated in the future, but this was added erroneously
## Issue ticket number and link
NA