### PR TITLE
fix: preserve array item types when converting mcp schema

### DIFF
--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -30,6 +30,44 @@ if TYPE_CHECKING:
 ANY_TYPE = Or(str, int, float, bool, list, dict)
 
 
+def add_items_to_bare_arrays(schema: dict) -> dict:
+    """Recursively add default items to bare array types in JSON schema.
+
+    This function works around a limitation in the schema library: when converting
+    Python types like Or(str, list[str], dict) to JSON schema, the library loses
+    the items type information and outputs bare {"type": "array"} without items.
+
+    OpenAI requires all array types to have an items property, so this post-processing
+    step ensures any bare arrays get a permissive {"items": {}} schema (accepts anything).
+
+    This approach handles:
+    - MCP servers that provide bare arrays in anyOf (e.g., Maya MCP)
+    - Schema library conversion issues with generic types inside Or()
+    - Any other source of bare arrays in the schema
+
+    Args:
+        schema: JSON schema dictionary
+
+    Returns:
+        Modified schema with items added to bare arrays
+    """
+    if isinstance(schema, dict):
+        # If this is an array type without items, add default items
+        if schema.get("type") == "array" and "items" not in schema:
+            schema["items"] = {}  # Empty items = accept any items
+
+        # Recursively process all nested schemas
+        for _key, value in schema.items():
+            if isinstance(value, dict):
+                add_items_to_bare_arrays(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        add_items_to_bare_arrays(item)
+
+    return schema
+
+
 def json_to_python_type(json_type: str) -> type:
     conversion_map = {
         "string": str,
@@ -41,6 +79,29 @@ def json_to_python_type(json_type: str) -> type:
         "null": type(None),
     }
     return conversion_map[json_type]
+
+
+def process_anyof_types(any_of_items: list) -> Or:
+    """Process anyOf array from JSON schema and convert to Python Or type.
+
+    Args:
+        any_of_items: List of type definitions from anyOf
+
+    Returns:
+        Or schema with all the types
+    """
+    any_of_types = set()
+    for item in any_of_items:
+        if "type" in item:
+            if item["type"] == "array":
+                # Default to string items if not specified
+                item_type = item.get("items", {}).get("type", "string")
+                any_of_types.add(list[json_to_python_type(item_type)])
+            elif item["type"] == "object":
+                any_of_types.add(dict)
+            else:
+                any_of_types.add(json_to_python_type(item["type"]))
+    return Or(*any_of_types) if any_of_types else ANY_TYPE
 
 
 def get_json_schema_value(original_schema: dict) -> dict:
@@ -65,11 +126,11 @@ def get_json_schema_value(original_schema: dict) -> dict:
             else:
                 schema_value = json_to_python_type(property_value["type"])
         elif "anyOf" in property_value:
-            any_of_types = set()
-            for item in property_value["anyOf"]:
-                if "type" in item:
-                    any_of_types.add(json_to_python_type(item["type"]))
-                    schema_value = Or(*any_of_types)
+            # Process anyOf types from MCP schema
+            # We try to preserve type information (e.g., list[str] for arrays with items)
+            # even though the schema library will lose it during JSON schema conversion.
+            # The add_items_to_bare_arrays post-processing will fix any bare arrays.
+            schema_value = process_anyof_types(property_value["anyOf"])
         json_schema_value[schema_key] = schema_value
     return json_schema_value
 
@@ -105,6 +166,19 @@ class MCPTool(BaseTool):
 
     def _get_session(self) -> _AsyncGeneratorContextManager[ClientSession, None]:
         return create_session(self.connection)
+
+    def to_activity_json_schema(self, activity: Callable, schema_id: str) -> dict:
+        """Override to post-process JSON schema and add items to bare arrays.
+
+        The schema library loses type information when converting Python types to JSON schema,
+        particularly for generic types like list[str] inside Or(). This results in bare arrays
+        without items, which OpenAI's API rejects with "array schema missing items" errors.
+
+        This override adds post-processing to fix bare arrays after the schema library conversion,
+        ensuring compatibility with OpenAI and other LLM providers that require valid JSON schemas.
+        """
+        json_schema = super().to_activity_json_schema(activity, schema_id)
+        return add_items_to_bare_arrays(json_schema)
 
     def _create_activity_handler(self, tool: types.Tool) -> Callable:
         """Creates an activity handler method for the MCP tool."""

--- a/tests/unit/tools/test_mcp_tool.py
+++ b/tests/unit/tools/test_mcp_tool.py
@@ -1,0 +1,140 @@
+from schema import Or
+
+from griptape.tools.mcp.tool import get_json_schema_value
+
+
+class TestMCPTool:
+    def test_get_json_schema_value_anyof_with_array(self):
+        """Test that anyOf with array types properly preserves items type."""
+        # This simulates the schema from Maya MCP's mesh_operations tool
+        original_schema = {
+            "properties": {
+                "select_components": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "string"},
+                    ],
+                    "description": "Component selection",
+                }
+            },
+            "required": [],
+        }
+
+        result = get_json_schema_value(original_schema)
+
+        # Verify the schema key exists (it's an Optional since not in required)
+        assert len(result) == 1
+        schema_key = list(result.keys())[0]
+        # schema_key is an Optional, and Optional.schema is a Literal
+        assert schema_key.schema.schema == "select_components"
+        assert schema_key.schema._description == "Component selection"
+
+        # Verify the schema value is an Or with proper types
+        schema_value = result[schema_key]
+        assert isinstance(schema_value, Or)
+        # The Or should contain list[str] and str
+        assert list[str] in schema_value._args
+        assert str in schema_value._args
+
+    def test_get_json_schema_value_anyof_with_multiple_array_types(self):
+        """Test that anyOf with different array item types works correctly."""
+        original_schema = {
+            "properties": {
+                "values": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "array", "items": {"type": "integer"}},
+                        {"type": "string"},
+                    ]
+                }
+            }
+        }
+
+        result = get_json_schema_value(original_schema)
+
+        schema_key = list(result.keys())[0]
+        schema_value = result[schema_key]
+        assert isinstance(schema_value, Or)
+        assert list[str] in schema_value._args
+        assert list[int] in schema_value._args
+        assert str in schema_value._args
+
+    def test_get_json_schema_value_anyof_with_object(self):
+        """Test that anyOf with bare object types works correctly."""
+        original_schema = {
+            "properties": {
+                "param": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "object"},  # Bare object, no properties
+                    ]
+                }
+            }
+        }
+
+        result = get_json_schema_value(original_schema)
+
+        schema_key = list(result.keys())[0]
+        schema_value = result[schema_key]
+        assert isinstance(schema_value, Or)
+        assert str in schema_value._args
+        assert dict in schema_value._args
+
+    def test_get_json_schema_value_anyof_bare_array(self):
+        """Test that anyOf with bare arrays defaults to string items."""
+        original_schema = {
+            "properties": {
+                "values": {
+                    "anyOf": [
+                        {"type": "array"},  # Bare array, no items specified
+                        {"type": "string"},
+                    ]
+                }
+            }
+        }
+
+        result = get_json_schema_value(original_schema)
+
+        schema_key = list(result.keys())[0]
+        schema_value = result[schema_key]
+        # Should default to list[str] for bare arrays
+        assert isinstance(schema_value, Or)
+        assert list[str] in schema_value._args
+        assert str in schema_value._args
+
+    def test_get_json_schema_value_maya_attribute_value(self):
+        """Test the Maya MCP set_object_attribute.attribute_value case."""
+        # This is the actual schema from Maya MCP that was causing the error
+        original_schema = {
+            "properties": {
+                "attribute_value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "number"},
+                        {"type": "boolean"},
+                        {"type": "array"},  # Bare array - will default to list[str]
+                        {"type": "object"},  # Bare object - will be dict
+                    ]
+                }
+            },
+            "required": ["attribute_value"],
+        }
+
+        result = get_json_schema_value(original_schema)
+
+        # Should have one key (not optional since it's required)
+        assert len(result) == 1
+        schema_key = list(result.keys())[0]
+        # Should be Literal, not Optional since it's required
+        assert schema_key.schema == "attribute_value"
+
+        # Should process all types with bare array/object getting defaults
+        schema_value = result[schema_key]
+        assert isinstance(schema_value, Or)
+        assert str in schema_value._args
+        assert int in schema_value._args
+        assert float in schema_value._args
+        assert bool in schema_value._args
+        assert list[str] in schema_value._args  # Bare array defaults to list[str]
+        assert dict in schema_value._args


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/2012