### PR TITLE
feat: Support gpt-image-1 in GriptapeCloudImageGenerationDriver

### DIFF
--- a/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
+++ b/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
@@ -16,7 +16,7 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
     """Driver for the OpenAI image generation API.
 
     Attributes:
-        model: Image generation model, 'gpt-image-1' or 'dall-e-3'. Defaults to 'gpt-image-1'.
+        model: Image generation model, 'gpt-image-1' or 'dall-e-3'. Defaults to 'dall-e-3'.
         base_url: Griptape Cloud API URL.
         api_key: Griptape Cloud API Key.
         headers: Headers for Griptape Cloud request. Overwrites api_key.
@@ -31,7 +31,7 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
         output_format: Optional and only supported for gpt-image-1. Can be either 'png' or 'jpeg'.
     """
 
-    model: str = field(default="gpt-image-1", kw_only=True, metadata={"serializable": True})
+    model: str = field(default="dall-e-3", kw_only=True, metadata={"serializable": True})
     base_url: str = field(
         default=Factory(lambda: os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")),
     )

--- a/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
+++ b/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
@@ -4,7 +4,7 @@ import os
 from typing import Literal, Optional
 
 import requests
-from attrs import Factory, define, field
+from attrs import Factory, define, field, fields_dict
 
 from griptape.artifacts import ImageArtifact
 from griptape.drivers.image_generation import BaseImageGenerationDriver
@@ -13,7 +13,25 @@ from griptape.utils.griptape_cloud import griptape_cloud_url
 
 @define
 class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
-    model: Optional[str] = field(default=None, kw_only=True)
+    """Driver for the OpenAI image generation API.
+
+    Attributes:
+        model: Image generation model, 'gpt-image-1' or 'dall-e-3'.
+        base_url: Griptape Cloud API URL.
+        api_key: Griptape Cloud API key.
+        headers: Headers for Griptape Cloud request. Overwrites api_key.
+        style: Optional and only supported for dall-e-3, can be either 'vivid' or 'natural'.
+        quality: Optional and only supported for dall-e-3. Accepts 'standard', 'hd'.
+        image_size: Size of the generated image. Must be one of the following, depending on the requested model:
+            dall-e-3: [1024x1024, 1024x1792, 1792x1024]
+            gpt-image-1: [1024x1024, 1536x1024, 1024x1536, auto]
+        background: Optional and only supported for gpt-image-1. Can be either 'transparent', 'opaque', or 'auto'.
+        moderation: Optional and only supported for gpt-image-1. Can be either 'low' or 'auto'.
+        output_compression: Optional and only supported for gpt-image-1. Can be an integer between 0 and 100.
+        output_format: Optional and only supported for gpt-image-1. Can be either 'png' or 'jpeg'.
+    """
+
+    model: str = field(default="gpt-image-1", kw_only=True, metadata={"serializable": True})
     base_url: str = field(
         default=Factory(lambda: os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")),
     )
@@ -21,11 +39,60 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
     headers: dict = field(
         default=Factory(lambda self: {"Authorization": f"Bearer {self.api_key}"}, takes_self=True), kw_only=True
     )
-    style: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
-    quality: Literal["standard", "hd"] = field(default="standard", kw_only=True, metadata={"serializable": True})
-    image_size: Literal["1024x1024", "1024x1792", "1792x1024"] = field(
-        default="1024x1024", kw_only=True, metadata={"serializable": True}
+    style: Optional[Literal["vivid", "natural"]] = field(
+        default=None, kw_only=True, metadata={"serializable": True, "model_allowlist": ["dall-e-3"]}
     )
+    quality: Optional[Literal["standard", "hd", "low", "medium", "high", "auto"]] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True, "model_allowlist": ["dall-e-3"]},
+    )
+    image_size: Optional[Literal["1024x1024", "1536x1024", "1024x1536", "1024x1792", "1792x1024", "auto"]] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True},
+    )
+    background: Optional[Literal["transparent", "opaque", "auto"]] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True, "model_allowlist": ["gpt-image-1"]},
+    )
+    moderation: Optional[Literal["low", "auto"]] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True, "model_allowlist": ["gpt-image-1"]},
+    )
+    output_compression: Optional[int] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True, "model_allowlist": ["gpt-image-1"]},
+    )
+    output_format: Optional[Literal["png", "jpeg"]] = field(
+        default=None,
+        kw_only=True,
+        metadata={"serializable": True, "model_allowlist": ["gpt-image-1"]},
+    )
+
+    @image_size.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
+    def validate_image_size(self, attribute: str, value: str | None) -> None:
+        """Validates the image size based on the model.
+
+        Must be one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or `auto` (default value) for
+        `gpt-image-1`or one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3`.
+
+        """
+        if value is None:
+            return
+
+        if self.model.startswith("gpt-image"):
+            allowed_sizes = ("1024x1024", "1536x1024", "1024x1536", "auto")
+        elif self.model == "dall-e-3":
+            allowed_sizes = ("1024x1024", "1792x1024", "1024x1792")
+        else:
+            raise NotImplementedError(f"Image size validation not implemented for model {self.model}")
+
+        if value is not None and value not in allowed_sizes:
+            raise ValueError(f"Image size, {value}, must be one of the following: {allowed_sizes}")
 
     def try_text_to_image(self, prompts: list[str], negative_prompts: Optional[list[str]] = None) -> ImageArtifact:
         url = griptape_cloud_url(self.base_url, "api/images/generations")
