### PR TITLE
fix(tasks): fix task input being lost on multiple Structure runs

### DIFF
--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -305,9 +305,7 @@ class PromptTask(
         task_input: str | tuple | list | BaseArtifact | Callable[[BaseTask], BaseArtifact],
     ) -> BaseArtifact:
         if isinstance(task_input, TextArtifact):
-            task_input.value = J2().render_from_string(task_input.value, **self.full_context)
-
-            return task_input
+            return TextArtifact(J2().render_from_string(task_input.value, **self.full_context), meta=task_input.meta)
         elif isinstance(task_input, Callable):
             return self._process_task_input(task_input(self))
         elif isinstance(task_input, ListArtifact):

--- a/tests/unit/tasks/test_prompt_task.py
+++ b/tests/unit/tasks/test_prompt_task.py
@@ -10,7 +10,7 @@ from griptape.memory.structure.run import Run
 from griptape.rules import Rule
 from griptape.rules.json_schema_rule import JsonSchemaRule
 from griptape.rules.ruleset import Ruleset
-from griptape.structures import Pipeline
+from griptape.structures import Agent, Pipeline
 from griptape.tasks import PromptTask
 from tests.mocks.mock_prompt_driver import MockPromptDriver
 from tests.mocks.mock_tool.tool import MockTool
@@ -133,6 +133,19 @@ class TestPromptTask:
         task = PromptTask({"default": "test"})
 
         assert task.input.value == str({"default": "test"})
+
+    def test_input_run(self):
+        agent = Agent(tasks=[PromptTask(TextArtifact("{{ args[0] }}", meta={"foo": "bar"}))])
+
+        agent.run("1")
+
+        assert agent.task.input.value == "1"
+        assert agent.task.input.meta["foo"] == "bar"
+
+        agent.run("2")
+
+        assert agent.task.input.value == "2"
+        assert agent.task.input.meta["foo"] == "bar"
 
     def test_input_context(self):
         pipeline = Pipeline(


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Create a new `TextArtifact` instead of mutating value of existing one. Fixes issues across multiple runs.
##  Issue ticket number and link
Closes #1731 