### PR TITLE
add max_subtasks to agent

### DIFF
--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -31,6 +31,7 @@ class Agent(Structure):
     output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
+    max_subtasks: Optional[int] = field(default=20, kw_only=True)
     fail_fast: bool = field(default=False, kw_only=True)
     _tasks: list[Union[BaseTask, list[BaseTask]]] = field(
         factory=list, kw_only=True, alias="tasks", metadata={"serializable": True}
@@ -107,6 +108,7 @@ class Agent(Structure):
             tools=self.tools,
             output_schema=self.output_schema,
             max_meta_memory_entries=self.max_meta_memory_entries,
+            max_subtasks=self.max_subtasks,
         )
 
         self.add_task(task)


### PR DESCRIPTION
- ☑️ I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

adds a max_subtasks parameter to agents, allowing for override of  max_subtasks on prompttasks created by the agent. helpful for using MCP servers as tools with complex tasks

## Issue ticket number and link
