### PR TITLE
ci: change dependabot prefix from chore to build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
         - "patch"
         - "major"
     commit-message:
-      prefix: chore(deps)
+      prefix: build(deps)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Slightly more accurate: https://stackoverflow.com/questions/65855111/what-would-be-a-good-commit-message-for-updating-package-versions-using-conventi
## Issue ticket number and link
NA