### PR TITLE
Remove Usage Of Deprecated Calls

### DIFF
--- a/docs/griptape-framework/drivers/src/embedding_drivers_6.py
+++ b/docs/griptape-framework/drivers/src/embedding_drivers_6.py
@@ -4,7 +4,7 @@ driver = OllamaEmbeddingDriver(
     model="all-minilm",
 )
 
-results = driver.embed_string("Hello world!")
+results = driver.embed("Hello world!")
 
 # display the first 3 embeddings
 print(results[:3])

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_1.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_1.py
@@ -15,7 +15,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=100).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts({"griptape": chunks})
+vector_store_driver.upsert_collection({"griptape": chunks})
 
 results = vector_store_driver.query(query="What is griptape?")
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_10.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_10.py
@@ -31,7 +31,7 @@ vector_store_driver.client.recreate_collection(
 )
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts({"griptape": chunks})
+vector_store_driver.upsert_collection({"griptape": chunks})
 
 results = vector_store_driver.query(query="What is griptape?")
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_11.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_11.py
@@ -26,7 +26,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker().chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts({"griptape": chunks})
+vector_store_driver.upsert_collection({"griptape": chunks})
 
 results = vector_store_driver.query(query="What is griptape?")
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_3.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_3.py
@@ -22,7 +22,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=100).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts({NAMESPACE: chunks})
+vector_store_driver.upsert_collection({NAMESPACE: chunks})
 
 results = vector_store_driver.query(query="What is griptape?", namespace=NAMESPACE)
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_4.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_4.py
@@ -26,7 +26,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=200).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts(
+vector_store_driver.upsert_collection(
     {
         "griptape": chunks,
     }

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_5.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_5.py
@@ -31,7 +31,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=200).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts({"griptape": chunks})
+vector_store_driver.upsert_collection({"griptape": chunks})
 
 results = vector_store_driver.query(query="What is griptape?")
 

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_6.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_6.py
@@ -31,7 +31,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=200).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts(
+vector_store_driver.upsert_collection(
     {
         "griptape": chunks,
     }

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_7.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_7.py
@@ -21,7 +21,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=200).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts(
+vector_store_driver.upsert_collection(
     {
         "griptape": chunks,
     }

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_8.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_8.py
@@ -22,7 +22,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker(max_tokens=200).chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts(
+vector_store_driver.upsert_collection(
     {
         "griptape": chunks,
     }

--- a/docs/griptape-framework/drivers/src/vector_store_drivers_9.py
+++ b/docs/griptape-framework/drivers/src/vector_store_drivers_9.py
@@ -28,7 +28,7 @@ artifact = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker().chunk(artifact)
 
 # Upsert Artifacts into the Vector Store Driver
-vector_store_driver.upsert_text_artifacts(
+vector_store_driver.upsert_collection(
     {
         "griptape": chunks,
     }

--- a/docs/griptape-framework/drivers/vector-store-drivers.md
+++ b/docs/griptape-framework/drivers/vector-store-drivers.md
@@ -7,10 +7,9 @@ search:
 
 Griptape provides a way to build drivers for vector DBs where embeddings can be stored and queried. Every Vector Store Driver implements the following methods:
 
-- `upsert_text_artifact()` for updating or inserting a new [TextArtifact](../../reference/griptape/artifacts/text_artifact.md) into vector DBs. The method will automatically generate embeddings for a given value.
-- `upsert_text_artifacts()` for updating or inserting multiple [TextArtifact](../../reference/griptape/artifacts/text_artifact.md)s into vector DBs. The method will automatically generate embeddings for given values.
-- `upsert_text()` for updating and inserting new arbitrary strings into vector DBs. The method will automatically generate embeddings for a given value.
-- `upsert_vector()` for updating and inserting new vectors directly.
+- `upsert()` for updating or inserting new text, [TextArtifact](../../reference/griptape/artifacts/text_artifact.md)s or [ImageArtifact](../../reference/griptape/artifacts/text_artifact.md)s into vector DBs. The method will automatically generate embeddings for a given value.
+- `upsert_collection()` for performing an `upsert()` in parallel.
+- `upsert_vector()` for updating new vectors directly.
 - `query()` for querying vector DBs.
 
 Each Vector Store Driver takes a [BaseEmbeddingDriver](../../reference/griptape/drivers/embedding/base_embedding_driver.md) used to dynamically generate embeddings for strings.

--- a/docs/griptape-framework/structures/src/tasks_9.py
+++ b/docs/griptape-framework/structures/src/tasks_9.py
@@ -15,7 +15,7 @@ artifacts = [
     TextArtifact("Griptape builds AI-powered applications that connect securely to your enterprise data and APIs."),
     TextArtifact("Griptape Agents provide incredible power and flexibility when working with large language models."),
 ]
-vector_store_driver.upsert_text_artifacts({"griptape": artifacts})
+vector_store_driver.upsert_collection({"griptape": artifacts})
 
 # Instantiate the agent and add RagTask with the RagEngine
 agent = Agent()

--- a/docs/griptape-framework/tools/official-tools/src/rag_tool_1.py
+++ b/docs/griptape-framework/tools/official-tools/src/rag_tool_1.py
@@ -15,7 +15,7 @@ artifact = TextArtifact(
     "Griptape Agents provide incredible power and flexibility when working with large language models."
 )
 
-vector_store_driver.upsert_text_artifact(artifact=artifact, namespace="griptape")
+vector_store_driver.upsert(artifact, namespace="griptape")
 
 rag_tool = RagTool(
     description="Contains information about Griptape",

--- a/docs/griptape-framework/tools/official-tools/src/vector_store_tool_1.py
+++ b/docs/griptape-framework/tools/official-tools/src/vector_store_tool_1.py
@@ -14,7 +14,7 @@ vector_store_driver = LocalVectorStoreDriver(
 artifacts = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker().chunk(artifacts)
 
-vector_store_driver.upsert_text_artifacts({NAMESPACE: chunks})
+vector_store_driver.upsert_collection({NAMESPACE: chunks})
 vector_db = VectorStoreTool(
     description="This DB has information about the Griptape Python framework",
     vector_store_driver=vector_store_driver,

--- a/docs/recipes/src/load_and_query_pinecone_1.py
+++ b/docs/recipes/src/load_and_query_pinecone_1.py
@@ -13,7 +13,7 @@ def load_data(driver: PineconeVectorStoreDriver) -> None:
     )
 
     for product in json.loads(response.read()):
-        driver.upsert_text(
+        driver.upsert(
             product["description"],
             vector_id=hashlib.md5(product["title"].encode()).hexdigest(),
             meta={

--- a/docs/recipes/src/load_query_and_chat_marqo_1.py
+++ b/docs/recipes/src/load_query_and_chat_marqo_1.py
@@ -29,7 +29,7 @@ artifacts = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker().chunk(artifacts)
 
 # Upsert the artifacts into the vector store
-vector_store.upsert_text_artifacts(
+vector_store.upsert_collection(
     {
         namespace: chunks,
     }

--- a/docs/recipes/src/query_webpage_1.py
+++ b/docs/recipes/src/query_webpage_1.py
@@ -10,7 +10,7 @@ vector_store = LocalVectorStoreDriver(embedding_driver=OpenAiEmbeddingDriver(api
 artifacts = WebLoader().load("https://www.griptape.ai")
 chunks = TextChunker().chunk(artifacts)
 
-vector_store.upsert_text_artifacts({"griptape": chunks})
+vector_store.upsert_collection({"griptape": chunks})
 
 results = vector_store.query("creativity", count=3, namespace="griptape")
 

--- a/docs/recipes/src/query_webpage_astra_db_1.py
+++ b/docs/recipes/src/query_webpage_astra_db_1.py
@@ -44,7 +44,7 @@ engine = RagEngine(
 
 artifacts = WebLoader().load(input_blogpost)
 chunks = TextChunker(max_tokens=256).chunk(artifacts)
-vector_store_driver.upsert_text_artifacts({namespace: chunks})
+vector_store_driver.upsert_collection({namespace: chunks})
 
 rag_tool = RagTool(
     description="A DataStax blog post",

--- a/docs/recipes/src/talk_to_a_pdf_1.py
+++ b/docs/recipes/src/talk_to_a_pdf_1.py
@@ -36,7 +36,7 @@ rag_tool = RagTool(
 artifacts = PdfLoader().parse(response.content)
 chunks = TextChunker().chunk(artifacts)
 
-vector_store.upsert_text_artifacts({namespace: chunks})
+vector_store.upsert_collection({namespace: chunks})
 
 agent = Agent(tools=[rag_tool])
 

--- a/docs/recipes/src/talk_to_a_webpage_1.py
+++ b/docs/recipes/src/talk_to_a_webpage_1.py
@@ -31,7 +31,7 @@ engine = RagEngine(
 artifacts = WebLoader().load("https://en.wikipedia.org/wiki/Physics")
 chunks = TextChunker().chunk(artifacts)
 
-vector_store_driver.upsert_text_artifacts({namespace: chunks})
+vector_store_driver.upsert_collection({namespace: chunks})
 
 rag_tool = RagTool(
     description="Contains information about physics. Use it to answer any physics-related questions.",

--- a/griptape/artifacts/text_artifact.py
+++ b/griptape/artifacts/text_artifact.py
@@ -26,7 +26,7 @@ class TextArtifact(BaseArtifact):
         return self.value
 
     def generate_embedding(self, driver: BaseEmbeddingDriver) -> list[float]:
-        embedding = driver.embed_string(str(self.value))
+        embedding = driver.embed(str(self.value))
 
         if self.embedding is None:
             self.embedding = []

--- a/griptape/drivers/rerank/local_rerank_driver.py
+++ b/griptape/drivers/rerank/local_rerank_driver.py
@@ -25,7 +25,7 @@ class LocalRerankDriver(BaseRerankDriver, FuturesExecutorMixin):
     )
 
     def run(self, query: str, artifacts: list[TextArtifact]) -> list[TextArtifact]:
-        query_embedding = self.embedding_driver.embed_string(query)
+        query_embedding = self.embedding_driver.embed(query)
 
         with self.create_futures_executor() as futures_executor:
             artifact_embeddings = execute_futures_list(

--- a/griptape/drivers/vector/pinecone_vector_store_driver.py
+++ b/griptape/drivers/vector/pinecone_vector_store_driver.py
@@ -75,7 +75,7 @@ class PineconeVectorStoreDriver(BaseVectorStoreDriver):
         # https://community.pinecone.io/t/is-there-a-way-to-query-all-the-vectors-and-or-metadata-from-a-namespace/797/5
 
         results = self.index.query(
-            vector=self.embedding_driver.embed_string(""),
+            vector=self.embedding_driver.embed(""),
             top_k=10000,
             include_metadata=True,
             namespace=namespace,

--- a/griptape/engines/rag/modules/retrieval/text_loader_retrieval_rag_module.py
+++ b/griptape/engines/rag/modules/retrieval/text_loader_retrieval_rag_module.py
@@ -41,6 +41,6 @@ class TextLoaderRetrievalRagModule(BaseRetrievalRagModule):
         loader_output = self.loader.load(source)
         chunks = self.chunker.chunk(loader_output)
 
-        self.vector_store_driver.upsert_text_artifacts({namespace: chunks})
+        self.vector_store_driver.upsert_collection({namespace: chunks})
 
         return self.process_query_output(self.vector_store_driver.query(context.query, **query_params))

--- a/griptape/memory/task/storage/text_artifact_storage.py
+++ b/griptape/memory/task/storage/text_artifact_storage.py
@@ -23,7 +23,7 @@ class TextArtifactStorage(BaseArtifactStorage):
 
     def store_artifact(self, namespace: str, artifact: BaseArtifact) -> None:
         if isinstance(artifact, TextArtifact):
-            self.vector_store_driver.upsert_text_artifact(artifact, namespace=namespace)
+            self.vector_store_driver.upsert(artifact, namespace=namespace)
         else:
             raise ValueError("Artifact must be of instance TextArtifact")
 

--- a/tests/integration/drivers/vector/test_astra_db_vector_store_driver.py
+++ b/tests/integration/drivers/vector/test_astra_db_vector_store_driver.py
@@ -58,16 +58,16 @@ class TestAstraDbVectorStoreDriver:
         """Test basic vector CRUD, various call patterns."""
         vector_store_collection.delete_many({})
 
-        vec1 = embedding_driver.embed_string("0.012")
+        vec1 = embedding_driver.embed("0.012")
         id1 = vector_store_driver.upsert_vector(vec1, vector_id="v1")
 
-        vec2 = embedding_driver.embed_string("0.024")
+        vec2 = embedding_driver.embed("0.024")
         id2 = vector_store_driver.upsert_vector(vec2, vector_id="v2", namespace="ns")
 
-        vec3 = embedding_driver.embed_string("0.036")
+        vec3 = embedding_driver.embed("0.036")
         id3 = vector_store_driver.upsert_vector(vec3)
 
-        vec4 = embedding_driver.embed_string("0.048")
+        vec4 = embedding_driver.embed("0.048")
         id4 = vector_store_driver.upsert_vector(vec4, vector_id="v4", meta={"i": 4}, namespace="ns")
 
         assert id1 == "v1"

--- a/tests/integration/drivers/vector/test_pgvector_vector_store_driver.py
+++ b/tests/integration/drivers/vector/test_pgvector_vector_store_driver.py
@@ -123,7 +123,7 @@ class TestPgVectorVectorStoreDriver:
     def test_can_query(self, vector_store_driver):
         value = "my string here"
         namespace = str(uuid.uuid4())
-        embedding = vector_store_driver.embedding_driver.embed_string(value)
+        embedding = vector_store_driver.embedding_driver.embed(value)
 
         vector_id = vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace)
@@ -134,7 +134,7 @@ class TestPgVectorVectorStoreDriver:
     def test_can_query_by_cosine_distance(self, vector_store_driver):
         value = "my string here"
         namespace = str(uuid.uuid4())
-        embedding = vector_store_driver.embedding_driver.embed_string(value)
+        embedding = vector_store_driver.embedding_driver.embed(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace, distance_metric="cosine_distance")
@@ -144,7 +144,7 @@ class TestPgVectorVectorStoreDriver:
     def test_can_query_by_l2_distance(self, vector_store_driver):
         value = "my string here"
         namespace = str(uuid.uuid4())
-        embedding = vector_store_driver.embedding_driver.embed_string(value)
+        embedding = vector_store_driver.embedding_driver.embed(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace, distance_metric="l2_distance")
@@ -154,7 +154,7 @@ class TestPgVectorVectorStoreDriver:
     def test_can_query_by_inner_product(self, vector_store_driver):
         value = "my string here"
         namespace = str(uuid.uuid4())
-        embedding = vector_store_driver.embedding_driver.embed_string(value)
+        embedding = vector_store_driver.embedding_driver.embed(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace, distance_metric="inner_product")
@@ -164,7 +164,7 @@ class TestPgVectorVectorStoreDriver:
     def test_query_returns_vectors_when_requested(self, vector_store_driver):
         value = "my string here"
         namespace = str(uuid.uuid4())
-        embedding = vector_store_driver.embedding_driver.embed_string(value)
+        embedding = vector_store_driver.embedding_driver.embed(value)
 
         vector_store_driver.upsert_vector(embedding, namespace=namespace)
         results = vector_store_driver.query(value, namespace=namespace, include_vectors=True)

--- a/tests/integration/tasks/test_rag_task.py
+++ b/tests/integration/tasks/test_rag_task.py
@@ -22,7 +22,7 @@ class TestRagTask:
         artifact = TextArtifact("John Doe works as as software engineer at Griptape.")
         rag_engine_instance = rag_engine(MockPromptDriver(), vector_store_driver)
 
-        vector_store_driver.upsert_text_artifact(artifact=artifact)
+        vector_store_driver.upsert(artifact=artifact)
 
         agent = Agent(prompt_driver=request.param)
         agent.add_task(RagTask("Respond to the users following query: {{ args[0] }}", rag_engine=rag_engine_instance))

--- a/tests/unit/drivers/embedding/test_base_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_base_embedding_driver.py
@@ -18,7 +18,7 @@ class TestBaseEmbeddingDriver:
         assert embedding == [0, 1]
 
     def test_embed_string(self, driver):
-        embedding = driver.embed_string("foobar")
+        embedding = driver.embed("foobar")
 
         assert embedding == [0, 1]
 
@@ -39,7 +39,7 @@ class TestBaseEmbeddingDriver:
     def test_no_tokenizer(self, driver):
         driver.tokenizer = None
 
-        embedding = driver.embed_string("foobar")
+        embedding = driver.embed("foobar")
 
         assert embedding == [0, 1]
 
@@ -48,6 +48,6 @@ class TestBaseEmbeddingDriver:
         try_embed_chunk.side_effect = Exception("nope")
 
         with pytest.raises(Exception) as e:
-            driver.embed_string("foobar")
+            driver.embed("foobar")
 
         assert e.value.args[0] == "nope"

--- a/tests/unit/drivers/vector/test_astra_db_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_astra_db_vector_store_driver.py
@@ -137,7 +137,7 @@ class TestAstraDbVectorStoreDriver:
     def test_query_allparams(self, driver, mock_collection, one_query_entry):
         entries1 = driver.query("some query", count=999, namespace="some_namespace", include_vectors=True)
         assert entries1 == [one_query_entry]
-        query_vector = driver.embedding_driver.embed_string("some query")
+        query_vector = driver.embedding_driver.embed("some query")
         mock_collection.return_value.find.assert_called_once_with(
             filter={"namespace": "some_namespace"},
             sort={"$vector": query_vector},
@@ -149,7 +149,7 @@ class TestAstraDbVectorStoreDriver:
     def test_query_minparams(self, driver, mock_collection, one_query_entry):
         entries0 = driver.query("some query")
         assert entries0 == [one_query_entry]
-        query_vector = driver.embedding_driver.embed_string("some query")
+        query_vector = driver.embedding_driver.embed("some query")
         mock_collection.return_value.find.assert_called_once_with(
             filter={},
             sort={"$vector": query_vector},

--- a/tests/unit/drivers/vector/test_azure_mongodb_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_azure_mongodb_vector_store_driver.py
@@ -29,13 +29,13 @@ class TestAzureMongoDbVectorStoreDriver:
 
     def test_upsert_text_artifact(self, driver):
         artifact = TextArtifact("foo")
-        test_id = driver.upsert_text_artifact(artifact)
+        test_id = driver.upsert(artifact)
         assert test_id is not None
 
     def test_upsert_text(self, driver):
         text = "foo"
         vector_id_str = "foo"
-        test_id = driver.upsert_text(text, vector_id=vector_id_str)
+        test_id = driver.upsert(text, vector_id=vector_id_str)
         assert test_id == vector_id_str
 
     def test_query_vector(self, driver, monkeypatch):

--- a/tests/unit/drivers/vector/test_base_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_base_vector_store_driver.py
@@ -13,21 +13,21 @@ class TestBaseVectorStoreDriver(ABC):
     def driver(self, *args, **kwargs) -> BaseVectorStoreDriver: ...
 
     def test_upsert(self, driver):
-        namespace = driver.upsert_text_artifact(TextArtifact(id="foo1", value="foobar"))
+        namespace = driver.upsert(TextArtifact(id="foo1", value="foobar"))
 
         assert len(driver.entries) == 1
         assert list(driver.entries.keys())[0] == namespace
 
-        driver.upsert_text_artifact(TextArtifact(id="foo1", value="foobar"))
+        driver.upsert(TextArtifact(id="foo1", value="foobar"))
 
         assert len(driver.entries) == 1
 
-        driver.upsert_text_artifact(TextArtifact(id="foo2", value="foobar2"))
+        driver.upsert(TextArtifact(id="foo2", value="foobar2"))
 
         assert len(driver.entries) == 2
 
     def test_upsert_multiple(self, driver):
-        driver.upsert_text_artifacts({"foo": [TextArtifact("foo")], "bar": [TextArtifact("bar")]})
+        driver.upsert_collection({"foo": [TextArtifact("foo")], "bar": [TextArtifact("bar")]})
 
         foo_entries = driver.load_entries(namespace="foo")
         bar_entries = driver.load_entries(namespace="bar")
@@ -37,7 +37,7 @@ class TestBaseVectorStoreDriver(ABC):
         assert bar_entries[0].to_artifact().value == "bar"
 
     def test_query(self, driver):
-        vector_id = driver.upsert_text_artifact(TextArtifact("foobar"), namespace="test-namespace")
+        vector_id = driver.upsert(TextArtifact("foobar"), namespace="test-namespace")
 
         assert len(driver.query("foobar")) == 1
         assert len(driver.query("foobar", namespace="bad-namespace")) == 0
@@ -48,23 +48,23 @@ class TestBaseVectorStoreDriver(ABC):
         assert driver.query("foobar")[0].id == vector_id
 
     def test_load_entry(self, driver):
-        vector_id = driver.upsert_text_artifact(TextArtifact("foobar"), namespace="test-namespace")
+        vector_id = driver.upsert(TextArtifact("foobar"), namespace="test-namespace")
 
         assert driver.load_entry(vector_id, namespace="test-namespace").id == vector_id
 
     def test_load_entries(self, driver):
-        driver.upsert_text_artifact(TextArtifact("foobar 1"), namespace="test-namespace-1")
-        driver.upsert_text_artifact(TextArtifact("foobar 2"), namespace="test-namespace-1")
-        driver.upsert_text_artifact(TextArtifact("foobar 3"), namespace="test-namespace-2")
+        driver.upsert(TextArtifact("foobar 1"), namespace="test-namespace-1")
+        driver.upsert(TextArtifact("foobar 2"), namespace="test-namespace-1")
+        driver.upsert(TextArtifact("foobar 3"), namespace="test-namespace-2")
 
         assert len(driver.load_entries()) == 3
         assert len(driver.load_entries(namespace="test-namespace-1")) == 2
         assert len(driver.load_entries(namespace="test-namespace-2")) == 1
 
     def test_load_artifacts(self, driver):
-        driver.upsert_text_artifact(TextArtifact("foobar 1"), namespace="test-namespace-1")
-        driver.upsert_text_artifact(TextArtifact("foobar 2"), namespace="test-namespace-1")
-        driver.upsert_text_artifact(TextArtifact("foobar 3"), namespace="test-namespace-2")
+        driver.upsert(TextArtifact("foobar 1"), namespace="test-namespace-1")
+        driver.upsert(TextArtifact("foobar 2"), namespace="test-namespace-1")
+        driver.upsert(TextArtifact("foobar 3"), namespace="test-namespace-2")
 
         assert len(driver.load_artifacts()) == 3
         assert len(driver.load_artifacts(namespace="test-namespace-1")) == 2

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -11,20 +11,20 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
     def driver(self):
         return LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver())
 
-    def test_upsert_text_artifacts_dict(self, driver):
-        driver.upsert_text_artifacts({"foo": [TextArtifact("bar"), TextArtifact("baz")], "bar": [TextArtifact("bar")]})
+    def test_upsert_collection_dict(self, driver):
+        driver.upsert_collection({"foo": [TextArtifact("bar"), TextArtifact("baz")], "bar": [TextArtifact("bar")]})
 
         assert len(driver.load_artifacts(namespace="foo")) == 2
         assert len(driver.load_artifacts(namespace="bar")) == 1
 
-    def test_upsert_text_artifacts_list(self, driver):
-        driver.upsert_text_artifacts([TextArtifact("bar"), TextArtifact("baz")])
+    def test_upsert_collection_list(self, driver):
+        driver.upsert_collection([TextArtifact("bar"), TextArtifact("baz")])
 
         assert len(driver.load_artifacts(namespace="foo")) == 0
         assert len(driver.load_artifacts()) == 2
 
-    def test_upsert_text_artifacts_stress_test(self, driver):
-        driver.upsert_text_artifacts(
+    def test_upsert_collection_stress_test(self, driver):
+        driver.upsert_collection(
             {
                 "test1": [TextArtifact(f"foo-{i}") for i in range(0, 1000)],
                 "test2": [TextArtifact(f"foo-{i}") for i in range(0, 1000)],
@@ -37,7 +37,7 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert len(driver.query("foo", namespace="test3")) == 1000
 
     def test_query_vector(self, driver):
-        driver.upsert_text_artifacts({"foo": [TextArtifact("foo bar")]})
+        driver.upsert_collection({"foo": [TextArtifact("foo bar")]})
 
         result = driver.query_vector([1.0, 1.0], count=1, include_vectors=True)
 
@@ -49,11 +49,11 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert result[0].namespace == "foo"
 
     @pytest.mark.parametrize("execution_number", range(1000))
-    def test_upsert_text_artifacts_meta(self, driver, mocker, execution_number):
+    def test_upsert_collection_meta(self, driver, mocker, execution_number):
         spy = mocker.spy(driver, "upsert_vector")
         artifact_1 = TextArtifact("foo bar", id="foo")
         artifact_2 = TextArtifact("bar foo", id="bar")
 
-        driver.upsert_text_artifacts({"foo": [artifact_1, artifact_2]}, meta={"foo": "bar"})
+        driver.upsert_collection({"foo": [artifact_1, artifact_2]}, meta={"foo": "bar"})
 
         assert spy.call_args_list[0].kwargs["meta"]["artifact"] != spy.call_args_list[1].kwargs["meta"]["artifact"]

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -91,7 +91,7 @@ class TestMarqoVectorStorageDriver:
         )
 
     def test_upsert_text(self, driver, mock_marqo):
-        result = driver.upsert_text("test text", vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d")
+        result = driver.upsert("test text", vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d")
         mock_marqo.index().add_documents.assert_called()
         assert result == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
 
@@ -106,7 +106,7 @@ class TestMarqoVectorStorageDriver:
         }
 
         # Act
-        result = driver.upsert_text_artifact(text)
+        result = driver.upsert(text)
 
         # Check that the return value is as expected
         expected_return_value = {

--- a/tests/unit/drivers/vector/test_mongodb_atlas_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_mongodb_atlas_vector_store_driver.py
@@ -29,13 +29,13 @@ class TestMongoDbAtlasVectorStoreDriver:
 
     def test_upsert_text_artifact(self, driver):
         artifact = TextArtifact("foo")
-        test_id = driver.upsert_text_artifact(artifact)
+        test_id = driver.upsert(artifact)
         assert test_id is not None
 
     def test_upsert_text(self, driver):
         text = "foo"
         vector_id_str = "foo"
-        test_id = driver.upsert_text(text, vector_id=vector_id_str)
+        test_id = driver.upsert(text, vector_id=vector_id_str)
         assert test_id == vector_id_str
 
     def test_query_vector(self, driver, monkeypatch):

--- a/tests/unit/drivers/vector/test_persistent_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_persistent_local_vector_store_driver.py
@@ -24,7 +24,7 @@ class TestPersistentLocalVectorStoreDriver(TestBaseVectorStoreDriver):
     def test_persistence(self, driver, temp_dir):
         persist_file = os.path.join(temp_dir, "store.json")
 
-        driver.upsert_text_artifact(TextArtifact("persistent foobar"))
+        driver.upsert(TextArtifact("persistent foobar"))
 
         new_driver = LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver(), persist_file=persist_file)
 

--- a/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
+++ b/tests/unit/drivers/vector/test_pinecone_vector_storage_driver.py
@@ -38,15 +38,15 @@ class TestPineconeVectorStorageDriver:
     def test_upsert_text_artifact(self, driver):
         artifact = TextArtifact("foo")
 
-        assert driver.upsert_text_artifact(artifact) == driver._get_default_vector_id("foo")
+        assert driver.upsert(artifact) == driver._get_default_vector_id("foo")
 
     def test_upsert_vector(self, driver):
         assert driver.upsert_vector([0, 1, 2], vector_id="foo") == "foo"
         assert isinstance(driver.upsert_vector([0, 1, 2]), str)
 
     def test_upsert_text(self, driver):
-        assert driver.upsert_text("foo", vector_id="foo") == "foo"
-        assert isinstance(driver.upsert_text("foo"), str)
+        assert driver.upsert("foo", vector_id="foo") == "foo"
+        assert isinstance(driver.upsert("foo"), str)
 
     def test_query_vector(self, driver):
         results = driver.query_vector([0.0, 0.5])

--- a/tests/unit/engines/rag/modules/retrieval/test_vector_store_retrieval_rag_module.py
+++ b/tests/unit/engines/rag/modules/retrieval/test_vector_store_retrieval_rag_module.py
@@ -11,10 +11,8 @@ class TestVectorStoreRetrievalRagModule:
         vector_store_driver = LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver())
         module = VectorStoreRetrievalRagModule(vector_store_driver=vector_store_driver)
 
-        vector_store_driver.upsert_text_artifact(
-            TextArtifact("foobar1", reference=Reference(title="boo")), namespace="test"
-        )
-        vector_store_driver.upsert_text_artifact(TextArtifact("foobar2"), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar1", reference=Reference(title="boo")), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar2"), namespace="test")
 
         result = module.run(RagContext(query="test"))
 
@@ -28,8 +26,8 @@ class TestVectorStoreRetrievalRagModule:
             vector_store_driver=vector_store_driver, query_params={"namespace": "test"}
         )
 
-        vector_store_driver.upsert_text_artifact(TextArtifact("foobar1"), namespace="test")
-        vector_store_driver.upsert_text_artifact(TextArtifact("foobar2"), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar1"), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar2"), namespace="test")
 
         result = module.run(RagContext(query="test"))
 
@@ -43,8 +41,8 @@ class TestVectorStoreRetrievalRagModule:
             name="TestModule", vector_store_driver=vector_store_driver, query_params={"namespace": "test"}
         )
 
-        vector_store_driver.upsert_text_artifact(TextArtifact("foobar1"), namespace="test")
-        vector_store_driver.upsert_text_artifact(TextArtifact("foobar2"), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar1"), namespace="test")
+        vector_store_driver.upsert(TextArtifact("foobar2"), namespace="test")
 
         result1 = module.run(
             RagContext(query="test", module_configs={"TestModule": {"query_params": {"namespace": "empty"}}})

--- a/tests/unit/tools/test_vector_store_tool.py
+++ b/tests/unit/tools/test_vector_store_tool.py
@@ -9,7 +9,7 @@ class TestVectorStoreTool:
         driver = LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver())
         tool = VectorStoreTool(description="Test", vector_store_driver=driver)
 
-        driver.upsert_text_artifacts({"test": [TextArtifact("foo"), TextArtifact("bar")]})
+        driver.upsert_collection({"test": [TextArtifact("foo"), TextArtifact("bar")]})
 
         assert {a.value for a in tool.search({"values": {"query": "test"}})} == {"foo", "bar"}
 
@@ -18,7 +18,7 @@ class TestVectorStoreTool:
         tool1 = VectorStoreTool(description="Test", vector_store_driver=driver, query_params={"namespace": "test"})
         tool2 = VectorStoreTool(description="Test", vector_store_driver=driver, query_params={"namespace": "test2"})
 
-        driver.upsert_text_artifacts({"test": [TextArtifact("foo"), TextArtifact("bar")]})
+        driver.upsert_collection({"test": [TextArtifact("foo"), TextArtifact("bar")]})
 
         assert len(tool1.search({"values": {"query": "test"}})) == 2
         assert len(tool2.search({"values": {"query": "test"}})) == 0
@@ -32,6 +32,6 @@ class TestVectorStoreTool:
             query_params={"include_vectors": True},
         )
 
-        driver.upsert_text_artifacts({"test": [TextArtifact("foo"), TextArtifact("bar")]})
+        driver.upsert_collection({"test": [TextArtifact("foo"), TextArtifact("bar")]})
 
         assert tool1.search({"values": {"query": "test"}}).value == [[0, 1], [0, 1]]


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
[This PR](https://github.com/griptape-ai/griptape/pull/1753) deprecated certain calls, but no effort was made to remove the usage of the deprecated calls in the codebase/examples.
## Issue ticket number and link
NA

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--1837.org.readthedocs.build//1837/

<!-- readthedocs-preview griptape end -->