### PR TITLE
fix(drivers-prompt-google): correctly handle debug logs

### DIFF
--- a/griptape/configs/logging/json_formatter.py
+++ b/griptape/configs/logging/json_formatter.py
@@ -15,5 +15,7 @@ class JsonFormatter(logging.Formatter):
     def format(self, record: Any) -> str:
         if isinstance(record.msg, dict):
             record.msg = json.dumps(record.msg, indent=self.indent)
+        elif isinstance(record.msg, (list, tuple)):
+            record.msg = json.dumps(list(record.msg), indent=self.indent)
 
         return super().format(record)

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -90,9 +90,9 @@ class GooglePromptDriver(BasePromptDriver):
     def try_run(self, prompt_stack: PromptStack) -> Message:
         messages = self.__to_google_messages(prompt_stack)
         params = self._base_params(prompt_stack)
-        logging.debug((messages, params))
+        logger.debug((messages, params["generation_config"].__dict__))
         response: GenerateContentResponse = self.client.generate_content(messages, **params)
-        logging.debug(response.to_dict())
+        logger.debug(response.to_dict())
 
         usage_metadata = response.usage_metadata
 
@@ -109,7 +109,7 @@ class GooglePromptDriver(BasePromptDriver):
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
         messages = self.__to_google_messages(prompt_stack)
         params = {**self._base_params(prompt_stack), "stream": True}
-        logging.debug((messages, params))
+        logger.debug((messages, params))
         response: GenerateContentResponse = self.client.generate_content(
             messages,
             **params,


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Use `logger.debug` vs `logging.debug` so that the correct handlers work. Update `JsonFormatter` to handle this.
## Issue ticket number and link
https://discord.com/channels/1096466116672487547/1378833098778738850/1378833098778738850