### PR TITLE
fix: remove inapplicable `errors` reference from `import_optional_dep…

### DIFF
--- a/griptape/utils/import_utils.py
+++ b/griptape/utils/import_utils.py
@@ -24,7 +24,6 @@ def import_optional_dependency(name: str) -> ModuleType:
 
     Returns:
         The imported module, when found.
-        None is returned when the package is not found and `errors` is False.
     """
     package_name = INSTALL_MAPPING.get(name)
     install_name = package_name if package_name is not None else name


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

Removed incorrect reference to an unused `errors` parameter in the `import_optional_dependency` docstring.

Fixes [#1929](https://github.com/griptape-ai/griptape/issues/1929)