### PR TITLE
fix: Make API key error message service-agnostic

### DIFF
--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -48,9 +48,9 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
         if api_key is None:
             raise ValueError(
                 "No value was found for the 'GT_CLOUD_API_KEY' environment variable. "
-                "This environment variable is required when running in Griptape Cloud for authorization. "
-                "You can generate a Griptape Cloud API Key by visiting https://cloud.griptape.ai/keys . "
-                "Specify it as an environment variable when creating a Managed Structure in Griptape Cloud."
+                "This environment variable is required for authorization. "
+                "Please generate an API key from your service provider. "
+                "Specify it as an environment variable."
             )
 
     def publish_event(self, event: BaseEvent | dict) -> None:


### PR DESCRIPTION
## Problem

An enterprise customer was confused when they were directed to Griptape Cloud to generate keys.

The error message specifically directed customers to `https://cloud.griptape.ai/keys`, but this may not be true for enterprise customers with custom deployments.

## Solution

Replace the explicit URL with a generic message:

**Before:**
```
No value was found for the 'GT_CLOUD_API_KEY' environment variable. 
This environment variable is required when running in Griptape Cloud for authorization. 
You can generate a Griptape Cloud API Key by visiting https://cloud.griptape.ai/keys . 
Specify it as an environment variable when creating a Managed Structure in Griptape Cloud.
```

**After:**
```
No value was found for the 'GT_CLOUD_API_KEY' environment variable. 
This environment variable is required for authorization. 
Please generate an API key from your service provider. 
Specify it as an environment variable.
```

This makes the error message work for any deployment scenario.