### PR TITLE
ci: fix dependabot beta ecosystems key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     versioning-strategy: "auto"
-    enable-beta-ecosystems: true
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Fix [confusing key](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#enable-beta-ecosystems-) location. Found usage [here](https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/).
## Issue ticket number and link
https://github.com/griptape-ai/griptape/runs/38129872586