### PR TITLE
Remove dependency on active event_loop in MCP tool initialization

### DIFF
--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -85,7 +85,7 @@ class MCPTool(BaseTool):
     connection: Connection = field(kw_only=True)
 
     def __attrs_post_init__(self) -> None:
-        asyncio.get_event_loop().run_until_complete(self._init_activities())
+        asyncio.run(self._init_activities())
 
     async def _init_activities(self) -> None:
         async with self._get_session() as session:


### PR DESCRIPTION
- [X] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
With the updated Griptape Nodes session logic, a bug was identified in past logic. If an event loop was not available, the initialization would fail.

## Issue ticket number and link
