### PR TITLE
fix(drivers): check existence of "audio" attribute

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -346,7 +346,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
 
         if response.content is not None:
             content.append(TextMessageContent(TextArtifact(response.content)))
-        if response.audio is not None:
+        if hasattr(response, "audio") and response.audio is not None:
             content.append(
                 AudioMessageContent(
                     AudioArtifact(


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Our dependencies require `openai^1.1.1` which means the client _might_ not include the audio attribute. Long term solution is to update minimum deps, but this hack is fine for now.
## Issue ticket number and link
![image](https://github.com/user-attachments/assets/8a2928e0-1010-4b23-8039-dec34057e632)
