### PR TITLE
fix(drivers-vector-store-astradb): pass correct client parameters

### DIFF
--- a/griptape/drivers/vector/astradb_vector_store_driver.py
+++ b/griptape/drivers/vector/astradb_vector_store_driver.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from attrs import define, field
 
 from griptape.drivers.vector import BaseVectorStoreDriver
-from griptape.utils import import_optional_dependency
 from griptape.utils.decorators import lazy_property
+from griptape.utils.import_utils import import_optional_dependency
 
 if TYPE_CHECKING:
     import astrapy
@@ -49,9 +49,11 @@ class AstraDbVectorStoreDriver(BaseVectorStoreDriver):
 
     @lazy_property()
     def client(self) -> astrapy.DataAPIClient:
-        return import_optional_dependency("astrapy").DataAPIClient(
-            caller_name=self.caller_name,
-            environment=self.environment,
+        astrapy = import_optional_dependency("astrapy")
+
+        return astrapy.DataAPIClient(
+            callers=[(self.caller_name, None)],
+            environment=self.environment or astrapy.utils.unset.UnsetType(),
         )
 
     @lazy_property()


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Pass correct parameters after updating to astrapy@2.
## Issue ticket number and link
Integration tests:
```
python_file = 'docs/recipes/src/query_webpage_astra_db_1.py'

    @pytest.mark.parametrize("python_file", discover_python_files("docs"))
    def test_python_file_execution(python_file):
        """Run each Python file using Poetry. If it executes successfully, copy the logs to /tmp/logs."""
        result = subprocess.run(
            ["uv", "run", "python", python_file],
            capture_output=True,
            text=True,
            input="Hi\nexit\n",
            check=False,
        )
    
>       assert result.returncode == 0
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['uv', 'run', 'python', 'docs/recipes/src/query_webpage_astra_db_1.py'], returncode=1, stdout=''...onal_dependency("astrapy").DataAPIClient(\nTypeError: __init__() got an unexpected keyword argument \'caller_name\'\n').returncode

tests/integration/test_code_blocks.py:54: AssertionError
_ test_python_file_execution[docs/***-framework/drivers/src/***_store_drivers_11.py] _
[gw0] linux -- Python 3.9.22 /home/runner/work/***/***/.venv/bin/python

python_file = 'docs/***-framework/drivers/src/***_store_drivers_11.py'

    @pytest.mark.parametrize("python_file", discover_python_files("docs"))
    def test_python_file_execution(python_file):
        """Run each Python file using Poetry. If it executes successfully, copy the logs to /tmp/logs."""
        result = subprocess.run(
            ["uv", "run", "python", python_file],
            capture_output=True,
            text=True,
            input="Hi\nexit\n",
            check=False,
        )
    
>       assert result.returncode == 0
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['uv', 'run', 'python', 'docs/***-framework/drivers/src/***_store_drivers_11.py'], retur...onal_dependency("astrapy").DataAPIClient(\nTypeError: __init__() got an unexpected keyword argument \'caller_name\'\n').returncode
```