### PR TITLE
docs: add back missing docs

### DIFF
--- a/docs/griptape-framework/structures/configs.md
+++ b/docs/griptape-framework/structures/configs.md
@@ -10,6 +10,101 @@ Griptape exposes a global singleton, [Defaults](../../reference/griptape/configs
 To update the default configurations, simply update the fields on the `Defaults` object.
 Framework objects will be created with the currently set default configurations, but you can always override at the individual class level.
 
+```python
+--8<-- "docs/griptape-framework/structures/src/config_defaults.py"
+```
+
+### Drivers Configs
+
+The [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md) class allows for the customization of Structures within Griptape, enabling specific settings such as Drivers to be defined for Tasks.
+
+Griptape provides predefined [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md)'s for widely used services that provide APIs for most Driver types Griptape offers.
+
+`DriversConfig`s can be used as a Python Context Manager using the `with` statement to temporarily change the default configurations for a block of code.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_with.py"
+```
+
+#### OpenAI
+
+The [OpenAI Driver config](../../reference/griptape/configs/drivers/openai_drivers_config.md) provides default Drivers for OpenAI's APIs. This is the default config for all Structures.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_1.py"
+```
+
+#### Azure OpenAI
+
+The [Azure OpenAI Driver config](../../reference/griptape/configs/drivers/azure_openai_drivers_config.md) provides default Drivers for Azure's OpenAI APIs.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_2.py"
+```
+
+#### Amazon Bedrock
+
+The [Amazon Bedrock Driver config](../../reference/griptape/configs/drivers/amazon_bedrock_drivers_config.md) provides default Drivers for Amazon Bedrock's APIs.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_3.py"
+```
+
+#### Google
+
+The [Google Driver config](../../reference/griptape/configs/drivers/google_drivers_config.md) provides default Drivers for Google's Gemini APIs.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_4.py"
+```
+
+#### Anthropic
+
+The [Anthropic Driver config](../../reference/griptape/configs/drivers/anthropic_drivers_config.md) provides default Drivers for Anthropic's APIs.
+
+!!! info
+
+    Anthropic does not provide an embeddings API which means you will need to use another service for embeddings.
+    To override the default embedding driver, see: [Override Default Structure Embedding Driver](../drivers/embedding-drivers.md#override-default-structure-embedding-driver).
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_5.py"
+```
+
+#### Cohere
+
+The [Cohere Driver config](../../reference/griptape/configs/drivers/cohere_drivers_config.md) provides default Drivers for Cohere's APIs.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_6.py"
+```
+
+#### Custom
+
+You can create your own [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md) by overriding relevant Drivers.
+The [DriversConfig](../../reference/griptape/configs/drivers/drivers_config.md) class includes "Dummy" Drivers for all types, which throw a [DummyError](../../reference/griptape/exceptions/dummy_exception.md) if invoked without being overridden.
+This approach ensures that you are informed through clear error messages if you attempt to use Structures without proper Driver configurations.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/drivers_config_7.py"
+```
+
+### Logging Config
+
+Griptape provides a predefined [LoggingConfig](../../reference/griptape/configs/logging/logging_config.md)'s for easily customizing the logging events that the framework emits. In order to customize the logger, the logger can be fetched by using the `Defaults.logging.logger_name`.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/logging_config.py"
+```
+
+#### Debug Logs
+
+You can enable debug logs to view more granular information such as request/response payloads.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/debug_logs.py"
+```
+
 ### Loading/Saving Configs
 
 You can serialize and deserialize Driver Configs using the [to_json()](../../reference/griptape/mixins/serializable_mixin.md#griptape.mixins.serializable_mixin.SerializableMixin.to_json) and [from_json()](../../reference/griptape/mixins/serializable_mixin.md#griptape.mixins.serializable_mixin.SerializableMixin.from_json) methods.

--- a/docs/griptape-framework/structures/task-memory.md
+++ b/docs/griptape-framework/structures/task-memory.md
@@ -95,6 +95,29 @@ Let's say we want to query the contents of a very large webpage.
 
 When running this example, we get the following error:
 
+```
+[04/26/24 13:20:02] ERROR    PromptTask 67e2f907f95d4850ae79f9da67df54c1
+                             Error code: 400 - {'error': {'message': "This model's maximum context length is 8192 tokens. However, your messages resulted in 73874 tokens.
+                             Please reduce the length of the messages.", 'type': 'invalid_request_error', 'param': 'messages', 'code': 'context_length_exceeded'}}
+```
+
+This is because the content of the webpage is too large to fit in the LLM's input token limit. We can fix this by storing the content in Task Memory, and then querying it with the `QueryTool`.
+Note that we're setting `off_prompt` to `False` on the `QueryTool` so that the _queried_ content can be returned directly to the LLM.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/task_memory_5.py"
+```
+
+And now we get the expected output.
+
+```
+[08/12/24 14:56:29] INFO     Subtask 8669ee523bb64550850566011bcd14e2
+                             Response: "Elden Ring" sold 13.4 million copies worldwide by the end of March 2022 and 25 million by June 2024. The downloadable content (DLC)
+                             "Shadow of the Erdtree" sold five million copies within three days of its release.
+[08/12/24 14:56:30] INFO     PromptTask d3ce58587dc944b0a30a205631b82944
+                             Output: Elden Ring sold 13.4 million copies worldwide by the end of March 2022 and 25 million by June 2024.
+```
+
 ## Sensitive Data
 
 Because Task Memory splits up the storage and retrieval of data, you can use different models for each step.

--- a/docs/griptape-framework/structures/workflows.md
+++ b/docs/griptape-framework/structures/workflows.md
@@ -167,8 +167,6 @@ Imperatively insert parallel tasks between a parent and child:
     --8<-- "docs/griptape-framework/structures/logs/workflows_9.txt"
     ```
 
-output:
-
 ### Bitshift Composition
 
 Task relationships can also be set up with the Python bitshift operators `>>` and `<<`. The following statements are all functionally equivalent:

--- a/docs/griptape-framework/tools/official-tools/index.md
+++ b/docs/griptape-framework/tools/official-tools/index.md
@@ -47,6 +47,10 @@ This tool enables LLMs to execute Python code and run shell commands inside a Do
 
 You can specify a local working directory and environment variables during tool initialization:
 
+```python
+--8<-- "docs/griptape-framework/tools/official-tools/src/computer_tool_1.py"
+```
+
 ### Date Time
 
 This tool enables LLMs to get current date and time.
@@ -66,6 +70,24 @@ This tool enables LLMs to get current date and time.
 ### Email
 
 The [EmailTool](../../../reference/griptape/tools/email/tool.md) enables LLMs to send emails.
+
+```python
+--8<-- "docs/griptape-framework/tools/official-tools/src/email_tool_1.py"
+```
+
+For debugging purposes, you can run a local SMTP server that the LLM can send emails to:
+
+```shell
+python -m smtpd -c DebuggingServer -n localhost:1025
+```
+
+### Extraction
+
+The [ExractionTool](../../../reference/griptape/tools/extraction/tool.md) enables LLMs to extract structured text from unstructured data.
+
+```python
+--8<-- "docs/griptape-framework/tools/official-tools/src/extraction_tool_1.py"
+```
 
 ### File Manager
 
@@ -198,6 +220,14 @@ Here is an example of how it can be used with a local vector store driver:
     ```text
     --8<-- "docs/griptape-framework/tools/official-tools/logs/rag_tool_1.txt"
     ```
+
+### Query
+
+The [QueryTool](../../../reference/griptape/tools/query/tool.md) enables Agents to query unstructured data for specific information.
+
+```python
+--8<-- "docs/griptape-framework/tools/official-tools/src/query_tool_1.py"
+```
 
 ### Rest Api
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Got accidentally removed by bad find and replace in https://github.com/griptape-ai/griptape/commit/f5503bdc3c89c9db47498c75eff44ad1201b2873#diff-6581c65f27bffff29bf243d07c1d94ce97e6b93cce1b29d30a304acbf30dfe3a.

I manually removed that diff so I'm hoping this is the last instance of this.

## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1797.org.readthedocs.build//1797/

<!-- readthedocs-preview griptape end -->