### PR TITLE
ci: fix automatic docs gen

### DIFF
--- a/.github/workflows/docs-integration-tests.yml
+++ b/.github/workflows/docs-integration-tests.yml
@@ -163,5 +163,6 @@ jobs:
           body: "This PR was automatically generated to update the code snippets logs in the documentation."
           commit-message: "chore(docs): update code snippets logs"
           base: "main"
+          labels: "docs"
           add-paths: |
             docs/**/*


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
### Problem
1. The documentation log script only runs on changed `*.py` files in the `docs/` directory. If integration tests fail for some reason, the next PR that fixes the integration tests will not contain the originally changed `*.py` files. Therefore logs are not generated for those files.
2. There is no way to regenerate logs without changing the associated `*.py` file.
### Solution
Run on _all_ `*.py` files. For each one that has logs:
- If it needs conversion ( [example](https://github.com/griptape-ai/griptape/pull/1808/files#diff-f1c3bc341c128d95892f4fa89b0ee20db0805e7dfc9ac960fee4367a15021ff3) of what I mean by "conversion"), convert it and copy the logs.
- If it doesn't need conversion, but it is a changed file, just copy the logs.

If a developer needs to regenerate logs without changing a `.py` file, they can "unconvert" the example and it will be converted on the next run.

Functioning PR [here](https://github.com/griptape-ai/griptape/pull/1808).
## Issue ticket number and link
NA