### PR TITLE
feat: add VideoUrlArtifact to artifacts module

### DIFF
--- a/griptape/artifacts/__init__.py
+++ b/griptape/artifacts/__init__.py
@@ -11,6 +11,7 @@ from .image_artifact import ImageArtifact
 from .image_url_artifact import ImageUrlArtifact
 from .audio_artifact import AudioArtifact
 from .audio_url_artifact import AudioUrlArtifact
+from .video_url_artifact import VideoUrlArtifact
 from .action_artifact import ActionArtifact
 from .generic_artifact import GenericArtifact
 from .model_artifact import ModelArtifact
@@ -32,4 +33,5 @@ __all__ = [
     "ListArtifact",
     "ModelArtifact",
     "TextArtifact",
+    "VideoUrlArtifact",
 ]

--- a/griptape/artifacts/video_url_artifact.py
+++ b/griptape/artifacts/video_url_artifact.py
@@ -1,0 +1,9 @@
+from griptape.artifacts.url_artifact import UrlArtifact
+
+
+class VideoUrlArtifact(UrlArtifact):
+    """Stores a url to a video.
+
+    Attributes:
+        value: The url.
+    """


### PR DESCRIPTION
Included VideoUrlArtifact in the artifacts module and updated the __all__ list accordingly.

- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

adds a VideoUrlArtifact type for use in Griptape Nodes

## Issue ticket number and link
