### PR TITLE
fix(tokenizers-simple): set model to None to avoid serialization issues

### DIFF
--- a/griptape/tokenizers/base_tokenizer.py
+++ b/griptape/tokenizers/base_tokenizer.py
@@ -30,7 +30,7 @@ class BaseTokenizer(ABC):
         return self._default_max_output_tokens()
 
     def __attrs_post_init__(self) -> None:
-        if hasattr(self, "model"):
+        if self.model is not None:
             if self.max_input_tokens is None:
                 self.max_input_tokens = self._default_max_input_tokens()
 

--- a/griptape/tokenizers/simple_tokenizer.py
+++ b/griptape/tokenizers/simple_tokenizer.py
@@ -7,7 +7,7 @@ from griptape.tokenizers import BaseTokenizer
 
 @define()
 class SimpleTokenizer(BaseTokenizer):
-    model: str = field(init=False, kw_only=True)
+    model: str | None = field(init=False, default=None, kw_only=True)
     characters_per_token: int = field(kw_only=True)
 
     def count_tokens(self, text: str) -> int:


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Remove `hasattr` magic to avoid downstream serialization issues.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape-nodes/issues/221