### PR TITLE
fix(decorators): preserve type hints on `@observable` decorator

### DIFF
--- a/docs/examples/src/amazon_dynamodb_sessions_1.py
+++ b/docs/examples/src/amazon_dynamodb_sessions_1.py
@@ -29,4 +29,4 @@ structure = Agent(
     )
 )
 
-print(structure.run(user_input).output_task.output.value)
+print(structure.run(user_input).output.value)

--- a/griptape/drivers/structure_run/local_structure_run_driver.py
+++ b/griptape/drivers/structure_run/local_structure_run_driver.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Callable
 
 from attrs import define, field
 
-from griptape.artifacts import BaseArtifact, InfoArtifact
 from griptape.drivers.structure_run.base_structure_run_driver import BaseStructureRunDriver
 
 if TYPE_CHECKING:
+    from griptape.artifacts import BaseArtifact
     from griptape.structures import Structure
 
 
@@ -25,7 +25,4 @@ class LocalStructureRunDriver(BaseStructureRunDriver):
             os.environ.clear()
             os.environ.update(old_env)
 
-        if structure.output_task.output is not None:
-            return structure.output_task.output
-        else:
-            return InfoArtifact("No output found in response")
+        return structure.output

--- a/griptape/utils/chat.py
+++ b/griptape/utils/chat.py
@@ -86,9 +86,7 @@ class Chat:
                     self._call_handle_output(chunk.value, stream=True)
             else:
                 self._call_handle_output(self.processing_text)
-                self._call_handle_output(
-                    f"{self.response_prefix}{self.structure.run(question).output_task.output.to_text()}"
-                )
+                self._call_handle_output(f"{self.response_prefix}{self.structure.run(question).output.to_text()}")
 
         # Restore the original logger level
         logging.getLogger(Defaults.logging_config.logger_name).setLevel(old_logger_level)

--- a/tests/unit/common/test_observable.py
+++ b/tests/unit/common/test_observable.py
@@ -71,7 +71,7 @@ class TestObservable:
     def test_observable_function_args(self, observe_spy):
         from griptape.common import observable
 
-        @observable("one", 2, {"th": "ree"}, a="b", b=6)
+        @observable(a="one", b=2, c={"th": "ree"}, d="b", e=6)
         def bar(*args, **kwargs):
             if args:
                 return args[0]
@@ -91,24 +91,39 @@ class TestObservable:
                     Observable.Call(
                         func=original_bar,
                         args=(),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
                     Observable.Call(
                         func=original_bar,
                         args=("a",),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
                     Observable.Call(
                         func=original_bar,
                         args=("b", "2"),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
@@ -116,8 +131,13 @@ class TestObservable:
                         func=original_bar,
                         args=("c",),
                         kwargs={"x": "y"},
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
             ]
@@ -183,7 +203,7 @@ class TestObservable:
         from griptape.common import observable
 
         class Foo:
-            @observable("one", 2, {"th": "ree"}, a="b", b=6)
+            @observable(a="one", b=2, c={"th": "ree"}, d="b", e=6)
             def bar(self, *args, **kwargs):
                 if args:
                     return args[0]
@@ -205,8 +225,13 @@ class TestObservable:
                         func=original_bar,
                         instance=foo,
                         args=(),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
@@ -214,8 +239,13 @@ class TestObservable:
                         func=original_bar,
                         instance=foo,
                         args=("a",),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
@@ -223,8 +253,13 @@ class TestObservable:
                         func=original_bar,
                         instance=foo,
                         args=("b", "2"),
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
                 call(
@@ -233,9 +268,23 @@ class TestObservable:
                         instance=foo,
                         args=("c",),
                         kwargs={"x": "y"},
-                        decorator_args=("one", 2, {"th": "ree"}),
-                        decorator_kwargs={"a": "b", "b": 6},
+                        decorator_kwargs={
+                            "a": "one",
+                            "b": 2,
+                            "c": {"th": "ree"},
+                            "d": "b",
+                            "e": 6,
+                        },
                     )
                 ),
             ]
         )
+
+    def test_positional_arg(self):
+        from griptape.common import observable
+
+        with pytest.raises(ValueError, match="Non-callable positional argument passed."):
+
+            @observable("foo")
+            def bar() -> None:
+                pass


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Problem:
`observable` decorator threw away the parameters and return type that it wrapped.

Solution:
Use `ParamSpec` plus `overload` to preserve them. This change removes the ability to set decorator args, though I'd argue this should have never been a feature in the first place considering wrapt's [official guide](https://wrapt.readthedocs.io/en/master/decorators.html#decorators-with-optional-arguments) on optional arguments.

Relevant: https://github.com/GrahamDumpleton/wrapt/issues/164

Rest of the PR changes are fixing type errors that were surfaced from fixing this.
## Issue ticket number and link
Closes #1766 

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1767.org.readthedocs.build//1767/

<!-- readthedocs-preview griptape end -->