### PR TITLE
fix(drivers-event-listener-griptape-cloud): add type/timestamp fallbacks for custom events

### DIFF
--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Optional
 from urllib.parse import urljoin
 
@@ -72,8 +73,8 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
     def _get_event_request(self, event_payload: dict) -> dict:
         return {
             "payload": event_payload,
-            "timestamp": event_payload["timestamp"],
-            "type": event_payload["type"],
+            "timestamp": event_payload.get("timestamp", time.time()),
+            "type": event_payload.get("type", "UserEvent"),
         }
 
     def _post_event(self, json: list[dict] | dict) -> None:

--- a/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
@@ -1,6 +1,6 @@
 import os
 import time
-from unittest.mock import MagicMock, Mock
+from unittest.mock import ANY, MagicMock, Mock
 
 import pytest
 
@@ -104,3 +104,27 @@ class TestGriptapeCloudEventListenerDriver:
                 json=driver._get_event_request(event.to_dict()),
                 headers={"Authorization": "Bearer foo bar"},
             )
+
+    @pytest.mark.parametrize(
+        ("event", "expected"),
+        [
+            (
+                MockEvent().to_dict(),
+                {
+                    "payload": {
+                        "id": ANY,
+                        "meta": {},
+                        "timestamp": ANY,
+                        "type": "MockEvent",
+                    },
+                    "timestamp": ANY,
+                    "type": "MockEvent",
+                },
+            ),
+            ({}, {"payload": {}, "timestamp": ANY, "type": "UserEvent"}),
+        ],
+    )
+    def test__get_event_request(self, driver, event, expected):
+        result = driver._get_event_request(event)
+
+        assert result == expected


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Problem:
Users can publish custom events by passing a dict to `publish_event`:
https://github.com/griptape-ai/griptape/blob/d15b2a676ba02c747c5950e6a057b46ebc404aed/griptape/drivers/event_listener/base_event_listener_driver.py?plain=1#L30-L31

`GriptapeCloudEventListenerDriver` makes assumptions about what these events will contain:
https://github.com/griptape-ai/griptape/blob/7af49daee247e72c60f3004d1d6b174942b20f57/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py?plain=1#L72-L77

### Solution:
Add fallbacks for these keys:
https://github.com/griptape-ai/griptape/blob/d15b2a676ba02c747c5950e6a057b46ebc404aed/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py?plain=1#L73-L78
## Issue ticket number and link
NA