### PR TITLE
fix: properly serialize pydantic models

### DIFF
--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -10,6 +10,7 @@ from .image_artifact import ImageArtifact
 from .audio_artifact import AudioArtifact
 from .action_artifact import ActionArtifact
 from .generic_artifact import GenericArtifact
+from .model_artifact import ModelArtifact
 
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "AudioArtifact",
     "ActionArtifact",
     "GenericArtifact",
+    "ModelArtifact",
 ]

--- a/griptape/artifacts/model_artifact.py
+++ b/griptape/artifacts/model_artifact.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from attrs import define, field
+from pydantic import BaseModel
+
+from griptape.artifacts.generic_artifact import GenericArtifact
+
+
+@define
+class ModelArtifact(GenericArtifact[BaseModel]):
+    """Stores Pydantic models as Artifacts.
+
+    Required since Pydantic models require a custom serialization method.
+
+    Attributes:
+        value: The pydantic model to store.
+    """
+
+    # We must explicitly define the type rather than rely on the parent T since
+    # generic type information is lost at runtime.
+    value: BaseModel = field(metadata={"serializable": True})
+
+    def to_text(self) -> str:
+        return self.value.model_dump_json()

--- a/griptape/schemas/__init__.py
+++ b/griptape/schemas/__init__.py
@@ -6,5 +6,7 @@ from .bytes_field import Bytes
 
 from .union_field import Union
 
+from .pydantic_model_field import PydanticModel
 
-__all__ = ["BaseSchema", "PolymorphicSchema", "Bytes", "Union"]
+
+__all__ = ["BaseSchema", "PolymorphicSchema", "Bytes", "Union", "PydanticModel"]

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -7,8 +7,10 @@ from typing import Any, Literal, Optional, TypeVar, Union, _SpecialForm, get_arg
 
 import attrs
 from marshmallow import INCLUDE, Schema, fields
+from pydantic import BaseModel
 
 from griptape.schemas.bytes_field import Bytes
+from griptape.schemas.pydantic_model_field import PydanticModel
 from griptape.schemas.union_field import Union as UnionField
 
 
@@ -16,7 +18,13 @@ class BaseSchema(Schema):
     class Meta:
         unknown = INCLUDE
 
-    DATACLASS_TYPE_MAPPING = {**Schema.TYPE_MAPPING, dict: fields.Dict, bytes: Bytes, Any: fields.Raw}
+    DATACLASS_TYPE_MAPPING = {
+        **Schema.TYPE_MAPPING,
+        dict: fields.Dict,
+        bytes: Bytes,
+        Any: fields.Raw,
+        BaseModel: PydanticModel,
+    }
 
     @classmethod
     def from_attrs_cls(cls, attrs_cls: type) -> type:

--- a/griptape/schemas/pydantic_model_field.py
+++ b/griptape/schemas/pydantic_model_field.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from marshmallow import fields
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+class PydanticModel(fields.Field):
+    def _serialize(self, value: Optional[BaseModel], attr: Any, obj: Any, **kwargs) -> Optional[dict]:
+        if value is None:
+            return None
+        return value.model_dump()
+
+    def _deserialize(self, value: dict, attr: Any, data: Any, **kwargs) -> dict:
+        # Not implemented as it is non-trivial to deserialize json back into a model
+        # since we need to know the model class to instantiate it.
+        # Would rather not implement right now rather than implement incorrectly.
+        raise NotImplementedError("Model fields cannot be deserialized directly.")

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -12,6 +12,7 @@ from griptape.structures import Structure
 from griptape.tasks import PromptTask
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
     from schema import Schema
 
     from griptape.artifacts import BaseArtifact
@@ -27,7 +28,7 @@ class Agent(Structure):
     )
     stream: bool = field(default=None, kw_only=True)
     prompt_driver: BasePromptDriver = field(default=None, kw_only=True)
-    output_schema: Optional[Schema] = field(default=None, kw_only=True)
+    output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
     fail_fast: bool = field(default=False, kw_only=True)

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -9,9 +9,17 @@ from pydantic import BaseModel, TypeAdapter
 from schema import Schema
 
 from griptape import utils