@@ -35,18 +102,37 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
             headers=self.headers,
             json={
                 "prompts": prompts,
-                "driver_configuration": {
-                    "model": self.model,
-                    "image_size": self.image_size,
-                    "quality": self.quality,
-                    "style": self.style,
-                },
+                "driver_configuration": self._build_model_params(),
             },
         )
         response.raise_for_status()
         response = response.json()
 
         return ImageArtifact.from_dict(response["artifact"])
+
+    def _build_model_params(self) -> dict:
+        """Builds parameters while considering field metadata and None values.
+
+        Field will be added to the params dictionary if all conditions are met:
+            - The field value is not None
+            - The model_allowlist is None or the model is in the allowlist
+        """
+        values = ["image_size", "quality", "style", "background", "moderation", "output_compression", "output_format"]
+
+        params = {}
+        fields = fields_dict(self.__class__)
+
+        for value in values:
+            metadata = fields[value].metadata
+            model_allowlist = metadata.get("model_allowlist")
+
+            field_value = getattr(self, value, None)
+
+            allowlist_condition = model_allowlist is None or self.model in model_allowlist
+
+            if field_value is not None and allowlist_condition:
+                params[value] = field_value
+        return params
 
     def try_image_variation(
         self,

--- a/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
+++ b/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
@@ -117,7 +117,7 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
             - The field value is not None
             - The model_allowlist is None or the model is in the allowlist
         """
-        values = ["image_size", "quality", "style", "background", "moderation", "output_compression", "output_format"]
+        values = ["model", "image_size", "quality", "style", "background", "moderation", "output_compression", "output_format"]
 
         params = {}
         fields = fields_dict(self.__class__)

--- a/tests/unit/drivers/image_generation/test_griptape_cloud_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_griptape_cloud_image_generation_driver.py
@@ -74,19 +74,19 @@ class TestGriptapeCloudImageGenerationDriver:
 
     def test_dall_e_3_driver_background(self):
         driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", background="transparent")
-        assert "background" not in driver._build_model_params()
+        assert "background" not in driver._build_driver_configuration()
 
     def test_dall_e_3_driver_moderation(self):
         driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", moderation="low")
-        assert "moderation" not in driver._build_model_params()
+        assert "moderation" not in driver._build_driver_configuration()
 
     def test_dall_e_3_driver_output_compression(self):
         driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", output_compression=0)
-        assert "output_compression" not in driver._build_model_params()
+        assert "output_compression" not in driver._build_driver_configuration()
 
     def test_dall_e_3_driver_output_format(self):
         driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", output_format="png")
-        assert "output_format" not in driver._build_model_params()
+        assert "output_format" not in driver._build_driver_configuration()
 
     def test_dall_e_3_driver_landscape(self):
         with pytest.raises(ValueError):
@@ -98,11 +98,11 @@ class TestGriptapeCloudImageGenerationDriver:
 
     def test_gpt_image_1_driver_style(self):
         driver = GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", style="vivid")
-        assert "style" not in driver._build_model_params()
+        assert "style" not in driver._build_driver_configuration()
 
     def test_gpt_image_1_driver_quality(self):
         driver = GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", quality="hd")
-        assert "quality" not in driver._build_model_params()
+        assert "quality" not in driver._build_driver_configuration()
 
     def test_gpt_image_1_driver_landscape(self):
         with pytest.raises(ValueError):

--- a/tests/unit/drivers/image_generation/test_griptape_cloud_image_generation_driver.py
+++ b/tests/unit/drivers/image_generation/test_griptape_cloud_image_generation_driver.py
@@ -14,11 +14,11 @@ class TestGriptapeCloudImageGenerationDriver:
                 mock_response.json.return_value = {
                     "artifact": {
                         "type": "ImageArtifact",
-                        "width": 512,
-                        "height": 512,
+                        "width": 1024,
+                        "height": 1024,
                         "format": "png",
                         "value": "aW1hZ2UgZGF0YQ==",
-                        "meta": {"model": "dall-e-2", "prompt": "test prompt"},
+                        "meta": {"model": "dall-e-3", "prompt": "test prompt"},
                     },
                 }
                 return mock_response
@@ -30,20 +30,87 @@ class TestGriptapeCloudImageGenerationDriver:
 
     @pytest.fixture()
     def driver(self):
-        return GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", quality="hd")
+        return GriptapeCloudImageGenerationDriver(api_key="foo")
 
-    def test_init(self, driver):
-        assert driver
+    @pytest.fixture()
+    def dall_e_3_driver(self):
+        return GriptapeCloudImageGenerationDriver(
+            model="dall-e-3", api_key="foo", style="vivid", quality="hd", image_size="1024x1024"
+        )
 
-    def test_try_text_to_image(self, driver):
-        image_artifact = driver.try_text_to_image(prompts=["test prompt"])
+    @pytest.fixture()
+    def gpt_image_1_driver(self):
+        return GriptapeCloudImageGenerationDriver(
+            model="gpt-image-1",
+            api_key="foo",
+            background="transparent",
+            moderation="low",
+            output_compression=0,
+            output_format="png",
+            image_size="1024x1024",
+        )
+
+    def test_init(self, dall_e_3_driver, gpt_image_1_driver):
+        assert dall_e_3_driver
+        assert gpt_image_1_driver
+
+    def test_try_text_to_image_dall_e_3(self, dall_e_3_driver):
+        image_artifact = dall_e_3_driver.try_text_to_image(prompts=["test prompt"])
 
         assert image_artifact.value == b"image data"
         assert image_artifact.mime_type == "image/png"
-        assert image_artifact.width == 512
-        assert image_artifact.height == 512
-        assert image_artifact.meta["model"] == "dall-e-2"
+        assert image_artifact.width == 1024
+        assert image_artifact.height == 1024
         assert image_artifact.meta["prompt"] == "test prompt"
+
+    def test_try_text_to_image_gpt_image_1(self, gpt_image_1_driver):
+        image_artifact = gpt_image_1_driver.try_text_to_image(prompts=["test prompt"])
+
+        assert image_artifact.value == b"image data"
+        assert image_artifact.mime_type == "image/png"
+        assert image_artifact.width == 1024
+        assert image_artifact.height == 1024
+        assert image_artifact.meta["prompt"] == "test prompt"
+
+    def test_dall_e_3_driver_background(self):
+        driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", background="transparent")
+        assert "background" not in driver._build_model_params()
+
+    def test_dall_e_3_driver_moderation(self):
+        driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", moderation="low")
+        assert "moderation" not in driver._build_model_params()
+
+    def test_dall_e_3_driver_output_compression(self):
+        driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", output_compression=0)
+        assert "output_compression" not in driver._build_model_params()
+
+    def test_dall_e_3_driver_output_format(self):
+        driver = GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", output_format="png")
+        assert "output_format" not in driver._build_model_params()
+
+    def test_dall_e_3_driver_landscape(self):
+        with pytest.raises(ValueError):
+            GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", image_size="1536x1024")
+
+    def test_dall_e_3_driver_portrait(self):
+        with pytest.raises(ValueError):
+            GriptapeCloudImageGenerationDriver(model="dall-e-3", api_key="foo", image_size="1024x1536")
+
+    def test_gpt_image_1_driver_style(self):
+        driver = GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", style="vivid")
+        assert "style" not in driver._build_model_params()
+
+    def test_gpt_image_1_driver_quality(self):
+        driver = GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", quality="hd")
+        assert "quality" not in driver._build_model_params()
+
+    def test_gpt_image_1_driver_landscape(self):
+        with pytest.raises(ValueError):
+            GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", image_size="1792x1024")
+
+    def test_gpt_image_1_driver_portrait(self):
+        with pytest.raises(ValueError):
+            GriptapeCloudImageGenerationDriver(model="gpt-image-1", api_key="foo", image_size="1024x1792")
 
     def test_try_image_variation(self, driver):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
- [X] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Support different models in GTCImageGenDriver in a similar pattern to [OpenAiImageGenDriver](https://github.com/griptape-ai/griptape/blob/main/griptape/drivers/image_generation/openai_image_generation_driver.py#L19). Now supports calls to dall-e-3 and gpt-image-1, with default behavior not changing

## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/1960
