### PR TITLE
Handle embedded text with commas for PGAI Vector Store Driver

### DIFF
--- a/griptape/drivers/vector/pgai_knowledge_base_vector_store_driver.py
+++ b/griptape/drivers/vector/pgai_knowledge_base_vector_store_driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import logging
 from typing import TYPE_CHECKING, NoReturn, Optional
 
@@ -52,14 +53,15 @@ class PgAiKnowledgeBaseVectorStoreDriver(BaseVectorStoreDriver):
 
         entries = []
         for (row,) in rows:
-            # Remove the first and last parentheses from the row and list by commas
-            # Example: '(foo,bar)' -> ['foo', 'bar']
-            row_list = "".join(row.replace("(", "", 1).rsplit(")", 1)).split(",")
+            # Split ID and score from text, accounting for commas in the text itself
+            striped_row = row.strip("()")
+            id, text_and_score = striped_row.split(",", 1)
+            text, score = text_and_score.rsplit(",", 1)
             entries.append(
                 BaseVectorStoreDriver.Entry(
-                    id=row_list[0],
-                    score=float(row_list[2]),
-                    meta={"artifact": TextArtifact(row_list[1]).to_json()},
+                    id=id,
+                    score=float(score),
+                    meta={"artifact": TextArtifact(text).to_json()},
                 )
             )
 

--- a/tests/unit/drivers/vector/test_pgai_knowledge_base_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_pgai_knowledge_base_vector_store_driver.py
@@ -30,7 +30,7 @@ class TestPgAiKnowledgeBaseVectorStoreDriver:
 
     def test_query(self, mock_engine, mock_session):
         test_ids = [17, 23]
-        test_values = ['"foo"', "bar"]
+        test_values = ['"foo"', "bar, baz"]
         test_scores = [0.4, 0.6]
         mock_query = MagicMock()
         mock_query.all.return_value = [


### PR DESCRIPTION
- [X] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Split aidb.retrieve_text's response in a safe manner, respecting complex text values with commas. 

## Issue ticket number and link
https://github.com/griptape-ai/griptape/issues/1966