### PR TITLE
fix(engines-eval): fix evaluation parameters not being included in prompt

### DIFF
--- a/griptape/templates/engines/eval/results/system.j2
+++ b/griptape/templates/engines/eval/results/system.j2
@@ -1,6 +1,6 @@
 Given the evaluation steps, return a JSON with two keys:
 1) a `score` key ranging from 0 - 10, with 10 being that it follows the criteria outlined in the steps and 0 being that it does not.
-2) a `reason` key, a reason for the given score. Please mention specific information from {{ parameters }} in your reason, but be very concise with it!
+2) a `reason` key, a reason for the given score. Please mention specific information from {{ evaluation_params }} in your reason, but be very concise with it!
 
 Evaluation Steps:
 {{ evaluation_steps }}


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
NA
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1750