### PR TITLE
feat: add support for image embeddings

### DIFF
--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -5,14 +5,8 @@ search:
 
 ## Overview
 
-Embeddings in Griptape are multidimensional representations of text data. Embeddings carry semantic information, which makes them useful for extracting relevant chunks from large bodies of text for search and querying.
-
-Griptape provides a way to build Embedding Drivers that are reused in downstream framework components. Every Embedding Driver has two basic methods that can be used to generate embeddings:
-
-- [embed_text_artifact()](../../reference/griptape/drivers/embedding/base_embedding_driver.md#griptape.drivers.embedding.base_embedding_driver.BaseEmbeddingDriver.embed_text_artifact) for [TextArtifact](../../reference/griptape/artifacts/text_artifact.md)s.
-- [embed_string()](../../reference/griptape/drivers/embedding/base_embedding_driver.md#griptape.drivers.embedding.base_embedding_driver.BaseEmbeddingDriver.embed_string) for any string.
-
-You can optionally provide a [Tokenizer](../misc/tokenizers.md) via the [tokenizer](../../reference/griptape/drivers/embedding/base_embedding_driver.md#griptape.drivers.embedding.base_embedding_driver.BaseEmbeddingDriver.tokenizer) field to have the Driver automatically chunk the input text to fit into the token limit.
+Embeddings in Griptape are multidimensional representations of text or image data.
+Embeddings carry semantic information, making them powerful for use-cases like text or image similarity search in a [Rag Engine](../engines/rag-engines.md).
 
 ## Embedding Drivers
 

--- a/docs/griptape-framework/drivers/src/embedding_drivers_1.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_1.py
@@ -1,6 +1,6 @@
 from griptape.drivers.embedding.openai import OpenAiEmbeddingDriver
 
-embeddings = OpenAiEmbeddingDriver().embed_string("Hello Griptape!")
+embeddings = OpenAiEmbeddingDriver().embed("Hello Griptape!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_2.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_2.py
@@ -5,7 +5,7 @@ embedding_driver = OpenAiEmbeddingDriver(
     model="nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q2_K",
 )
 
-embeddings = embedding_driver.embed_string("Hello world!")
+embeddings = embedding_driver.embed("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_3.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_3.py
@@ -1,6 +1,14 @@
 from griptape.drivers.embedding.amazon_bedrock import AmazonBedrockTitanEmbeddingDriver
+from griptape.loaders import ImageLoader
 
-embeddings = AmazonBedrockTitanEmbeddingDriver().embed_string("Hello world!")
+embedding_driver = AmazonBedrockTitanEmbeddingDriver()
+embeddings = embedding_driver.embed("Hello world!")
 
-# display the first 3 embeddings
 print(embeddings[:3])
+
+# Some models support images!
+multi_modal_embedding_driver = AmazonBedrockTitanEmbeddingDriver(model="amazon.titan-embed-image-v1")
+image = ImageLoader().load("tests/resources/cow.png")
+image_embeddings = multi_modal_embedding_driver.embed(image)
+
+print(image_embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_4.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_4.py
@@ -1,6 +1,6 @@
 from griptape.drivers.embedding.google import GoogleEmbeddingDriver
 
-embeddings = GoogleEmbeddingDriver().embed_string("Hello world!")
+embeddings = GoogleEmbeddingDriver().embed("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_5.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_5.py
@@ -12,7 +12,7 @@ driver = HuggingFaceHubEmbeddingDriver(
     ),
 )
 
-embeddings = driver.embed_string("Hello world!")
+embeddings = driver.embed("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_7.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_7.py
@@ -7,7 +7,7 @@ driver = AmazonSageMakerJumpstartEmbeddingDriver(
     model=os.environ["SAGEMAKER_TENSORFLOW_HUB_MODEL"],
 )
 
-embeddings = driver.embed_string("Hello world!")
+embeddings = driver.embed("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_8.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_8.py
@@ -1,10 +1,18 @@
 import os
 
 from griptape.drivers.embedding.voyageai import VoyageAiEmbeddingDriver
+from griptape.loaders import ImageLoader
 
-driver = VoyageAiEmbeddingDriver(api_key=os.environ["VOYAGE_API_KEY"])
+embedding_driver = VoyageAiEmbeddingDriver(api_key=os.environ["VOYAGE_API_KEY"])
+embeddings = embedding_driver.embed("Hello world!")
 
-embeddings = driver.embed_string("Hello world!")
-
-# display the first 3 embeddings
 print(embeddings[:3])
+
+# Some models support images!
+multi_modal_embedding_driver = VoyageAiEmbeddingDriver(
+    api_key=os.environ["VOYAGE_API_KEY"], model="voyage-multimodal-3"
+)
+image = ImageLoader().load("tests/resources/cow.png")
+image_embeddings = multi_modal_embedding_driver.embed(image)
+
+print(image_embeddings[:3])

--- a/docs/griptape-framework/drivers/src/embedding_drivers_9.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_9.py
@@ -8,7 +8,7 @@ embedding_driver = CohereEmbeddingDriver(
     input_type="search_document",
 )
 
-embeddings = embedding_driver.embed_string("Hello world!")
+embeddings = embedding_driver.embed("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])

--- a/griptape/drivers/vector/azure_mongodb_vector_store_driver.py
+++ b/griptape/drivers/vector/azure_mongodb_vector_store_driver.py
@@ -61,23 +61,3 @@ class AzureMongoDbVectorStoreDriver(MongoDbAtlasVectorStoreDriver):
             )
             for doc in collection.aggregate(pipeline)
         ]
-
-    def query(
-        self,
-        query: str,
-        *,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
-        include_vectors: bool = False,
-        offset: Optional[int] = None,
-        **kwargs,
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        """Queries the MongoDB collection for documents that match the provided query string.
-
-        Results can be customized based on parameters like count, namespace, inclusion of vectors, offset, and index.
-        """
-        # Using the embedding driver to convert the query string into a vector
-        vector = self.embedding_driver.embed_string(query)
-        return self.query_vector(
-            vector, count=count, namespace=namespace, include_vectors=include_vectors, offset=offset, **kwargs
-        )

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import uuid
+import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, overload
 
 from attrs import define, field
 
 from griptape import utils
-from griptape.artifacts import BaseArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import BaseArtifact, ImageArtifact, ListArtifact, TextArtifact
 from griptape.mixins.futures_executor_mixin import FuturesExecutorMixin
 from griptape.mixins.serializable_mixin import SerializableMixin
 from griptape.utils import with_contextvars
@@ -40,13 +41,78 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         meta: Optional[dict] = None,
         **kwargs,
     ) -> list[str] | dict[str, list[str]]:
+        warnings.warn(
+            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert_collection` is a drop-in replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.upsert_collection(artifacts, meta=meta, **kwargs)
+
+    def upsert_text_artifact(
+        self,
+        artifact: TextArtifact,
+        *,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
+        vector_id: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        warnings.warn(
+            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert` is a drop-in replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.upsert(artifact, namespace=namespace, meta=meta, vector_id=vector_id, **kwargs)
+
+    def upsert_text(
+        self,
+        string: str,
+        *,
+        namespace: Optional[str] = None,
+        meta: Optional[dict] = None,
+        vector_id: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        warnings.warn(
+            "`BaseVectorStoreDriver.upsert_text` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert` is a drop-in replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.upsert(string, namespace=namespace, meta=meta, vector_id=vector_id, **kwargs)
+
+    @overload
+    def upsert_collection(
+        self,
+        artifacts: list[TextArtifact] | list[ImageArtifact],
+        *,
+        meta: Optional[dict] = None,
+        **kwargs,
+    ) -> list[str]: ...
+
+    @overload
+    def upsert_collection(
+        self,
+        artifacts: dict[str, list[TextArtifact]] | dict[str, list[ImageArtifact]],
+        *,
+        meta: Optional[dict] = None,
+        **kwargs,
+    ) -> dict[str, list[str]]: ...
+
+    def upsert_collection(
+        self,
+        artifacts: list[TextArtifact]
+        | list[ImageArtifact]
+        | dict[str, list[TextArtifact]]
+        | dict[str, list[ImageArtifact]],
+        *,
+        meta: Optional[dict] = None,
+        **kwargs,
+    ):
         with self.create_futures_executor() as futures_executor:
             if isinstance(artifacts, list):
                 return utils.execute_futures_list(
                     [
-                        futures_executor.submit(
-                            with_contextvars(self.upsert_text_artifact), a, namespace=None, meta=meta, **kwargs
-                        )
+                        futures_executor.submit(with_contextvars(self.upsert), a, namespace=None, meta=meta, **kwargs)
                         for a in artifacts
                     ],
                 )
@@ -60,21 +126,23 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
 
                         futures_dict[namespace].append(
                             futures_executor.submit(
-                                with_contextvars(self.upsert_text_artifact), a, namespace=namespace, meta=meta, **kwargs
+                                with_contextvars(self.upsert), a, namespace=namespace, meta=meta, **kwargs
                             )
                         )
 
                 return utils.execute_futures_list_dict(futures_dict)
 
-    def upsert_text_artifact(
+    def upsert(
         self,
-        artifact: TextArtifact,
+        value: str | TextArtifact | ImageArtifact,
         *,
         namespace: Optional[str] = None,
         meta: Optional[dict] = None,
         vector_id: Optional[str] = None,
         **kwargs,
     ) -> str:
+        artifact = TextArtifact(value) if isinstance(value, str) else value
+
         meta = {} if meta is None else meta
 
         if vector_id is None:
@@ -86,22 +154,9 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         else:
             meta = {**meta, "artifact": artifact.to_json()}
 
-            vector = artifact.embedding or artifact.generate_embedding(self.embedding_driver)
+            vector = self.embedding_driver.embed(artifact)
 
             return self.upsert_vector(vector, vector_id=vector_id, namespace=namespace, meta=meta, **kwargs)
-
-    def upsert_text(
-        self,
-        string: str,
-        *,
-        namespace: Optional[str] = None,
-        meta: Optional[dict] = None,
-        vector_id: Optional[str] = None,
-        **kwargs,
-    ) -> str:
-        return self.upsert_text_artifact(
-            TextArtifact(string), vector_id=vector_id, namespace=namespace, meta=meta, **kwargs
-        )
 
     def does_entry_exist(self, vector_id: str, *, namespace: Optional[str] = None) -> bool:
         try:
@@ -149,14 +204,22 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
 
     def query(
         self,
-        query: str,
+        query: str | TextArtifact | ImageArtifact,
         *,
         count: Optional[int] = None,
         namespace: Optional[str] = None,
         include_vectors: bool = False,
         **kwargs,
     ) -> list[Entry]:
-        vector = self.embedding_driver.embed_string(query)
+        try:
+            vector = self.embedding_driver.embed(query)
+        except ValueError as e:
+            raise ValueError(
+                "The Embedding Driver, %s, used by the Vector Store does not support embedding the %s type."
+                "To resolve, provide an Embedding Driver that supports this type.",
+                self.embedding_driver.__class__.__name__,
+                type(query),
+            ) from e
         return self.query_vector(vector, count=count, namespace=namespace, include_vectors=include_vectors, **kwargs)
 
     def _get_default_vector_id(self, value: str) -> str:

--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
 
@@ -21,17 +20,13 @@ if TYPE_CHECKING:
 class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
     DEFAULT_QUERY_COUNT = 5
 
-    @dataclass
-    class Entry:
-        id: str
-        vector: Optional[list[float]] = None
-        score: Optional[float] = None
-        meta: Optional[dict] = None
-        namespace: Optional[str] = None
-
-        @staticmethod
-        def from_dict(data: dict[str, Any]) -> BaseVectorStoreDriver.Entry:
-            return BaseVectorStoreDriver.Entry(**data)
+    @define
+    class Entry(SerializableMixin):
+        id: str = field(metadata={"serializable": True})
+        vector: Optional[list[float]] = field(default=None, metadata={"serializable": True})
+        score: Optional[float] = field(default=None, metadata={"serializable": True})
+        meta: Optional[dict] = field(default=None, metadata={"serializable": True})
+        namespace: Optional[str] = field(default=None, metadata={"serializable": True})
 
         def to_artifact(self) -> BaseArtifact:
             return BaseArtifact.from_json(self.meta["artifact"])  # pyright: ignore[reportOptionalSubscript]

--- a/griptape/drivers/vector/dummy_vector_store_driver.py
+++ b/griptape/drivers/vector/dummy_vector_store_driver.py
@@ -9,6 +9,7 @@ from griptape.drivers.vector import BaseVectorStoreDriver
 from griptape.exceptions import DummyError
 
 if TYPE_CHECKING:
+    from griptape.artifacts import ImageArtifact, TextArtifact
     from griptape.drivers.embedding import BaseEmbeddingDriver
 
 
@@ -52,7 +53,7 @@ class DummyVectorStoreDriver(BaseVectorStoreDriver):
 
     def query(
         self,
-        query: str,
+        query: str | TextArtifact | ImageArtifact,
         *,
         count: Optional[int] = None,
         namespace: Optional[str] = None,

--- a/griptape/drivers/vector/griptape_cloud_vector_store_driver.py
+++ b/griptape/drivers/vector/griptape_cloud_vector_store_driver.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 import requests
 from attrs import Factory, define, field
 
+from griptape.artifacts.image_artifact import ImageArtifact
 from griptape.drivers.embedding.dummy import DummyEmbeddingDriver
 from griptape.drivers.vector import BaseVectorStoreDriver
 
@@ -83,7 +84,7 @@ class GriptapeCloudVectorStoreDriver(BaseVectorStoreDriver):
 
     def query(
         self,
-        query: str,
+        query: str | TextArtifact | ImageArtifact,
         *,
         count: Optional[int] = None,
         namespace: Optional[str] = None,
@@ -97,6 +98,8 @@ class GriptapeCloudVectorStoreDriver(BaseVectorStoreDriver):
 
         Performs a query on the Knowledge Base and returns Artifacts with close vector proximity to the query, optionally filtering to only those that match the provided filter(s).
         """
+        if isinstance(query, ImageArtifact):
+            raise ValueError(f"{self.__class__.__name__} does not support querying with Image Artifacts.")
         url = urljoin(self.base_url.strip("/"), f"/api/knowledge-bases/{self.knowledge_base_id}/query")
 
         query_args = {
@@ -108,7 +111,7 @@ class GriptapeCloudVectorStoreDriver(BaseVectorStoreDriver):
         query_args = {k: v for k, v in query_args.items() if v is not None}
 
         request: dict[str, Any] = {
-            "query": query,
+            "query": str(query),
             "query_args": query_args,
         }
 

--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -4,7 +4,6 @@ import json
 import operator
 import os
 import threading
-from dataclasses import asdict
 from typing import Callable, NoReturn, Optional, TextIO
 
 from attrs import Factory, define, field
@@ -118,7 +117,7 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
 
     def __save_entries_to_file(self, json_file: TextIO) -> None:
         with self.thread_lock:
-            serialized_data = {k: asdict(v) for k, v in self.entries.items()}
+            serialized_data = {k: v.to_dict() for k, v in self.entries.items()}
 
             json.dump(serialized_data, json_file)
 

--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -12,7 +12,7 @@ from griptape.utils.decorators import lazy_property
 if TYPE_CHECKING:
     import marqo
 
-    from griptape.artifacts import TextArtifact
+    from griptape.artifacts import ImageArtifact, TextArtifact
 
 
 @define
@@ -167,9 +167,42 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
 
         return entries
 
+    def query_vector(
+        self,
+        vector: list[float],
+        *,
+        count: Optional[int] = None,
+        namespace: Optional[str] = None,
+        include_vectors: bool = False,
+        include_metadata: bool = True,
+        **kwargs: Any,
+    ) -> list[BaseVectorStoreDriver.Entry]:
+        """Query the Marqo index for documents.
+
+        Args:
+            vector: The vector to query by.
+            count: The maximum number of results to return.
+            namespace: The namespace to filter results by.
+            include_vectors: Whether to include vector data in the results.
+            include_metadata: Whether to include metadata in the results.
+            kwargs: Additional keyword arguments to pass to the Marqo client.
+
+        Returns:
+            The list of query results.
+        """
+        params = {
+            "limit": count or BaseVectorStoreDriver.DEFAULT_QUERY_COUNT,
+            "attributes_to_retrieve": None if include_metadata else ["_id"],
+            "filter_string": f"namespace:{namespace}" if namespace else None,
+        } | kwargs
+
+        results = self.client.index(self.index).search(**params, context={"tensor": [vector], "weight": 1})
+
+        return self.__process_results(results, include_vectors=include_vectors)
+
     def query(
         self,
-        query: str,
+        query: str | TextArtifact | ImageArtifact,
         *,
         count: Optional[int] = None,
         namespace: Optional[str] = None,
@@ -197,22 +230,7 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
         } | kwargs
 
         results = self.client.index(self.index).search(query, **params)
-
-        if include_vectors:
-            results["hits"] = [
-                {**r, **self.client.index(self.index).get_document(r["_id"], expose_facets=True)}
-                for r in results["hits"]
-            ]
-
-        return [
-            BaseVectorStoreDriver.Entry(
-                id=r["_id"],
-                vector=r["_tensor_facets"][0]["_embedding"] if include_vectors else [],
-                score=r["_score"],
-                meta={k: v for k, v in r.items() if k not in ["_score", "_tensor_facets"]},
-            )
-            for r in results["hits"]
-        ]
+        return self.__process_results(results, include_vectors=include_vectors)
 
     def delete_index(self, name: str) -> dict[str, Any]:
         """Delete an index in the Marqo client.
@@ -258,3 +276,20 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
 
     def delete_vector(self, vector_id: str) -> NoReturn:
         raise NotImplementedError(f"{self.__class__.__name__} does not support deletion.")
+
+    def __process_results(self, results: dict, *, include_vectors: bool) -> list[BaseVectorStoreDriver.Entry]:
+        if include_vectors:
+            results["hits"] = [
+                {**r, **self.client.index(self.index).get_document(r["_id"], expose_facets=True)}
+                for r in results["hits"]
+            ]
+
+        return [
+            BaseVectorStoreDriver.Entry(
+                id=r["_id"],
+                vector=r["_tensor_facets"][0]["_embedding"] if include_vectors else [],
+                score=r["_score"],
+                meta={k: v for k, v in r.items() if k not in ["_score", "_tensor_facets"]},
+            )
+            for r in results["hits"]
+        ]

--- a/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
+++ b/griptape/drivers/vector/mongodb_atlas_vector_store_driver.py
@@ -168,26 +168,6 @@ class MongoDbAtlasVectorStoreDriver(BaseVectorStoreDriver):
             for doc in collection.aggregate(pipeline)
         ]
 
-    def query(
-        self,
-        query: str,
-        *,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
-        include_vectors: bool = False,
-        offset: Optional[int] = None,
-        **kwargs,
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        """Queries the MongoDB collection for documents that match the provided query string.
-
-        Results can be customized based on parameters like count, namespace, inclusion of vectors, offset, and index.
-        """
-        # Using the embedding driver to convert the query string into a vector
-        vector = self.embedding_driver.embed_string(query)
-        return self.query_vector(
-            vector, count=count, namespace=namespace, include_vectors=include_vectors, offset=offset, **kwargs
-        )
-
     def delete_vector(self, vector_id: str) -> None:
         """Deletes the vector from the collection."""
         collection = self.get_collection()

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -164,34 +164,5 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
             for hit in response["hits"]["hits"]
         ]
 
-    def query(
-        self,
-        query: str,
-        *,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
-        include_vectors: bool = False,
-        include_metadata: bool = True,
-        field_name: str = "vector",
-        **kwargs,
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        """Performs a nearest neighbor search on OpenSearch to find vectors similar to the provided query string.
-
-        Results can be limited using the count parameter and optionally filtered by a namespace.
-
-        Returns:
-            A list of BaseVectorStoreDriver.Entry objects, each encapsulating the retrieved vector, its similarity score, metadata, and namespace.
-        """
-        vector = self.embedding_driver.embed_string(query)
-        return self.query_vector(
-            vector,
-            count=count,
-            namespace=namespace,
-            include_vectors=include_vectors,
-            include_metadata=include_metadata,
-            field_name=field_name,
-            **kwargs,
-        )
-
     def delete_vector(self, vector_id: str) -> NoReturn:
         raise NotImplementedError(f"{self.__class__.__name__} does not support deletion.")

--- a/griptape/drivers/vector/pgvector_vector_store_driver.py
+++ b/griptape/drivers/vector/pgvector_vector_store_driver.py
@@ -182,27 +182,6 @@ class PgVectorVectorStoreDriver(BaseVectorStoreDriver):
                 for result in results
             ]
 
-    def query(
-        self,
-        query: str,
-        *,
-        count: Optional[int] = BaseVectorStoreDriver.DEFAULT_QUERY_COUNT,
-        namespace: Optional[str] = None,
-        include_vectors: bool = False,
-        distance_metric: str = "cosine_distance",
-        **kwargs,
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        """Performs a search on the collection to find vectors similar to the provided input vector, optionally filtering to only those that match the provided namespace."""
-        vector = self.embedding_driver.embed_string(query)
-        return self.query_vector(
-            vector,
-            count=count,
-            namespace=namespace,
-            include_vectors=include_vectors,
-            distance_metric=distance_metric,
-            **kwargs,
-        )
-
     def default_vector_model(self) -> Any:
         pgvector_sqlalchemy = import_optional_dependency("pgvector.sqlalchemy")
         sqlalchemy = import_optional_dependency("sqlalchemy")

--- a/griptape/drivers/vector/pinecone_vector_store_driver.py
+++ b/griptape/drivers/vector/pinecone_vector_store_driver.py
@@ -121,25 +121,5 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
             for r in results["matches"]
         ]
 
-    def query(
-        self,
-        query: str,
-        *,
-        count: Optional[int] = None,
-        namespace: Optional[str] = None,
-        include_vectors: bool = False,
-        include_metadata: bool = True,
-        **kwargs,
-    ) -> list[BaseVectorStoreDriver.Entry]:
-        vector = self.embedding_driver.embed_string(query)
-        return self.query_vector(
-            vector,
-            count=count,
-            namespace=namespace,
-            include_vectors=include_vectors,
-            include_metadata=include_metadata,
-            **kwargs,
-        )
-
     def delete_vector(self, vector_id: str) -> NoReturn:
         raise NotImplementedError(f"{self.__class__.__name__} does not support deletion.")

--- a/griptape/tokenizers/amazon_bedrock_tokenizer.py
+++ b/griptape/tokenizers/amazon_bedrock_tokenizer.py
@@ -26,6 +26,8 @@ class AmazonBedrockTokenizer(BaseTokenizer):
         "mistral.mixtral": 32000,
         "amazon.nova-micro-v1": 128000,
         "amazon.nova": 300000,
+        "amazon.titan-embed-image": 128000,
+        "amazon.titan-embed-text": 8000,
         "amazon.titan-text-express-v1": 8000,
         "amazon.titan-text-lite-v1": 4000,
         "amazon.titan-text-premier-v1": 32000,

--- a/griptape/tokenizers/voyageai_tokenizer.py
+++ b/griptape/tokenizers/voyageai_tokenizer.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 @define()
 class VoyageAiTokenizer(BaseTokenizer):
     MODEL_PREFIXES_TO_MAX_INPUT_TOKENS = {
+        "voyage-3": 32000,
         "voyage-large-2": 16000,
         "voyage-code-2": 16000,
         "voyage-2": 4000,
@@ -31,4 +32,4 @@ class VoyageAiTokenizer(BaseTokenizer):
     )
 
     def count_tokens(self, text: str) -> int:
-        return self.client.count_tokens([text])
+        return self.client.count_tokens([text], model=self.model)

--- a/tests/mocks/mock_embedding_driver.py
+++ b/tests/mocks/mock_embedding_driver.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from attrs import define, field
 
 from griptape.drivers.embedding import BaseEmbeddingDriver
 from tests.mocks.mock_tokenizer import MockTokenizer
+
+if TYPE_CHECKING:
+    from griptape.artifacts.image_artifact import ImageArtifact
+    from griptape.artifacts.text_artifact import TextArtifact
 
 
 @define
@@ -14,7 +18,12 @@ class MockEmbeddingDriver(BaseEmbeddingDriver):
     dimensions: int = field(default=42, kw_only=True)
     max_attempts: int = field(default=1, kw_only=True)
     tokenizer: MockTokenizer = field(factory=lambda: MockTokenizer(model="foo bar"), kw_only=True)
-    mock_output: Callable[[str], list[float]] = field(default=lambda chunk: [0, 1], kw_only=True)
+    mock_output: Callable[[str | TextArtifact | ImageArtifact], list[float]] = field(
+        default=lambda chunk: [0, 1], kw_only=True
+    )
+
+    def try_embed_artifact(self, artifact: TextArtifact | ImageArtifact) -> list[float]:
+        return self.mock_output(artifact)
 
     def try_embed_chunk(self, chunk: str) -> list[float]:
         return self.mock_output(chunk)

--- a/tests/unit/drivers/embedding/test_amazon_bedrock_titan_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_amazon_bedrock_titan_embedding_driver.py
@@ -1,7 +1,9 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
 
+from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.drivers.embedding.amazon_bedrock import AmazonBedrockTitanEmbeddingDriver
 
 
@@ -24,5 +26,22 @@ class TestAmazonBedrockTitanEmbeddingDriver:
     def test_init(self):
         assert AmazonBedrockTitanEmbeddingDriver()
 
-    def test_try_embed_chunk(self):
-        assert AmazonBedrockTitanEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]
+    @pytest.mark.parametrize(
+        ("value", "expected_output", "expected_error"),
+        [
+            ("foobar", [0, 1, 0], nullcontext()),
+            (
+                TextArtifact("foobar"),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+            (
+                ImageArtifact(b"foobar", format="jpeg", width=1, height=1),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+        ],
+    )
+    def test_embed(self, value, expected_output, expected_error):
+        with expected_error:
+            assert AmazonBedrockTitanEmbeddingDriver().embed(value) == expected_output

--- a/tests/unit/drivers/embedding/test_azure_openai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_azure_openai_embedding_driver.py
@@ -1,7 +1,9 @@
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
 
+from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.drivers.embedding.openai import AzureOpenAiEmbeddingDriver
 
 
@@ -27,5 +29,22 @@ class TestAzureOpenAiEmbeddingDriver:
         assert driver
         assert AzureOpenAiEmbeddingDriver(azure_endpoint="foobar", model="gpt-4").azure_deployment == "gpt-4"
 
-    def test_embed_chunk(self, driver):
-        assert driver.try_embed_chunk("foobar") == [0, 1, 0]
+    @pytest.mark.parametrize(
+        ("value", "expected_output", "expected_error"),
+        [
+            ("foobar", [0, 1, 0], nullcontext()),
+            (
+                TextArtifact("foobar"),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+            (
+                ImageArtifact(b"foobar", format="jpeg", width=1, height=1),
+                [],
+                pytest.raises(ValueError, match="AzureOpenAiEmbeddingDriver does not support embedding images."),
+            ),
+        ],
+    )
+    def test_embed(self, value, expected_output, expected_error):
+        with expected_error:
+            assert AzureOpenAiEmbeddingDriver(azure_endpoint="foo").embed(value) == expected_output

--- a/tests/unit/drivers/embedding/test_base_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_base_embedding_driver.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from griptape.artifacts import TextArtifact
+from griptape.artifacts.image_artifact import ImageArtifact
 from tests.mocks.mock_embedding_driver import MockEmbeddingDriver
 
 
@@ -21,10 +22,19 @@ class TestBaseEmbeddingDriver:
 
         assert embedding == [0, 1]
 
-    def test_embed_long_string(self, driver):
-        embedding = driver.embed_string("foobar" * 5000)
+    @pytest.mark.parametrize(
+        ("value", "expected_output"),
+        [
+            ("foobar", [0, 1]),
+            ("foobar" * 5000, [0, 1]),
+            (TextArtifact("foobar"), [0, 1]),
+            (ImageArtifact(b"foobar", format="png", width=100, height=100), [0, 1]),
+        ],
+    )
+    def test_embed(self, driver, value, expected_output):
+        embedding = driver.embed(value)
 
-        assert embedding == [0, 1]
+        assert embedding == expected_output
 
     def test_no_tokenizer(self, driver):
         driver.tokenizer = None

--- a/tests/unit/drivers/embedding/test_dummy_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_dummy_embedding_driver.py
@@ -12,6 +12,6 @@ class TestDummyEmbeddingDriver:
     def test_init(self, embedding_driver):
         assert embedding_driver
 
-    def test_try_embed_chunk(self, embedding_driver):
+    def test_embed(self, embedding_driver):
         with pytest.raises(DummyError):
-            embedding_driver.try_embed_chunk("prompt-stack")
+            embedding_driver.embed("prompt-stack")

--- a/tests/unit/drivers/embedding/test_ollama_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_ollama_embedding_driver.py
@@ -1,5 +1,9 @@
+from contextlib import nullcontext
+
 import pytest
 
+from griptape.artifacts.image_artifact import ImageArtifact
+from griptape.artifacts.text_artifact import TextArtifact
 from griptape.drivers.embedding.ollama import OllamaEmbeddingDriver
 
 
@@ -15,5 +19,22 @@ class TestOllamaEmbeddingDriver:
     def test_init(self):
         assert OllamaEmbeddingDriver(model="foo")
 
-    def test_try_embed_chunk(self):
-        assert OllamaEmbeddingDriver(model="foo").try_embed_chunk("foobar") == [0, 1, 0]
+    @pytest.mark.parametrize(
+        ("value", "expected_output", "expected_error"),
+        [
+            ("foobar", [0, 1, 0], nullcontext()),
+            (
+                TextArtifact("foobar"),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+            (
+                ImageArtifact(b"foobar", format="jpeg", width=1, height=1),
+                [],
+                pytest.raises(ValueError, match="OllamaEmbeddingDriver does not support embedding images."),
+            ),
+        ],
+    )
+    def test_embed(self, value, expected_output, expected_error):
+        with expected_error:
+            assert OllamaEmbeddingDriver(model="foo").embed(value) == expected_output

--- a/tests/unit/drivers/embedding/test_openai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_openai_embedding_driver.py
@@ -1,7 +1,9 @@
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
 
+from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.drivers.embedding.openai import OpenAiEmbeddingDriver
 from griptape.tokenizers import OpenAiTokenizer
 
@@ -23,8 +25,25 @@ class TestOpenAiEmbeddingDriver:
     def test_init(self):
         assert OpenAiEmbeddingDriver()
 
-    def test_try_embed_chunk(self):
-        assert OpenAiEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]
+    @pytest.mark.parametrize(
+        ("value", "expected_output", "expected_error"),
+        [
+            ("foobar", [0, 1, 0], nullcontext()),
+            (
+                TextArtifact("foobar"),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+            (
+                ImageArtifact(b"foobar", format="jpeg", width=1, height=1),
+                [],
+                pytest.raises(ValueError, match="OpenAiEmbeddingDriver does not support embedding images."),
+            ),
+        ],
+    )
+    def test_embed(self, value, expected_output, expected_error):
+        with expected_error:
+            assert OpenAiEmbeddingDriver().embed(value) == expected_output
 
     @pytest.mark.parametrize("model", OpenAiTokenizer.EMBEDDING_MODELS)
     def test_try_embed_chunk_replaces_newlines_in_older_ada_models(self, model, mock_openai):

--- a/tests/unit/drivers/embedding/test_voyageai_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_voyageai_embedding_driver.py
@@ -1,7 +1,9 @@
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
 
+from griptape.artifacts import ImageArtifact, TextArtifact
 from griptape.drivers.embedding.voyageai import VoyageAiEmbeddingDriver
 
 
@@ -10,11 +12,35 @@ class TestVoyageAiEmbeddingDriver:
     def mock_client(self, mocker):
         mock_client = mocker.patch("voyageai.Client")
         mock_client.return_value.embed.return_value = Mock(embeddings=[[0, 1, 0]])
+        mock_client.return_value.count_tokens.return_value = 5
+        mock_client.return_value.multimodal_embed.return_value = Mock(embeddings=[[0, 1, 0]])
 
         return mock_client
+
+    @pytest.fixture(autouse=True)
+    def mock_pil_image(self, mocker):
+        mock_image = mocker.MagicMock()
+        mocker.patch("PIL.Image.open", return_value=mock_image)
 
     def test_init(self):
         assert VoyageAiEmbeddingDriver()
 
-    def test_try_embed_chunk(self):
-        assert VoyageAiEmbeddingDriver().try_embed_chunk("foobar") == [0, 1, 0]
+    @pytest.mark.parametrize(
+        ("value", "expected_output", "expected_error"),
+        [
+            ("foobar", [0, 1, 0], nullcontext()),
+            (
+                TextArtifact("foobar"),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+            (
+                ImageArtifact(b"foobar", format="jpeg", width=1, height=1),
+                [0, 1, 0],
+                nullcontext(),
+            ),
+        ],
+    )
+    def test_embed(self, value, expected_output, expected_error):
+        with expected_error:
+            assert VoyageAiEmbeddingDriver().embed(value) == expected_output

--- a/tests/unit/drivers/vector/test_griptape_cloud_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_griptape_cloud_vector_store_driver.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 
+from griptape.artifacts.image_artifact import ImageArtifact
 from griptape.drivers.vector.griptape_cloud import GriptapeCloudVectorStoreDriver
 
 
@@ -73,3 +74,9 @@ class TestGriptapeCloudVectorStoreDriver:
         assert result[1].meta == self.test_metas[1]
         assert result[0].score == self.test_scores[0]
         assert result[1].score == self.test_scores[1]
+
+    def test_query_artifact(self, driver):
+        with pytest.raises(
+            ValueError, match="GriptapeCloudVectorStoreDriver does not support querying with Image Artifacts."
+        ):
+            driver.query(ImageArtifact(b"image", width=1, height=1, format="png"))

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -117,9 +117,14 @@ class TestMarqoVectorStorageDriver:
         }
         assert result == expected_return_value["items"][0]["_id"]
 
-    def test_query_vector(self, driver):
-        with pytest.raises(NotImplementedError):
-            driver.query_vector([0.0, 0.5])
+    def test_query_vector(self, driver, mock_marqo):
+        results = driver.query_vector([0.1, 0.2, 0.3])
+        mock_marqo.index().search.assert_called()
+        assert len(results) == 1
+        assert results[0].score == 0.6047464
+        assert results[0].meta["Title"] == "Test Title"
+        assert results[0].meta["Description"] == "Test description"
+        assert results[0].id == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
 
     def test_search(self, driver, mock_marqo):
         results = driver.query("Test query")

--- a/tests/unit/drivers/vector/test_qdrant_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_qdrant_vector_store_driver.py
@@ -91,7 +91,7 @@ class TestQdrantVectorStoreDriver:
         ]
 
         with (
-            patch.object(driver.embedding_driver, "embed_string", return_value=[0.1, 0.2, 0.3]) as mock_embed,
+            patch.object(driver.embedding_driver, "embed", return_value=[0.1, 0.2, 0.3]) as mock_embed,
             patch.object(driver.client, "search", return_value=mock_query_result) as mock_search,
         ):
             query = "test"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Sorry for big-ish PR, lots of overlapping changes here:
1. Add support for embedding images in Embeddings Drivers. Also refactors Embedding Drivers to have a single `embed` method rather than type-specific methods (embed_string, embed_image, etc).
a. Add support for embedding images in Amazon Bedrock Titan Embedding Driver.
b. Add support for embedding images in VoyageAi Embedding Driver.
1. Add support for querying/upserting with Vector Store Drivers. Vector Store Driver must be configured with a multi-modal Embedding Driver. Also refactors Vector Store Drivers to add single `upsert` method rather than type-specific methods (`upsert_text`, `upsert_text_artifact`, etc).
a. Add support to Local Vector Store Driver to save `Entry`s with Image Artifacts into the `persist_file`.

## Issue ticket number and link
Closes #1729 