### PR TITLE
feat(tools): allow setting allowlist and denylist on Tools

### DIFF
--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -31,9 +31,6 @@ class ActivityMixin:
         if allowlist is None:
             return
 
-        if self.denylist is not None:
-            raise ValueError("can't have both allowlist and denylist specified")
-
         for activity_name in allowlist:
             self._validate_tool_activity(activity_name)
 
@@ -41,9 +38,6 @@ class ActivityMixin:
     def validate_denylist(self, _: Attribute, denylist: Optional[list[str]]) -> None:
         if denylist is None:
             return
-
-        if self.allowlist is not None:
-            raise ValueError("can't have both allowlist and denylist specified")
 
         for activity_name in denylist:
             self._validate_tool_activity(activity_name)

--- a/tests/unit/mixins/test_activity_mixin.py
+++ b/tests/unit/mixins/test_activity_mixin.py
@@ -43,17 +43,33 @@ class TestActivityMixin:
 
     def test_allowlist_and_denylist_validation(self):
         with pytest.raises(ValueError):
-            MockTool(test_field="hello", test_int=5, allowlist=[], denylist=[])
+            MockTool(test_field="hello", test_int=5, allowlist=["not_an_activity"], denylist=[])
 
-    def test_allowlist(self):
-        tool = MockTool(test_field="hello", test_int=5, allowlist=["test"])
+    @pytest.mark.parametrize(
+        ("allowlist", "denylist", "expected_activities"),
+        [
+            (["test"], None, ["test"]),
+            (["test"], ["test"], []),
+            (
+                None,
+                ["test"],
+                [
+                    "test_callable_schema",
+                    "test_error",
+                    "test_exception",
+                    "test_list_output",
+                    "test_no_schema",
+                    "test_str_output",
+                    "test_without_default_memory",
+                ],
+            ),
+            ([], ["test"], []),
+        ],
+    )
+    def test_allowdenylist(self, allowlist, denylist, expected_activities):
+        tool = MockTool(test_field="hello", test_int=5, allowlist=allowlist, denylist=denylist)
 
-        assert len(tool.activities()) == 1
-
-    def test_denylist(self):
-        tool = MockTool(test_field="hello", test_int=5, denylist=["test"])
-
-        assert len(tool.activities()) == 7
+        assert [getattr(activity, "name") for activity in tool.activities()] == expected_activities
 
     def test_invalid_allowlist(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Removes arbitrary restriction preventing setting allowlist and denylist on Tools. Both conditions must be satisfied to have the activity included.
## Issue ticket number and link
Closes #1735 