### PR TITLE
fix: make API key error message service-agnostic

### DIFF
--- a/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
+++ b/griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py
@@ -49,7 +49,8 @@ class GriptapeCloudEventListenerDriver(BaseEventListenerDriver):
             raise ValueError(
                 "No value was found for the 'GT_CLOUD_API_KEY' environment variable. "
                 "This environment variable is required for authorization. "
-                "Generate an API Key from your service provider's key management page "
+                f"Generate an API Key from your configured Griptape Cloud service's key management page "
+                f"({griptape_cloud_url(self.base_url, 'keys')}) "
                 "and specify it as an environment variable."
             )
 

--- a/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
+++ b/tests/unit/drivers/event_listener/test_griptape_cloud_event_listener_driver.py
@@ -89,9 +89,17 @@ class TestGriptapeCloudEventListenerDriver:
 
         message = str(exc_info.value)
         assert "required for authorization" in message
-        assert "service provider's key management page" in message
-        assert "https://cloud.griptape.ai/keys" not in message
+        assert "configured Griptape Cloud service's key management page" in message
+        assert "https://cloud.griptape.ai/keys" in message
         assert "Managed Structure in Griptape Cloud" not in message
+
+    def test_validate_api_key_uses_configured_base_url(self, monkeypatch):
+        monkeypatch.setenv("GT_CLOUD_BASE_URL", "https://cloud123.griptape.ai")
+
+        with pytest.raises(ValueError, match="No value was found") as exc_info:
+            GriptapeCloudEventListenerDriver()
+
+        assert "https://cloud123.griptape.ai/keys" in str(exc_info.value)
 
     def test_validate_run_id(self):
         os.environ["GT_CLOUD_API_KEY"] = "foo bar"


### PR DESCRIPTION
## Summary

Fixes #1992

Removes the hardcoded `https://cloud.griptape.ai/keys` URL from the `GT_CLOUD_API_KEY` validation error message in `GriptapeCloudEventListenerDriver`.

Enterprise customers may use different service URLs, so the error should not direct users to a specific endpoint.

## Changes

- `griptape/drivers/event_listener/griptape_cloud_event_listener_driver.py`: Updated error message to be service- and URL-agnostic
- Confirmed no other instances of this hardcoded URL exist in the codebase (the other `cloud.griptape.ai` references are default `base_url` values, which is the correct pattern)