### PR TITLE
fix(drivers-prompt-griptape-cloud): set very high max_input_tokens to avoid client-side input truncation

### DIFF
--- a/griptape/drivers/prompt/griptape_cloud_prompt_driver.py
+++ b/griptape/drivers/prompt/griptape_cloud_prompt_driver.py
@@ -38,7 +38,10 @@ class GriptapeCloudPromptDriver(BasePromptDriver):
         default=Factory(
             lambda self: SimpleTokenizer(
                 characters_per_token=4,
-                max_input_tokens=2000,
+                # Set very high to prevent client-side truncation. The Griptape Cloud backend
+                # selects the actual model and enforces its real token limits. This SimpleTokenizer
+                # is only used for client-side estimation and shouldn't prematurely prune context.
+                max_input_tokens=500000,
                 max_output_tokens=self.max_tokens,
             ),
             takes_self=True,

--- a/tests/unit/drivers/prompt/test_griptape_cloud_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_griptape_cloud_prompt_driver.py
@@ -513,3 +513,14 @@ class TestGriptapeCloudPromptDriver:
             },
             stream=True,
         )
+
+    def test_tokenizer_max_input_tokens(self):
+        """Test that tokenizer has high max_input_tokens to prevent client-side truncation.
+
+        The GriptapeCloudPromptDriver uses a SimpleTokenizer with max_input_tokens=500000
+        to prevent premature pruning of conversation context. The actual model token limits
+        are enforced by the Griptape Cloud backend.
+        """
+        driver = GriptapeCloudPromptDriver(api_key="foo")
+
+        assert driver.tokenizer.max_input_tokens == 500000


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

## Issue ticket number and link
