### PR TITLE
fix: resolve python version ambiguity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "griptape"
 version = "1.8.2"
 description = "Modular Python framework for LLM workflows, tools, memory, and data."
 authors = [{ name = "Griptape", email = "hello@griptape.ai" }]
-requires-python = "~=3.9"
+requires-python = ">=3.9, <4"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
@@ -60,9 +60,7 @@ drivers-vector-pgvector = [
 ]
 drivers-vector-qdrant = ["qdrant-client>=1.10.1"]
 drivers-vector-astra-db = ["astrapy>=2.0"]
-drivers-vector-pgai = [
-  "sqlalchemy>=2.0.31"
-]
+drivers-vector-pgai = ["sqlalchemy>=2.0.31"]
 drivers-embedding-amazon-bedrock = ["boto3>=1.34.119"]
 drivers-embedding-amazon-sagemaker = ["boto3>=1.34.119"]
 drivers-embedding-huggingface = [


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
From uv:
```
warning: The `requires-python` specifier (`~=3.9`) in `griptape` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.9, <4`. Did you mean `~=3.9.0` to constrain the version as `>=3.9.0, <3.10`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
```
## Issue ticket number and link
NA