### PR TITLE
fix(drivers-prompt-openai): convert to text rather than error when passing GenericArtifacts

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -352,7 +352,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
         elif isinstance(content, ActionResultMessageContent):
             return content.artifact.to_text()
         else:
-            raise ValueError(f"Unsupported content type: {type(content)}")
+            return {"type": "text", "text": content.artifact.to_text()}
 
     def __to_prompt_stack_message_content(self, response: ChatCompletionMessage) -> list[BaseMessageContent]:
         content = []

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -7,6 +7,7 @@ import schema
 
 from griptape.artifacts import ActionArtifact, ImageArtifact, ListArtifact, TextArtifact
 from griptape.artifacts.audio_artifact import AudioArtifact
+from griptape.artifacts.generic_artifact import GenericArtifact
 from griptape.common import ActionCallDeltaMessageContent, PromptStack, TextDeltaMessageContent, ToolAction
 from griptape.common.prompt_stack.contents.audio_delta_message_content import AudioDeltaMessageContent
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
@@ -366,6 +367,8 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 },
             ),
         )
+
+        prompt_stack.add_user_message(GenericArtifact(value="generic-value"))
         return prompt_stack
 
     @pytest.fixture()
@@ -402,6 +405,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
             },
             {"audio": {"id": "audio-id"}, "content": "", "role": "assistant"},
             {"content": [{"type": "text", "text": "assistant-audio-transcription"}], "role": "assistant"},
+            {"content": [{"type": "text", "text": "generic-value"}], "role": "user"},
         ]
 
     @pytest.fixture()


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Fixes issue when using conversation memory with structured output.
## Issue ticket number and link
NA