### PR TITLE
Always upsert vectors in BaseVectorStoreDriver

### DIFF
--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -148,8 +148,6 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
             value = artifact.to_text() if artifact.reference is None else artifact.to_text() + str(artifact.reference)
             vector_id = self._get_default_vector_id(value)
 
-        if self.does_entry_exist(vector_id, namespace=namespace):
-            return vector_id
         meta = {**meta, "artifact": artifact.to_json()}
 
         vector = self.embedding_driver.embed(artifact, vector_operation="upsert")


### PR DESCRIPTION
- [X] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
The check for an existing vector at the specified ID is unexpected from a function named `upsert`. With this change, the vector will always be upserted, independent of an existing vector.

## Issue ticket number and link
