### PR TITLE
fix: export mcp tool from griptape.tools package

### DIFF
--- a/griptape/tools/__init__.py
+++ b/griptape/tools/__init__.py
@@ -24,6 +24,7 @@ from .extraction.tool import ExtractionTool
 from .prompt_summary.tool import PromptSummaryTool
 from .query.tool import QueryTool
 from .structured_output.tool import StructuredOutputTool
+from .mcp.tool import MCPTool
 
 __all__ = [
     "AudioTranscriptionTool",
@@ -52,4 +53,5 @@ __all__ = [
     "VectorStoreTool",
     "WebScraperTool",
     "WebSearchTool",
+    "MCPTool",
 ]

--- a/griptape/tools/mcp/sessions.py
+++ b/griptape/tools/mcp/sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, Union
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -121,7 +121,7 @@ class WebsocketConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession"""
 
 
-Connection = StdioConnection | SSEConnection | StreamableHttpConnection | WebsocketConnection  # type: ignore[reportGeneralTypeIssues]
+Connection = Union[StdioConnection, SSEConnection, StreamableHttpConnection, WebsocketConnection]
 
 
 @asynccontextmanager


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Exports `MCPTool` from `griptape.tools`.
## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/2002