### PR TITLE
ci: use even more accurate dependabot prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
         - "patch"
         - "major"
     commit-message:
-      prefix: build(deps)
+      prefix: deps
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Oops, missed this: https://github.com/googleapis/release-please/blob/4b5eb72ebec09e1e39ce5f8495b75b4b85bdbac0/src/strategies/python.ts#L35
## Issue ticket number and link
NA