### PR TITLE
fix(drivers): lower max_attempts in ExponentialBackoffMixin to reasonable value

### DIFF
--- a/griptape/mixins/exponential_backoff_mixin.py
+++ b/griptape/mixins/exponential_backoff_mixin.py
@@ -12,7 +12,7 @@ from tenacity import Retrying, retry_if_not_exception_type, stop_after_attempt, 
 class ExponentialBackoffMixin(ABC):
     min_retry_delay: float = field(default=2, kw_only=True)
     max_retry_delay: float = field(default=10, kw_only=True)
-    max_attempts: int = field(default=10, kw_only=True)
+    max_attempts: int = field(default=2, kw_only=True)
     after_hook: Callable = field(default=lambda s: logging.warning(s), kw_only=True)
     ignored_exception_types: tuple[type[Exception], ...] = field(factory=tuple, kw_only=True)
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
> Usually if something is going to fail, one or two retries is fine - and if the user needs more they can always increase it.
## Issue ticket number and link
Closes #1439 