### PR TITLE
fix(drivers-prompt-openai): don't include user if not set

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -178,7 +178,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
     def _base_params(self, prompt_stack: PromptStack) -> dict:
         params = {
             "model": self.model,
-            "user": self.user,
+            **({"user": self.user} if self.user else {}),
             "seed": self.seed,
             **({"modalities": self.modalities} if self.modalities and not self.is_reasoning_model else {}),
             **(


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
some openai-compatible services do not like empty inputs

## Issue ticket number and link
