### PR TITLE
docs: don't use structured output in perplexity example

### DIFF
--- a/docs/griptape-framework/drivers/src/prompt_drivers_perplexity.py
+++ b/docs/griptape-framework/drivers/src/prompt_drivers_perplexity.py
@@ -1,22 +1,14 @@
 import os
 
-from pydantic import BaseModel
-
 from griptape.drivers.prompt.perplexity import PerplexityPromptDriver
 from griptape.rules import Rule
 from griptape.structures import Agent
 from griptape.tasks import PromptTask
 
-
-class Output(BaseModel):
-    final_answer: str
-
-
 agent = Agent(
     tasks=[
         PromptTask(
             prompt_driver=PerplexityPromptDriver(model="sonar-pro", api_key=os.environ["PERPLEXITY_API_KEY"]),
-            output_schema=Output,
             rules=[
                 Rule("Be precise and concise"),
             ],

--- a/docs/griptape-framework/drivers/src/web_search_drivers_perplexity.py
+++ b/docs/griptape-framework/drivers/src/web_search_drivers_perplexity.py
@@ -5,5 +5,10 @@ from griptape.drivers.web_search.perplexity import PerplexityWebSearchDriver
 driver = PerplexityWebSearchDriver(
     api_key=os.environ["PERPLEXITY_API_KEY"],
 )
+result = driver.search("griptape ai")
 
-print(driver.search("griptape ai").to_text())
+print(result.to_text())
+# The search results will only contain a single Artifact.
+# This Artifact contains the search results and any citations.
+for citation in result[0].meta["citations"]:
+    print(citation)

--- a/griptape/common/prompt_stack/messages/base_message.py
+++ b/griptape/common/prompt_stack/messages/base_message.py
@@ -35,7 +35,6 @@ class BaseMessage(ABC, SerializableMixin):
     content: list[Union[BaseMessageContent, BaseDeltaMessageContent]] = field(metadata={"serializable": True})
     role: str = field(kw_only=True, metadata={"serializable": True})
     usage: Usage = field(kw_only=True, default=Factory(lambda: BaseMessage.Usage()), metadata={"serializable": True})
-    meta: dict = field(kw_only=True, factory=dict, metadata={"serializable": True})
 
     def is_system(self) -> bool:
         return self.role == self.SYSTEM_ROLE

--- a/griptape/drivers/prompt/perplexity_prompt_driver.py
+++ b/griptape/drivers/prompt/perplexity_prompt_driver.py
@@ -23,8 +23,8 @@ class PerplexityPromptDriver(OpenAiChatPromptDriver):
     @override
     def _to_message(self, result: ChatCompletion) -> Message:
         message = super()._to_message(result)
-        if hasattr(result, "citations"):
-            message.meta["citations"] = getattr(result, "citations")
+
+        message.content[0].artifact.meta["citations"] = getattr(result, "citations", [])
 
         return message
 

--- a/griptape/drivers/web_search/perplexity_web_search_driver.py
+++ b/griptape/drivers/web_search/perplexity_web_search_driver.py
@@ -26,7 +26,4 @@ class PerplexityWebSearchDriver(BaseWebSearchDriver):
     def search(self, query: str, **kwargs) -> ListArtifact:
         message = self.prompt_driver.run(PromptStack.from_artifact(TextArtifact(query)))
 
-        artifact = message.to_artifact()
-        artifact.meta["citations"] = message.meta.get("citations", [])
-
         return ListArtifact([message.to_artifact()])


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
- Removes `Message.meta` since it was breaking the GTC Chat API and feels redundant with `BaseArtifact.meta`.
- Refactors Perplexity Drivers for this change.
- Updates Perplexity doc that uses feature users are unlikely to have available.

BEGIN_COMMIT_OVERRIDE
hidden: don't use structured output in perplexity example
hidden: remove the need for a meta field on Message
END_COMMIT_OVERRIDE

## Issue ticket number and link
Fixes integration tests.

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1827.org.readthedocs.build//1827/

<!-- readthedocs-preview griptape end -->