### PR TITLE
feat(tasks-prompt): add `reflect_on_tool_use` flag to disable LLM reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ The important thing to note here is that no matter how big the webpage is it can
 In the above example, we set [off_prompt](https://docs.griptape.ai/stable/griptape-framework/structures/task-memory.md#off-prompt) to `True`, which means that the LLM can never see the data it manipulates, but can send it to other Tools.
 
 > [!IMPORTANT]
-> This example uses Griptape's [PromptTask](https://docs.griptape.ai/stable/griptape-framework/structures/tasks/#prompt-task) with `tools`, which requires a highly capable LLM to function correctly. By default, Griptape uses the [OpenAiChatPromptDriver](https://docs.griptape.ai/stable/griptape-framework/drivers/prompt-drivers/#openai-chat); for another powerful LLM try swapping to the [AnthropicPromptDriver](https://docs.griptape.ai/stable/griptape-framework/drivers/prompt-drivers/#anthropic)!
-> If you're using a less powerful LLM, consider using the [ToolTask](https://docs.griptape.ai/stable/griptape-framework/structures/tasks/#tool-task) instead, as the `PromptTask` with `tools` might not work properly or at all.
+> This example uses Griptape's [PromptTask](https://docs.griptape.ai/stable/griptape-framework/structures/tasks/#prompt-task) with multiple `tools`, which requires a highly capable LLM to function correctly.
+> If you're using a less powerful LLM, consider setting [reflect_on_tool_use](https://docs.griptape.ai/latest/griptape-framework/structures/tasks/#reflect-on-tool-use) to `False` to have the LLM return tool outputs directly.
+> You can then make the same tool calls yourself rather than having the LLM coordinate them.
 
 [Check out our docs](https://docs.griptape.ai/stable/griptape-framework/drivers/prompt-drivers/) to learn more about how to use Griptape with other LLM providers like Anthropic, Claude, Hugging Face, and Azure.
 

--- a/docs/griptape-framework/structures/src/tasks_reflect_on_tool_use.py
+++ b/docs/griptape-framework/structures/src/tasks_reflect_on_tool_use.py
@@ -1,0 +1,23 @@
+from griptape.artifacts.list_artifact import ListArtifact
+from griptape.drivers.web_search.duck_duck_go import DuckDuckGoWebSearchDriver
+from griptape.tasks import PromptTask
+from griptape.tools import WebScraperTool, WebSearchTool
+
+search_task = PromptTask(
+    tools=[WebSearchTool(web_search_driver=DuckDuckGoWebSearchDriver())],
+    reflect_on_tool_use=False,
+)
+search_results = search_task.run("Do two searches, one for 'vim' and one for 'emacs'.")
+
+# When disabling `reflect_on_tool_use`, the Task's results will be returned as a ListArtifact.
+# Each item in the ListArtifact will be the result of a single tool execution.
+if isinstance(search_results, ListArtifact):
+    for result in search_results:
+        print(result)
+
+scrape_task = PromptTask(
+    tools=[WebScraperTool()],
+    reflect_on_tool_use=True,
+)
+# If we don't care about the individual results, we can join them back together before passing to the next task.
+answer = scrape_task.run(["Compare and contrast vim and emacs: ", search_results.to_text()])

--- a/docs/griptape-framework/structures/tasks.md
+++ b/docs/griptape-framework/structures/tasks.md
@@ -80,6 +80,22 @@ You can pass in one or more Tools which the LLM will decide to use through Chain
     --8<-- "docs/griptape-framework/structures/logs/tasks_4.txt"
     ```
 
+#### Reflect On Tool Use
+
+By default, Griptape will pass the results of Tool runs back to the LLM for reflection. This enables the LLM to reason about the results and potentially use additional tools.
+
+However, there may be times where you may want the LLM to give you back the results directly, without reflection.
+You can disable this behavior by setting [reflect_on_tool_use](../../reference/griptape/tasks/prompt_task.md#griptape.tasks.prompt_task.PromptTask.reflect_on_tool_use) to `False`.
+
+```python
+--8<-- "docs/griptape-framework/structures/src/tasks_reflect_on_tool_use.py"
+```
+
+!!! important
+
+    Disabling reflection will prevent the LLM from using one Tool to inform the use of another Tool.
+    Instead, you must coordinate the Tool uses yourself.
+
 ### Images
 
 If the model supports it, you can also pass image inputs:
@@ -97,6 +113,10 @@ If the model supports it, you can also pass image inputs:
     ```
 
 ## Tool Task
+
+!!! warning
+
+    `ToolTask` is deprecated and will be removed in a future version. Use [Prompt Task](./tasks.md#prompt-task) with [reflect_on_tool_use](./tasks.md#reflect-on-tool-use) set to `False` instead.
 
 Another way to use [Griptape Tools](../../griptape-framework/tools/index.md), is with a [Tool Task](../../reference/griptape/tasks/tool_task.md).
 This Task takes in a single Tool which the LLM will use without Chain of Thought (CoT) reasoning. Because this Task does not use CoT, it is better suited for less capable models.

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
@@ -64,6 +65,11 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
         return self._actions_schema_for_tools([self.tool])
 
     def try_run(self) -> ListArtifact | TextArtifact | ErrorArtifact:
+        warnings.warn(
+            "`ToolTask` is deprecated and will be removed in a future release. Use `PromptTask` with `reflect_on_tool_use=False` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         result = self.prompt_driver.run(self.prompt_stack)
 
         if self.prompt_driver.use_native_tools:

--- a/griptape/templates/tasks/prompt_task/system.j2
+++ b/griptape/templates/tasks/prompt_task/system.j2
@@ -12,10 +12,14 @@ Actions: <JSON array of actions that MUST follow this schema: {{ actions_schema 
 You must use the following format when providing your final answer:
 Answer: <final answer>
 {% endif %}
+
+{% if reflect_on_tool_use %}
 Repeat executing actions as many times as you need.
 If an action's output contains an error, you MUST ALWAYS try to fix the error by executing another action. 
 
-Be truthful. ALWAYS be proactive and NEVER ask the user for more information input. Keep using actions until you have your final answer.
+Keep using actions until you have your final answer.
+{% endif %}
+Be truthful. ALWAYS be proactive and NEVER ask the user for more information input.
 NEVER make up actions, action names, or action paths. NEVER make up facts. NEVER reference tags in other action input values.
 {% endif %}
 {% if meta_memory %}

--- a/tests/unit/tasks/test_prompt_task.py
+++ b/tests/unit/tasks/test_prompt_task.py
@@ -285,3 +285,18 @@ class TestPromptTask:
             assert output.value.model_dump_json() == expected_output.model_dump_json()
         else:
             assert output.value == expected_output
+
+    @pytest.mark.parametrize(
+        ("reflect_on_tool_use", "expected"),
+        [(True, "mock output"), (False, "ack test-value")],
+    )
+    def test_reflect_on_tool_use(self, reflect_on_tool_use, expected):
+        task = PromptTask(
+            tools=[MockTool()],
+            prompt_driver=MockPromptDriver(use_native_tools=True),
+            reflect_on_tool_use=reflect_on_tool_use,
+        )
+
+        result = task.run()
+
+        assert result.to_text() == expected

--- a/tests/unit/tasks/test_tool_task.py
+++ b/tests/unit/tasks/test_tool_task.py
@@ -285,3 +285,11 @@ class TestToolTask:
 
         deserialized_tool_task = ToolTask.from_dict(serialized_tool_task)
         assert isinstance(deserialized_tool_task, ToolTask)
+
+    def test_deprecated_warning(self, agent):
+        task = ToolTask(tool=MockTool())
+
+        agent.add_task(task)
+
+        with pytest.warns(DeprecationWarning):
+            task.run()


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
- Adds `PromptTask.reflect_on_tool_use` to have the LLM return the results directly back to you.
- Deprecates `ToolTask`, as `PromptTask.reflect_on_tool_use` does a better job.

Concept borrowed from [autogen](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html#using-tools).
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1471

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1810.org.readthedocs.build//1810/

<!-- readthedocs-preview griptape end -->