### PR TITLE
docs: restrict height of `text` code blocks (logs)

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -5,3 +5,9 @@
 .md-typeset table:not([class]) {
     display: table;
 }
+
+/* Add scrollbars to large text code blocks (logs) */
+.language-text pre {
+    max-height: 500px;
+    overflow-y: scroll;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - Misc:
           - Events: "griptape-framework/misc/events.md"
           - Tokenizers: "griptape-framework/misc/tokenizers.md"
+          - Serialization: "griptape-framework/misc/serialization.md"
       - Recipes:
           - Agents:
               - Talk to Redshift: "recipes/talk-to-redshift.md"


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
BEGIN_COMMIT_OVERRIDE
hidden: restrict height of `text` code blocks (logs)
END_COMMIT_OVERRIDE
## Issue ticket number and link


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1835.org.readthedocs.build//1835/

<!-- readthedocs-preview griptape end -->