### PR TITLE
feat: add allow_any_type parameter to JSON schema resolver

### DIFF
--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -175,7 +175,7 @@ class MCPTool(BaseTool):
             config={
                 "name": tool.name,
                 "description": tool.description or tool.title or tool.name,
-                "schema": create_model(tool.inputSchema),
+                "schema": create_model(tool.inputSchema, allow_undefined_array_items=True, allow_any_type=True),
             }
         )
         def activity_handler(self: MCPTool, values: dict) -> Any:

--- a/griptape/utils/json_schema_to_pydantic/__init__.py
+++ b/griptape/utils/json_schema_to_pydantic/__init__.py
@@ -33,6 +33,7 @@ def create_model(
     base_model_type: Type[T] = BaseModel,
     root_schema: Optional[Dict[str, Any]] = None,
     allow_undefined_array_items: bool = False,
+    allow_any_type: bool = False,
 ) -> Type[T]:
     """
     Create a Pydantic model from a JSON Schema.
@@ -41,6 +42,8 @@ def create_model(
         schema: The JSON Schema to convert
         root_schema: The root schema containing definitions.
                     Defaults to schema if not provided.
+        allow_undefined_array_items: If True, allows arrays without items schema
+        allow_any_type: If True, infers Any type for schemas without explicit types
 
     Returns:
         A Pydantic model class
@@ -52,7 +55,7 @@ def create_model(
         ReferenceError: If there's an error resolving references
     """
     builder = PydanticModelBuilder(base_model_type=base_model_type)
-    return builder.create_pydantic_model(schema, root_schema, allow_undefined_array_items)
+    return builder.create_pydantic_model(schema, root_schema, allow_undefined_array_items, allow_any_type)
 
 
 __all__ = [

--- a/griptape/utils/json_schema_to_pydantic/handlers.py
+++ b/griptape/utils/json_schema_to_pydantic/handlers.py
@@ -42,6 +42,7 @@ class CombinerHandler(ICombinerHandler):
         schemas: List[Dict[str, Any]],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Type[BaseModel]:
         """Combines multiple schemas with AND logic."""
         if not schemas:
@@ -80,7 +81,7 @@ class CombinerHandler(ICombinerHandler):
         field_definitions = {}
         for name, prop_schema in merged_properties.items():
             field_type = self.recursive_field_builder(
-                prop_schema, root_schema, allow_undefined_array_items
+                prop_schema, root_schema, allow_undefined_array_items, allow_any_type
             )
             field_info = self.field_info_builder(prop_schema, name in required_fields)
             field_definitions[name] = (field_type, field_info)
@@ -96,6 +97,7 @@ class CombinerHandler(ICombinerHandler):
         schemas: List[Dict[str, Any]],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Any:
         """Allows validation against any of the given schemas."""
         if not schemas:
@@ -114,7 +116,7 @@ class CombinerHandler(ICombinerHandler):
 
             # Use the recursive_field_builder callback to resolve the type
             resolved_type = self.recursive_field_builder(
-                schema, root_schema, allow_undefined_array_items
+                schema, root_schema, allow_undefined_array_items, allow_any_type
             )
             possible_types.append(resolved_type)
 
@@ -125,6 +127,7 @@ class CombinerHandler(ICombinerHandler):
         schema: Dict[str, Any],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Type[BaseModel]:
         """Implements discriminated unions using a type field."""
         schemas = schema.get("oneOf", [])
@@ -165,7 +168,7 @@ class CombinerHandler(ICombinerHandler):
                 elif "oneOf" in prop_schema:
                     # Handle nested oneOf using the callback
                     field_type = self.recursive_field_builder(
-                        prop_schema, root_schema, allow_undefined_array_items
+                        prop_schema, root_schema, allow_undefined_array_items, allow_any_type
                     )
                     # Use field_info_builder for nested oneOf field info
                     field_info = self.field_info_builder(prop_schema, name in required)
@@ -173,7 +176,7 @@ class CombinerHandler(ICombinerHandler):
                 # Add other properties to the fields dictionary
                 elif name != "type":  # Skip the type field as it's handled above
                     field_type = self.recursive_field_builder(
-                        prop_schema, root_schema, allow_undefined_array_items
+                        prop_schema, root_schema, allow_undefined_array_items, allow_any_type
                     )
                     field_info = self.field_info_builder(prop_schema, name in required)
                     fields[name] = (field_type, field_info)

--- a/griptape/utils/json_schema_to_pydantic/interfaces.py
+++ b/griptape/utils/json_schema_to_pydantic/interfaces.py
@@ -13,6 +13,7 @@ class ITypeResolver(ABC):
         schema: Dict[str, Any],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Any:
         """Resolves JSON Schema types to Pydantic types"""
         pass
@@ -32,6 +33,7 @@ class ICombinerHandler(ABC):
         schemas: List[Dict[str, Any]],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Any:
         """Handles allOf combiner"""
         pass
@@ -42,6 +44,7 @@ class ICombinerHandler(ABC):
         schemas: List[Dict[str, Any]],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Any:
         """Handles anyOf combiner"""
         pass
@@ -52,6 +55,7 @@ class ICombinerHandler(ABC):
         schema: Dict[str, Any],
         root_schema: Dict[str, Any],
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Any:
         """Handles oneOf combiner"""
         pass
@@ -73,6 +77,7 @@ class IModelBuilder(ABC, Generic[T]):
         schema: Dict[str, Any],
         root_schema: Optional[Dict[str, Any]] = None,
         allow_undefined_array_items: bool = False,
+        allow_any_type: bool = False,
     ) -> Type[T]:
         """Creates a Pydantic model from JSON Schema"""
         pass


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Add opt-in allow_any_type parameter to JSON schema type resolution. When enabled, schemas without explicit types infer Any type instead of raising TypeError.

- Add allow_any_type parameter to ITypeResolver.resolve_type() interface
- Update TypeResolver to use existing anyType logic when allow_any_type=True
- Thread parameter through all recursive calls and combiner handlers
- Update error message to inform users about the new parameter
- Add allow_any_type parameter to create_model() public API
- Enable allow_any_type in MCPTool for flexible MCP tool schemas

Will try upstreaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Issue ticket number and link
Closes #2031
Towards https://github.com/griptape-ai/griptape-nodes/issues/2916