### PR TITLE
fix(drivers-vector): don't mutate same instance of meta

### DIFF
--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -89,7 +89,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         if self.does_entry_exist(vector_id, namespace=namespace):
             return vector_id
         else:
-            meta["artifact"] = artifact.to_json()
+            meta = {**meta, "artifact": artifact.to_json()}
 
             vector = artifact.embedding or artifact.generate_embedding(self.embedding_driver)
 

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -47,3 +47,11 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert result[0].vector == [0, 1]
         assert result[0].score is not None
         assert result[0].namespace == "foo"
+
+    def test_upsert_text_artifacts_meta(self, driver, mocker):
+        spy = mocker.spy(driver, "upsert_vector")
+        artifact_1 = TextArtifact("foo bar")
+        artifact_2 = TextArtifact("bar foo")
+        driver.upsert_text_artifacts({"foo": [artifact_1, artifact_2]}, meta={"foo": "bar"})
+        assert spy.call_args_list[0].kwargs["meta"]["artifact"] == artifact_1.to_json()
+        assert spy.call_args_list[1].kwargs["meta"]["artifact"] == artifact_2.to_json()


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Problem:
Specifying a `meta` object with `upsert_text_artifacts` caused all underlying calls to `upsert_text_artifact` to share the same `meta` instance.

### Solution
Create a new instance of `meta` before inserting `artifact`.
## Issue ticket number and link
Closes #1781 