### PR TITLE
fix: use parameter value in output_schema validator error message

### DIFF
--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -173,7 +173,7 @@ class PromptTask(
             or (isinstance(output_schema, type) and issubclass(output_schema, BaseModel))
         ):
             return
-        raise ValueError(f"Unsupported output schema type: {type(self.output_schema)}")
+        raise ValueError(f"Unsupported output schema type: {type(output_schema)}")
 
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()

--- a/tests/unit/tasks/test_prompt_task.py
+++ b/tests/unit/tasks/test_prompt_task.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import nullcontext
 
 import pytest
@@ -326,3 +327,42 @@ class TestPromptTask:
             # Should not raise
             task = PromptTask(input="test", output_schema=output_schema)
             assert task.output_schema == output_schema
+
+    @pytest.mark.parametrize(
+        ("initial_schema", "new_schema"),
+        [
+            (None, "invalid_string"),
+            (None, 123),
+            (None, [{"foo": "bar"}]),
+            (schema.Schema({"foo": str}), {"not": "a_schema"}),
+            (create_model("ValidModel", foo=(str, ...)), 42),
+        ],
+    )
+    def test_validate_output_schema_error_reports_new_value(self, initial_schema, new_schema):
+        """Test that the error message reports the type of the rejected value, not the current one.
+
+        Regression test for https://github.com/griptape-ai/griptape/issues/2038:
+        The validator was using `self.output_schema` (old value) in the error message
+        instead of the `output_schema` parameter (the new invalid value).
+        """
+        task = PromptTask(input="test", output_schema=initial_schema)
+
+        with pytest.raises(ValueError, match=re.escape(str(type(new_schema)))):
+            task.output_schema = new_schema
+
+    def test_validate_output_schema_reassignment_valid(self):
+        """Test that reassigning output_schema with a valid schema works."""
+        task = PromptTask(input="test", output_schema=None)
+
+        # Assign a valid Schema
+        task.output_schema = schema.Schema({"foo": str})
+        assert isinstance(task.output_schema, schema.Schema)
+
+        # Reassign to a valid BaseModel subclass
+        model = create_model("NewModel", bar=(int, ...))
+        task.output_schema = model
+        assert task.output_schema is model
+
+        # Reassign back to None
+        task.output_schema = None
+        assert task.output_schema is None


### PR DESCRIPTION
## Summary

Fixes the `output_schema` validator in `PromptTask` to report the correct type in error messages.

## Problem

The `validate_output_schema` validator was referencing `self.output_schema` (the current/old value) in its error message instead of the `output_schema` parameter (the new value being validated). Since `attrs` validators run **before** the assignment takes effect, `self.output_schema` still holds the previous value at validation time.

**Example:** When `output_schema` starts as `None` and a user tries to set it to `"invalid_string"`, the error incorrectly reports:
```
Unsupported output schema type: <class 'NoneType'>
```
instead of:
```
Unsupported output schema type: <class 'str'>
```

## Fix

Changed `type(self.output_schema)` → `type(output_schema)` on line 176 of `griptape/tasks/prompt_task.py` so the error message reports the type of the rejected value.

## Tests

Added 6 new test cases:

- **`test_validate_output_schema_error_reports_new_value`** (5 parametrized cases) — verifies the error message contains the type of the new invalid value, not the old one. Covers transitions from `None`, `Schema`, and `BaseModel` to various invalid types.
- **`test_validate_output_schema_reassignment_valid`** — verifies that reassigning `output_schema` with valid types (`Schema` → `BaseModel` → `None`) works correctly.

All 32 tests in `test_prompt_task.py` pass. No regressions.

Fixes #2038
