### PR TITLE
fix(drivers-vector-marqo): fix upsert failing due to inability to upsert_vectors

### DIFF
--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -42,7 +42,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         **kwargs,
     ) -> list[str] | dict[str, list[str]]:
         warnings.warn(
-            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert_collection` is a drop-in replacement.",
+            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseVectorStoreDriver.upsert_collection` is a drop-in replacement.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -58,7 +58,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         **kwargs,
     ) -> str:
         warnings.warn(
-            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert` is a drop-in replacement.",
+            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseVectorStoreDriver.upsert` is a drop-in replacement.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -74,7 +74,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         **kwargs,
     ) -> str:
         warnings.warn(
-            "`BaseVectorStoreDriver.upsert_text` is deprecated and will be removed in a future release. `BaseEmbeddingDriver.upsert` is a drop-in replacement.",
+            "`BaseVectorStoreDriver.upsert_text` is deprecated and will be removed in a future release. `BaseVectorStoreDriver.upsert` is a drop-in replacement.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
[This PR](https://github.com/griptape-ai/griptape/pull/1753) made it so that Vector Store Drivers must only implement `upsert_vector`.  Marqo is unique, however, since they do the embeddings themselves, server-side. So rather than generate embeddings client-side and upsert them, we need to hand over the full process to Marqo.
## Issue ticket number and link
Closes #1798 
Fixes failing integration test https://github.com/griptape-ai/griptape/actions/runs/13659043403/job/38185583853