### PR TITLE
fix(serialization): add fallback JSON encoder for SerializableMixin

### DIFF
--- a/griptape/mixins/serializable_mixin.py
+++ b/griptape/mixins/serializable_mixin.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 from abc import ABC
 from importlib import import_module
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
+from json import JSONEncoder
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, cast
 
 from attrs import Factory, define, field
 
@@ -13,6 +14,16 @@ if TYPE_CHECKING:
     from marshmallow import Schema
 
 T = TypeVar("T", bound="SerializableMixin")
+
+
+def _default(_self: Any, obj: Any) -> Any:
+    """Fallback method for JSONEncoder to handle custom serialization."""
+    return getattr(obj.__class__, "to_dict", getattr(_default, "default"))(obj)
+
+
+# Adapted from https://stackoverflow.com/questions/18478287/making-object-json-serializable-with-regular-encoder/18561055#18561055
+setattr(_default, "default", JSONEncoder.default)
+setattr(JSONEncoder, "default", _default)
 
 
 @define(slots=False)

--- a/tests/mocks/mock_serializable.py
+++ b/tests/mocks/mock_serializable.py
@@ -25,3 +25,4 @@ class MockSerializable(SerializableMixin):
         default=None, kw_only=True, metadata={"serializable": True}
     )
     model: Optional[BaseModel] = field(default=None, kw_only=True, metadata={"serializable": True})
+    buzz: Optional[dict[str, MockSerializable]] = field(default=None, kw_only=True, metadata={"serializable": True})

--- a/tests/unit/mixins/test_seriliazable_mixin.py
+++ b/tests/unit/mixins/test_seriliazable_mixin.py
@@ -37,8 +37,26 @@ class TestSerializableMixin:
         assert isinstance(TextArtifact.from_json('{"value": "foobar"}'), TextArtifact)
 
     def test_str(self):
-        assert str(MockSerializable()) == json.dumps(
-            {"type": "MockSerializable", "foo": "bar", "bar": None, "baz": None, "nested": None, "model": None}
+        assert str(MockSerializable(buzz={"foo": MockSerializable()})) == json.dumps(
+            {
+                "type": "MockSerializable",
+                "foo": "bar",
+                "bar": None,
+                "baz": None,
+                "nested": None,
+                "model": None,
+                "buzz": {
+                    "foo": {
+                        "type": "MockSerializable",
+                        "foo": "bar",
+                        "bar": None,
+                        "baz": None,
+                        "nested": None,
+                        "model": None,
+                        "buzz": None,
+                    }
+                },
+            }
         )
 
     def test_to_json(self):
@@ -50,6 +68,7 @@ class TestSerializableMixin:
                 "baz": None,
                 "nested": None,
                 "model": {"foo": "bar"},
+                "buzz": None,
             }
         )
 
@@ -61,6 +80,7 @@ class TestSerializableMixin:
             "baz": None,
             "nested": None,
             "model": {"foo": "bar"},
+            "buzz": None,
         }
 
     def test_import_class_rec(self):


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Monkey patches a fallback JSON encoder to use `SerializableMixin` methods.
## Issue ticket number and link
Closes #1868 