-from griptape.artifacts import ActionArtifact, BaseArtifact, ErrorArtifact, JsonArtifact, ListArtifact, TextArtifact
-from griptape.artifacts.audio_artifact import AudioArtifact
-from griptape.artifacts.generic_artifact import GenericArtifact
+from griptape.artifacts import (
+    ActionArtifact,
+    AudioArtifact,
+    BaseArtifact,
+    ErrorArtifact,
+    GenericArtifact,
+    JsonArtifact,
+    ListArtifact,
+    ModelArtifact,
+    TextArtifact,
+)
 from griptape.common import PromptStack, ToolAction
 from griptape.configs import Defaults
 from griptape.memory.structure import Run
@@ -216,7 +224,7 @@ class PromptTask(
             if isinstance(self.output_schema, Schema):
                 return JsonArtifact(output.value)
             elif isinstance(self.output_schema, type) and issubclass(self.output_schema, BaseModel):
-                return GenericArtifact(TypeAdapter(self.output_schema).validate_json(output.value))
+                return ModelArtifact(TypeAdapter(self.output_schema).validate_json(output.value))
             else:
                 raise ValueError(f"Unsupported output schema type: {type(self.output_schema)}")
         elif isinstance(output, (TextArtifact, AudioArtifact, JsonArtifact, ErrorArtifact)):

--- a/tests/mocks/mock_serializable.py
+++ b/tests/mocks/mock_serializable.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from attrs import define, field
+from pydantic import BaseModel
 
 from griptape.mixins.serializable_mixin import SerializableMixin
 
@@ -13,6 +14,9 @@ class MockSerializable(SerializableMixin):
     class NestedMockSerializable(SerializableMixin):
         foo: str = field(default="bar", kw_only=True, metadata={"serializable": True})
 
+    class MockOutput(BaseModel):
+        foo: str
+
     foo: str = field(default="bar", kw_only=True, metadata={"serializable": True})
     bar: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     baz: Optional[list[int]] = field(default=None, kw_only=True, metadata={"serializable": True})
@@ -20,3 +24,4 @@ class MockSerializable(SerializableMixin):
     nested: Optional[MockSerializable.NestedMockSerializable] = field(
         default=None, kw_only=True, metadata={"serializable": True}
     )
+    model: Optional[BaseModel] = field(default=None, kw_only=True, metadata={"serializable": True})

--- a/tests/unit/artifacts/test_model_artifact.py
+++ b/tests/unit/artifacts/test_model_artifact.py
@@ -1,0 +1,25 @@
+import pytest
+from pydantic import create_model
+
+from griptape.artifacts import BaseArtifact, ModelArtifact
+
+
+class TestModelArtifact:
+    @pytest.fixture()
+    def model_artifact(self):
+        return ModelArtifact(
+            value=create_model("ModelArtifact", value=(str, ...))(value="foo"),
+        )
+
+    def test_to_text(self, model_artifact: ModelArtifact):
+        assert model_artifact.to_text() == '{"value":"foo"}'
+
+    def test_to_dict(self, model_artifact: ModelArtifact):
+        generic_dict = model_artifact.to_dict()
+
+        assert generic_dict["value"] == {"value": "foo"}
+
+    def test_deserialization(self, model_artifact):
+        artifact_dict = model_artifact.to_dict()
+        with pytest.raises(NotImplementedError):
+            BaseArtifact.from_dict(artifact_dict)

--- a/tests/unit/mixins/test_seriliazable_mixin.py
+++ b/tests/unit/mixins/test_seriliazable_mixin.py
@@ -38,21 +38,29 @@ class TestSerializableMixin:
 
     def test_str(self):
         assert str(MockSerializable()) == json.dumps(
-            {"type": "MockSerializable", "foo": "bar", "bar": None, "baz": None, "nested": None}
+            {"type": "MockSerializable", "foo": "bar", "bar": None, "baz": None, "nested": None, "model": None}
         )
 
     def test_to_json(self):
-        assert MockSerializable().to_json() == json.dumps(
-            {"type": "MockSerializable", "foo": "bar", "bar": None, "baz": None, "nested": None}
+        assert MockSerializable(model=MockSerializable.MockOutput(foo="bar")).to_json() == json.dumps(
+            {
+                "type": "MockSerializable",
+                "foo": "bar",
+                "bar": None,
+                "baz": None,
+                "nested": None,
+                "model": {"foo": "bar"},
+            }
         )
 
     def test_to_dict(self):
-        assert MockSerializable().to_dict() == {
+        assert MockSerializable(model=MockSerializable.MockOutput(foo="bar")).to_dict() == {
             "type": "MockSerializable",
             "foo": "bar",
             "bar": None,
             "baz": None,
             "nested": None,
+            "model": {"foo": "bar"},
         }
 
     def test_import_class_rec(self):

--- a/tests/unit/schemas/test_base_schema.py
+++ b/tests/unit/schemas/test_base_schema.py
@@ -6,12 +6,14 @@ from typing import Literal, Optional, Union
 
 import pytest
 from marshmallow import fields
+from pydantic import BaseModel
 
 from griptape.artifacts import BaseArtifact, TextArtifact
 from griptape.loaders import TextLoader
 from griptape.schemas import PolymorphicSchema
 from griptape.schemas.base_schema import BaseSchema
 from griptape.schemas.bytes_field import Bytes
+from griptape.schemas.pydantic_model_field import PydanticModel
 from griptape.schemas.union_field import Union as UnionField
 from tests.mocks.mock_serializable import MockSerializable
 
@@ -24,6 +26,10 @@ class MockEnum(Enum):
 
 class UnsupportedType:
     pass
+
+
+class MockModel(BaseModel):
+    foo: str
 
 
 class TestBaseSchema:
@@ -64,6 +70,8 @@ class TestBaseSchema:
         assert isinstance(BaseSchema._get_field_for_type(bool), fields.Bool)
         assert isinstance(BaseSchema._get_field_for_type(tuple), fields.Raw)
         assert isinstance(BaseSchema._get_field_for_type(dict), fields.Dict)
+
+        assert isinstance(BaseSchema._get_field_for_type(BaseModel), PydanticModel)
         with pytest.raises(ValueError):
             BaseSchema._get_field_for_type(list)
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Problem:
Pydantic models are not being handled by our serialization process. This results in events that look like this:

```
{
│   'type': 'FinishStructureRunEvent',
│   'id': '224441bcb1c449b391576081914dd4a2',
│   'timestamp': 1740425885.337445,
│   'meta': {},
│   'structure_id': None,
│   'output_task_input': None,
│   'output_task_output': {
│   │   'type': 'ModelArtifact',
│   │   'id': '49469681d5c049139a34f95e5bdda990',
│   │   'reference': None,
│   │   'meta': {},
│   │   'name': '49469681d5c049139a34f95e5bdda990',
│   │   'value': Output(text='hello') # not serializable!
│   }
}
```


### Solution:
1. Introduce a `ModelArtifact` that is used exclusively for wrapping Pydantic models. This should be a non-breaking change since it subclasses `GenericArtifact`. There are [hacks](https://discuss.python.org/t/getting-type-of-a-concrete-generic-inside-another-generic-at-runtime/52144) we could use for getting information out of `GenericArtifact`, but they are hacky and would require non-trivial refactors to implement.

2. During serialization, detect instances of `BaseModel`s and serialize them using a custom marshmallow field, `fields.Model`. Deserialization for this field has not been implemented at this time as it would require us to somehow store the Pydantic model with the field. I don't _think_ users will run into this during regular usage, but the workaround would be to manually deserialize the Pydantic model outside griptape.

Serialized events now look like:
```
{
│   'type': 'FinishStructureRunEvent',
│   'id': '8ab4850b69534589a36cc2254612a004',
│   'timestamp': 1740426782.152982,
│   'meta': {},
│   'structure_id': None,
│   'output_task_input': None,
│   'output_task_output': {
│   │   'type': 'ModelArtifact',
│   │   'id': 'b3c96262b9be4d78bb89399321f84f72',
│   │   'reference': None,
│   │   'meta': {},
│   │   'name': 'b3c96262b9be4d78bb89399321f84f72',
│   │   'value': {'text': 'hello'} # serializable!
│   }
}
```
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1756
YASW (yet another serialization woe): #1587 