### PR TITLE
docs: add back missing observability examples

### DIFF
--- a/docs/griptape-framework/drivers/observability-drivers.md
+++ b/docs/griptape-framework/drivers/observability-drivers.md
@@ -27,3 +27,21 @@ The Griptape Cloud Observability Driver instruments `@observable` functions and 
     or locally via the [Skatepark Emulator](https://github.com/griptape-ai/griptape-cli?tab=readme-ov-file#skatepark-emulator).
 
 Here is an example of how to use the `GriptapeCloudObservabilityDriver` with the `Observability` context manager to send the telemetry to Griptape Cloud:
+
+```python
+--8<-- "docs/griptape-framework/drivers/src/observability_drivers_1.py"
+```
+
+### OpenTelemetry
+
+!!! info
+
+    This driver requires the `drivers-observability-opentelemetry` [extra](../index.md#extras).
+
+The [OpenTelemetry](https://opentelemetry.io/) Observability Driver instruments `@observable` functions and methods with metrics and traces for use with OpenTelemetry. You must configure a destination for the telemetry by providing a `SpanProcessor` to the Driver.
+
+Here is an example of how to use the `OpenTelemetryObservabilityDriver` with the `Observability` context manager to output the telemetry directly to the console:
+
+```python
+--8<-- "docs/griptape-framework/drivers/src/observability_drivers_2.py"
+```


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Add back example.
## Issue ticket number and link
> Also, when I came to edit the Observability Drivers docs page, not sure whether it was intentional or not, but https://github.com/griptape-ai/griptape/commit/f5503bdc3c89c9db47498c75eff44ad1201b2873 truncated the file https://github.com/griptape-ai/griptape/blob/f5503bdc3c89c9db47498c75eff44ad1201b2873/docs/griptape-framework/drivers/observability-drivers.md, deleting a sample and a lot of log output. I'm pretty sure that should not have happened


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1787.org.readthedocs.build//1787/

<!-- readthedocs-preview griptape end -->