### PR TITLE
build: fix uv lock version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1242,7 +1242,7 @@ wheels = [
 
 [[package]]
 name = "griptape"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Ran `uv lock` to update the version.
## Issue ticket number and link
NA