### PR TITLE
revert: don't use lazy_property on Agent, it erroneously triggers deprecation warnings

### DIFF
--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
-from attrs import Attribute, define, evolve, field
+from attrs import Attribute, define, evolve, field, validators
 
 from griptape.artifacts.text_artifact import TextArtifact
 from griptape.common import observable
 from griptape.configs import Defaults
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
-from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -27,8 +26,8 @@ class Agent(Structure):
     input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
     )
-    _stream: Optional[bool] = field(default=None, kw_only=True, alias="stream")
-    _prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True, alias="prompt_driver")
+    stream: Optional[bool] = field(default=None, kw_only=True)
+    prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
     output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
@@ -37,20 +36,12 @@ class Agent(Structure):
         factory=list, kw_only=True, alias="tasks", metadata={"serializable": True}
     )
 
-    @lazy_property()
-    def prompt_driver(self) -> BasePromptDriver:
-        return evolve(Defaults.drivers_config.prompt_driver, stream=self.stream)
-
-    @lazy_property()
-    def stream(self) -> bool:
-        return Defaults.drivers_config.prompt_driver.stream
-
     @fail_fast.validator  # pyright: ignore[reportAttributeAccessIssue]
     def validate_fail_fast(self, _: Attribute, fail_fast: bool) -> None:  # noqa: FBT001
         if fail_fast:
             raise ValueError("Agents cannot fail fast, as they can only have 1 task.")
 
-    @_prompt_driver.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
+    @prompt_driver.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
     def validate_prompt_driver(self, _: Attribute, prompt_driver: Optional[BasePromptDriver]) -> None:  # noqa: FBT001
         if prompt_driver is not None and self.stream is not None:
             warnings.warn(
@@ -99,9 +90,20 @@ class Agent(Structure):
         return self
 
     def _init_task(self) -> None:
+        if self.stream is None:
+            with validators.disabled():
+                self.stream = Defaults.drivers_config.prompt_driver.stream
+
+        if self.prompt_driver is None:
+            with validators.disabled():
+                prompt_driver = evolve(Defaults.drivers_config.prompt_driver, stream=self.stream)
+                self.prompt_driver = prompt_driver
+        else:
+            prompt_driver = self.prompt_driver
+
         task = PromptTask(
             self.input,
-            prompt_driver=self.prompt_driver,
+            prompt_driver=prompt_driver,
             tools=self.tools,
             output_schema=self.output_schema,
             max_meta_memory_entries=self.max_meta_memory_entries,

--- a/tests/unit/structures/test_agent.py
+++ b/tests/unit/structures/test_agent.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import Mock
 
 import pytest
@@ -294,6 +295,16 @@ class TestAgent:
     def test_validate_tasks(self):
         with pytest.warns(UserWarning, match="`Agent.tasks` is set, but `Agent.prompt_driver` was provided."):
             Agent(prompt_driver=MockPromptDriver(), tasks=[PromptTask()])
+
+    def test_valid_agent_no_warnings(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert Agent()
+            assert Agent(
+                tasks=[PromptTask()],
+            )
+            assert Agent(stream=True)
+            assert Agent(prompt_driver=MockPromptDriver())
 
     def test_field_hierarchy(self):
         # Test that stream on its own propagates to the task.


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
https://github.com/griptape-ai/griptape/pull/1779/files#diff-43b695bb6fb7125662cd7dbe70ebcbd57e34bfd19dfee1b7901b819ce014847a

## Issue ticket number and link
Closes #1804 