### PR TITLE
update: GriptapeCloudPromptDriver model serialization

### DIFF
--- a/griptape/drivers/prompt/griptape_cloud_prompt_driver.py
+++ b/griptape/drivers/prompt/griptape_cloud_prompt_driver.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(Defaults.logging_config.logger_name)
 
 @define
 class GriptapeCloudPromptDriver(BasePromptDriver):
-    model: Optional[str] = field(default=None, kw_only=True)
+    model: Optional[str] = field(default=None, kw_only=True, metadata={"serializable": True})
     base_url: str = field(
         default=Factory(lambda: os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")),
     )


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Just made sure the model was serialized for `GriptapeCloudPromptDriver`, like how `BasePromptDriver` has it defined. Seems like it was an oversight.

## Issue ticket number and link
https://github.com/griptape-ai/griptape-nodes/issues/2399
