### PR TITLE
fix: remove `content` from Message if `content` is an empty array

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -273,7 +273,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
 
                 # Some OpenAi-compatible services don't accept an empty array for content
                 if not openai_message["content"]:
-                    openai_message["content"] = ""
+                    del openai_message["content"]
 
                 openai_messages.append(openai_message)
 

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -385,7 +385,6 @@ class TestOpenAiChatPromptDriverFixtureMixin:
             },
             {"role": "assistant", "content": "assistant-input"},
             {
-                "content": "",
                 "role": "assistant",
                 "tool_calls": [
                     {
@@ -403,7 +402,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 ],
                 "role": "user",
             },
-            {"audio": {"id": "audio-id"}, "content": "", "role": "assistant"},
+            {"audio": {"id": "audio-id"}, "role": "assistant"},
             {"content": [{"type": "text", "text": "assistant-audio-transcription"}], "role": "assistant"},
             {"content": [{"type": "text", "text": "generic-value"}], "role": "user"},
         ]


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Remove `content` param if it is empty, rather than settting it to a blank string. 

## Issue ticket number and link
