### PR TITLE
feat: parameterize event types on Stream util

### DIFF
--- a/docs/griptape-framework/misc/events.md
+++ b/docs/griptape-framework/misc/events.md
@@ -125,6 +125,20 @@ Make sure to enable streaming on the Drivers or else `Stream` will yield no iter
     --8<-- "docs/griptape-framework/misc/logs/events_4.txt"
     ```
 
+Sometimes, streaming can be too verbose. You can use `Stream.event_types` to only listen to specific event types. A good example is to remove the `ActionChunkEvent` from the stream if you don't need to see events related to Tool usage.
+
+=== "Code"
+
+    ```python
+    --8<-- "docs/griptape-framework/misc/src/events_4_filtered.py"
+    ```
+
+=== "Logs"
+
+    ```text
+    --8<-- "docs/griptape-framework/misc/logs/events_4_filtered.txt"
+    ```
+
 ## Counting Tokens
 
 To count tokens, you can use Event Listeners and the [TokenCounter](../../reference/griptape/utils/token_counter.md) util:

--- a/docs/griptape-framework/misc/src/events_4_filtered.py
+++ b/docs/griptape-framework/misc/src/events_4_filtered.py
@@ -1,0 +1,25 @@
+import logging
+
+from griptape.configs import Defaults
+from griptape.events import FinishPromptEvent, FinishStructureRunEvent, TextChunkEvent
+from griptape.structures import Agent
+from griptape.tools import PromptSummaryTool, WebScraperTool
+from griptape.utils import Stream
+
+# Hide Griptape's usual output
+logging.getLogger(Defaults.logging_config.logger_name).setLevel(logging.ERROR)
+
+agent = Agent(
+    input="Based on https://griptape.ai, tell me what griptape is.",
+    tools=[
+        PromptSummaryTool(off_prompt=True),
+        WebScraperTool(off_prompt=False),
+    ],
+    stream=True,
+)
+
+# Listen for the following event types
+event_types = [TextChunkEvent, FinishPromptEvent, FinishStructureRunEvent]
+
+for artifact in Stream(agent, event_types=event_types).run():
+    print(artifact.value, end="", flush=True)

--- a/griptape/utils/stream.py
+++ b/griptape/utils/stream.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from attrs import define, field
+from attrs import Factory, define, field
 
 from griptape.artifacts.text_artifact import TextArtifact
 from griptape.events import (
@@ -30,7 +30,7 @@ class Stream:
 
     structure: Structure = field()
     event_types: list[type[BaseEvent]] = field(
-        default=[TextChunkEvent, ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent]
+        default=Factory(lambda: [TextChunkEvent, ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent])
     )
 
     def run(self, *args) -> Iterator[TextArtifact]:

--- a/griptape/utils/stream.py
+++ b/griptape/utils/stream.py
@@ -16,6 +16,7 @@ from griptape.events import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from griptape.events.base_event import BaseEvent
     from griptape.structures import Structure
 
 
@@ -28,13 +29,14 @@ class Stream:
     """
 
     structure: Structure = field()
+    event_types: list[type[BaseEvent]] = field(
+        default=[TextChunkEvent, ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent]
+    )
 
     def run(self, *args) -> Iterator[TextArtifact]:
         action_str = ""
 
-        for event in self.structure.run_stream(
-            *args, event_types=[TextChunkEvent, ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent]
-        ):
+        for event in self.structure.run_stream(*args, event_types=self.event_types):
             if isinstance(event, FinishPromptEvent):
                 yield TextArtifact(value="\n")
             elif isinstance(event, TextChunkEvent):

--- a/tests/unit/utils/test_stream.py
+++ b/tests/unit/utils/test_stream.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from griptape.events import ActionChunkEvent, FinishPromptEvent, FinishStructureRunEvent, TextChunkEvent
 from griptape.structures import Agent
 from griptape.utils import Stream
 from tests.mocks.mock_prompt_driver import MockPromptDriver
@@ -39,5 +40,28 @@ class TestStream:
                 next(chat_stream_run)
         else:
             assert next(chat_stream_run).value == "\n"
+            with pytest.raises(StopIteration):
+                next(chat_stream_run)
+
+    @pytest.mark.parametrize(
+        "event_types",
+        [[TextChunkEvent], [TextChunkEvent, FinishPromptEvent, FinishStructureRunEvent, ActionChunkEvent]],
+    )
+    def test_run(self, event_types):
+        prompt_driver = MockPromptDriver(use_native_tools=True, stream=True)
+        agent = Agent(tools=[MockTool()], prompt_driver=prompt_driver)
+        chat_stream = Stream(agent, event_types=event_types)
+
+        chat_stream_run = chat_stream.run()
+        assert chat_stream.structure == agent
+        assert isinstance(chat_stream_run, Iterator)
+        if len(event_types) == 1:
+            assert next(chat_stream_run).value == "mock output"
+        else:
+            assert next(chat_stream_run).value == "MockTool.mock-tag (test)"
+            assert next(chat_stream_run).value == json.dumps({"values": {"test": "test-value"}}, indent=2)
+            next(chat_stream_run)
+            assert next(chat_stream_run).value == "mock output"
+            next(chat_stream_run)
             with pytest.raises(StopIteration):
                 next(chat_stream_run)


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Add an optional `event_types` parameter to the `Stream` util to control what events get returned

## Issue ticket number and link

