### PR TITLE
fix: add type annotation to kwargs to fix docs build

### DIFF
--- a/griptape/artifacts/url_artifact.py
+++ b/griptape/artifacts/url_artifact.py
@@ -16,7 +16,7 @@ class UrlArtifact(BaseArtifact):
 
     value: str = field(metadata={"serializable": True})
 
-    def to_bytes(self, *, headers: dict | None = None, **kwargs) -> bytes:
+    def to_bytes(self, *, headers: dict | None = None, **kwargs: dict) -> bytes:
         """Fetches the content of the URL and returns it as bytes.
 
         Args:


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Fixes this:
```
WARNING -  griffe: griptape/artifacts/url_artifact.py:24: No type or annotation for parameter '**kwargs'
```
## Issue ticket number and link
https://app.readthedocs.org/projects/griptape/builds/27998669/