### PR TITLE
Image variation in the GTC Image Generation Driver

### DIFF
--- a/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
+++ b/griptape/drivers/image_generation/griptape_cloud_image_generation_driver.py
@@ -149,7 +149,24 @@ class GriptapeCloudImageGenerationDriver(BaseImageGenerationDriver):
         image: ImageArtifact,
         negative_prompts: Optional[list[str]] = None,
     ) -> ImageArtifact:
-        raise NotImplementedError(f"{self.__class__.__name__} does not support image variation")
+        if self.model != "gpt-image-1":
+            raise ValueError(f"Image variation is only supported with gpt-image-1 model, but {self.model} was provided")
+
+        url = griptape_cloud_url(self.base_url, "api/images/variations")
+
+        response = requests.post(
+            url,
+            headers=self.headers,
+            json={
+                "prompts": prompts,
+                "image_base64": image.base64,
+                "driver_configuration": self._build_driver_configuration(),
+            },
+        )
+        response.raise_for_status()
+        response = response.json()
+
+        return ImageArtifact.from_dict(response["artifact"])
 
     def try_image_inpainting(
         self,


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
The Griptape Cloud API now supports image variation! This change updates the Griptape Cloud Image Generation Driver to support image variation using the new API endpoint.

## Issue ticket number and link
#1991