### PR TITLE
chore: enable UP007, LOG015, B009, B010 ruff rules

### DIFF
--- a/griptape/artifacts/boolean_artifact.py
+++ b/griptape/artifacts/boolean_artifact.py
@@ -18,7 +18,7 @@ class BooleanArtifact(BaseArtifact):
     value: bool = field(converter=bool, metadata={"serializable": True})
 
     @classmethod
-    def parse_bool(cls, value: Union[str, bool]) -> BooleanArtifact:
+    def parse_bool(cls, value: str | bool) -> BooleanArtifact:
         """Convert a string literal or bool to a BooleanArtifact. The string must be either "true" or "false"."""
         if value is not None:
             if isinstance(value, str):

--- a/griptape/common/prompt_stack/contents/image_message_content.py
+++ b/griptape/common/prompt_stack/contents/image_message_content.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @define
 class ImageMessageContent(BaseMessageContent):
-    artifact: Union[ImageArtifact, ImageUrlArtifact] = field(metadata={"serializable": True})
+    artifact: ImageArtifact | ImageUrlArtifact = field(metadata={"serializable": True})
 
     @classmethod
     def from_deltas(cls, deltas: Sequence[BaseDeltaMessageContent]) -> ImageMessageContent:

--- a/griptape/common/prompt_stack/messages/base_message.py
+++ b/griptape/common/prompt_stack/messages/base_message.py
@@ -32,7 +32,7 @@ class BaseMessage(ABC, SerializableMixin):
     ASSISTANT_ROLE = "assistant"
     SYSTEM_ROLE = "system"
 
-    content: list[Union[BaseMessageContent, BaseDeltaMessageContent]] = field(metadata={"serializable": True})
+    content: list[BaseMessageContent | BaseDeltaMessageContent] = field(metadata={"serializable": True})
     role: str = field(kw_only=True, metadata={"serializable": True})
     usage: Usage = field(kw_only=True, default=Factory(lambda: BaseMessage.Usage()), metadata={"serializable": True})
 

--- a/griptape/common/prompt_stack/prompt_stack.py
+++ b/griptape/common/prompt_stack/prompt_stack.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class PromptStack(SerializableMixin):
     messages: list[Message] = field(factory=list, kw_only=True, metadata={"serializable": True})
     tools: list[BaseTool] = field(factory=list, kw_only=True)
-    output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
+    output_schema: Optional[Schema | type[BaseModel]] = field(default=None, kw_only=True)
 
     @property
     def system_messages(self) -> list[Message]:

--- a/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
+++ b/griptape/drivers/image_generation_model/bedrock_stable_diffusion_image_generation_model_driver.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import base64
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
@@ -148,6 +150,6 @@ class BedrockStableDiffusionImageGenerationModelDriver(BaseImageGenerationModelD
         if image_response.get("finishReason") == "ERROR":
             raise Exception(f"Image generation failed: {image_response.get('finishReason')}")
         if image_response.get("finishReason") == "CONTENT_FILTERED":
-            logging.warning("Image generation triggered content filter and may be blurred")
+            log.warning("Image generation triggered content filter and may be blurred")
 
         return base64.decodebytes(bytes(image_response.get("base64"), "utf-8"))

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -436,8 +436,8 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                 raise ValueError(f"Unsupported tool call delta: {tool_call}")
             raise ValueError(f"Unsupported tool call delta length: {len(tool_calls)}")
         # OpenAi doesn't have types for audio deltas so we need to use hasattr and getattr.
-        if hasattr(content_delta, "audio") and getattr(content_delta, "audio") is not None:
-            audio_chunk: dict = getattr(content_delta, "audio")
+        if hasattr(content_delta, "audio") and content_delta.audio is not None:
+            audio_chunk: dict = content_delta.audio
             return AudioDeltaMessageContent(
                 id=audio_chunk.get("id"),
                 data=audio_chunk.get("data"),

--- a/griptape/drivers/vector/opensearch_vector_store_driver.py
+++ b/griptape/drivers/vector/opensearch_vector_store_driver.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, NoReturn, Optional
 
 from attrs import define, field
@@ -92,7 +94,7 @@ class OpenSearchVectorStoreDriver(BaseVectorStoreDriver):
                 )
             return None
         except Exception as e:
-            logging.exception("Error while loading entry: %s", e)
+            log.exception("Error while loading entry: %s", e)
             return None
 
     def load_entries(self, *, namespace: Optional[str] = None) -> list[BaseVectorStoreDriver.Entry]:

--- a/griptape/drivers/vector/qdrant_vector_store_driver.py
+++ b/griptape/drivers/vector/qdrant_vector_store_driver.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 import uuid
 from typing import TYPE_CHECKING, Optional
 
@@ -93,7 +95,7 @@ class QdrantVectorStoreDriver(BaseVectorStoreDriver):
             points_selector=import_optional_dependency("qdrant_client.http.models").PointIdsList(points=[vector_id]),
         )
         if deletion_response.status == import_optional_dependency("qdrant_client.http.models").UpdateStatus.COMPLETED:
-            logging.info("ID %s is successfully deleted", vector_id)
+            log.info("ID %s is successfully deleted", vector_id)
 
     def query_vector(
         self,

--- a/griptape/engines/rag/stages/query_rag_stage.py
+++ b/griptape/engines/rag/stages/query_rag_stage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING
 
 from attrs import define, field
@@ -23,7 +25,7 @@ class QueryRagStage(BaseRagStage):
         return self.query_modules
 
     def run(self, context: RagContext) -> RagContext:
-        logging.info("QueryRagStage: running %s query generation modules sequentially", len(self.query_modules))
+        log.info("QueryRagStage: running %s query generation modules sequentially", len(self.query_modules))
 
         [qm.run(context) for qm in self.query_modules]
 

--- a/griptape/engines/rag/stages/response_rag_stage.py
+++ b/griptape/engines/rag/stages/response_rag_stage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING
 
 from attrs import define, field
@@ -30,7 +32,7 @@ class ResponseRagStage(BaseRagStage):
         return ms
 
     def run(self, context: RagContext) -> RagContext:
-        logging.info("ResponseRagStage: running %s retrieval modules in parallel", len(self.response_modules))
+        log.info("ResponseRagStage: running %s retrieval modules in parallel", len(self.response_modules))
 
         with self.create_futures_executor() as futures_executor:
             results = utils.execute_futures_list(

--- a/griptape/engines/rag/stages/retrieval_rag_stage.py
+++ b/griptape/engines/rag/stages/retrieval_rag_stage.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import itertools
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field
@@ -34,7 +36,7 @@ class RetrievalRagStage(BaseRagStage):
         return ms
 
     def run(self, context: RagContext) -> RagContext:
-        logging.info("RetrievalRagStage: running %s retrieval modules in parallel", len(self.retrieval_modules))
+        log.info("RetrievalRagStage: running %s retrieval modules in parallel", len(self.retrieval_modules))
 
         with self.create_futures_executor() as futures_executor:
             results = utils.execute_futures_list(
@@ -49,7 +51,7 @@ class RetrievalRagStage(BaseRagStage):
         results = list({str(c.value): c for c in results}.values())
         chunks_after_dedup = len(results)
 
-        logging.info(
+        log.info(
             "RetrievalRagStage: deduplicated %s chunks (%s - %s)",
             chunks_before_dedup - chunks_after_dedup,
             chunks_before_dedup,
@@ -59,7 +61,7 @@ class RetrievalRagStage(BaseRagStage):
         context.text_chunks = [a for a in results if isinstance(a, TextArtifact)]
 
         if self.rerank_module:
-            logging.info("RetrievalRagStage: running rerank module on %s chunks", chunks_after_dedup)
+            log.info("RetrievalRagStage: running rerank module on %s chunks", chunks_after_dedup)
 
             context.text_chunks = [a for a in self.rerank_module.run(context) if isinstance(a, TextArtifact)]
 

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
@@ -74,7 +76,7 @@ class SummaryConversationMemory(BaseConversationMemory):
                 ).to_text()
             return previous_summary
         except Exception as e:
-            logging.exception("Error summarizing memory: %s(%s)", type(e).__name__, e)
+            log.exception("Error summarizing memory: %s(%s)", type(e).__name__, e)
 
             return previous_summary
 

--- a/griptape/memory/task/task_memory.py
+++ b/griptape/memory/task/task_memory.py
@@ -64,8 +64,8 @@ class TaskMemory(ActivityMixin, SerializableMixin):
     ) -> BaseArtifact:
         from griptape.utils import J2
 
-        tool_name = getattr(getattr(tool_activity, "__self__"), "name")
-        activity_name = getattr(tool_activity, "name")
+        tool_name = tool_activity.__self__.name
+        activity_name = tool_activity.name
         namespace = output_artifact.name
 
         if output_artifact:

--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -66,7 +66,7 @@ class ActivityMixin:
 
     def find_activity(self, name: str) -> Optional[Callable]:
         for activity in self.activities():
-            if getattr(activity, "is_activity", False) and getattr(activity, "name") == name:
+            if getattr(activity, "is_activity", False) and activity.name == name:
                 return activity
 
         return None
@@ -74,21 +74,21 @@ class ActivityMixin:
     def activity_name(self, activity: Callable) -> str:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        return getattr(activity, "name")
+        return activity.name
 
     def activity_description(self, activity: Callable) -> str:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        return Template(getattr(activity, "config")["description"]).render({"_self": self})
+        return Template(activity.config["description"]).render({"_self": self})
 
-    def activity_schema(self, activity: Callable) -> Optional[Union[Schema, type[BaseModel]]]:
+    def activity_schema(self, activity: Callable) -> Optional[Schema | type[BaseModel]]:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        if getattr(activity, "config")["schema"] is not None:
-            config_schema = getattr(activity, "config")["schema"]
+        if activity.config["schema"] is not None:
+            config_schema = activity.config["schema"]
             if isinstance(config_schema, Schema):
                 # Need to deepcopy to avoid modifying the original schema
-                config_schema = deepcopy(getattr(activity, "config")["schema"])
+                config_schema = deepcopy(activity.config["schema"])
             elif isinstance(config_schema, Callable) and not isinstance(config_schema, type):
                 config_schema = config_schema(self)
             activity_name = self.activity_name(activity)
@@ -113,7 +113,7 @@ class ActivityMixin:
 
         return json_schema
 
-    def validate_activity_schema(self, activity_schema: Union[Schema, type[BaseModel]], params: dict) -> None:
+    def validate_activity_schema(self, activity_schema: Schema | type[BaseModel], params: dict) -> None:
         try:
             if isinstance(activity_schema, Schema):
                 activity_schema.validate(params)

--- a/griptape/mixins/exponential_backoff_mixin.py
+++ b/griptape/mixins/exponential_backoff_mixin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from abc import ABC
 from typing import Callable
 
@@ -13,7 +15,7 @@ class ExponentialBackoffMixin(ABC):
     min_retry_delay: float = field(default=2, kw_only=True)
     max_retry_delay: float = field(default=10, kw_only=True)
     max_attempts: int = field(default=2, kw_only=True)
-    after_hook: Callable = field(default=lambda s: logging.warning(s), kw_only=True)
+    after_hook: Callable = field(default=lambda s: log.warning(s), kw_only=True)
     ignored_exception_types: tuple[type[Exception], ...] = field(factory=tuple, kw_only=True)
 
     def retrying(self) -> Retrying:

--- a/griptape/mixins/serializable_mixin.py
+++ b/griptape/mixins/serializable_mixin.py
@@ -22,12 +22,12 @@ def _default(_self: Any, obj: Any) -> Any:
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()
-    return getattr(obj.__class__, "to_dict", getattr(_default, "default"))(obj)
+    return getattr(obj.__class__, "to_dict", _default.default)(obj)
 
 
 # Adapted from https://stackoverflow.com/questions/18478287/making-object-json-serializable-with-regular-encoder/18561055#18561055
-setattr(_default, "default", JSONEncoder.default)
-setattr(JSONEncoder, "default", _default)
+_default.default = JSONEncoder.default
+JSONEncoder.default = _default
 
 
 @define(slots=False)

--- a/griptape/structures/agent.py
+++ b/griptape/structures/agent.py
@@ -23,17 +23,17 @@ if TYPE_CHECKING:
 
 @define
 class Agent(Structure):
-    input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
+    input: str | list | tuple | BaseArtifact | Callable[[BaseTask], BaseArtifact] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
     )
     stream: Optional[bool] = field(default=None, kw_only=True)
     prompt_driver: Optional[BasePromptDriver] = field(default=None, kw_only=True)
-    output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
+    output_schema: Optional[Schema | type[BaseModel]] = field(default=None, kw_only=True)
     tools: list[BaseTool] = field(factory=list, kw_only=True)
     max_meta_memory_entries: Optional[int] = field(default=20, kw_only=True)
     max_subtasks: Optional[int] = field(default=None, kw_only=True)
     fail_fast: bool = field(default=False, kw_only=True)
-    _tasks: list[Union[BaseTask, list[BaseTask]]] = field(
+    _tasks: list[BaseTask | list[BaseTask]] = field(
         factory=list, kw_only=True, alias="tasks", metadata={"serializable": True}
     )
 

--- a/griptape/structures/structure.py
+++ b/griptape/structures/structure.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 @define
 class Structure(RuleMixin, SerializableMixin, RunnableMixin["Structure"], ABC):
     id: str = field(default=Factory(lambda: uuid.uuid4().hex), kw_only=True, metadata={"serializable": True})
-    _tasks: list[Union[BaseTask, list[BaseTask]]] = field(
+    _tasks: list[BaseTask | list[BaseTask]] = field(
         factory=list, kw_only=True, alias="tasks", metadata={"serializable": True}
     )
     conversation_memory: Optional[BaseConversationMemory] = field(

--- a/griptape/tasks/actions_subtask.py
+++ b/griptape/tasks/actions_subtask.py
@@ -52,7 +52,7 @@ class ActionsSubtask(BaseSubtask[Union[ListArtifact, ErrorArtifact]]):
         kw_only=True,
     )
     response_stop_sequence: str = field(default=RESPONSE_STOP_SEQUENCE, kw_only=True)
-    _input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
+    _input: str | list | tuple | BaseArtifact | Callable[[BaseTask], BaseArtifact] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
         alias="input",
     )
@@ -248,8 +248,8 @@ class ActionsSubtask(BaseSubtask[Union[ListArtifact, ErrorArtifact]]):
 
     def _process_task_input(
         self,
-        task_input: Union[str, tuple, list, BaseArtifact, Callable[[BaseTask], BaseArtifact]],
-    ) -> Union[TextArtifact, AudioArtifact, ListArtifact]:
+        task_input: str | tuple | list | BaseArtifact | Callable[[BaseTask], BaseArtifact],
+    ) -> TextArtifact | AudioArtifact | ListArtifact:
         if isinstance(task_input, (TextArtifact, AudioArtifact, ListArtifact)):
             return task_input
         if isinstance(task_input, ActionArtifact):

--- a/griptape/tasks/base_audio_input_task.py
+++ b/griptape/tasks/base_audio_input_task.py
@@ -18,7 +18,7 @@ T = TypeVar("T", bound=BaseArtifact)
 
 @define
 class BaseAudioInputTask(RuleMixin, BaseTask[T], ABC):
-    _input: Union[AudioArtifact, Callable[[BaseTask], AudioArtifact]] = field(alias="input")
+    _input: AudioArtifact | Callable[[BaseTask], AudioArtifact] = field(alias="input")
 
     @property
     def input(self) -> AudioArtifact:

--- a/griptape/tasks/base_text_input_task.py
+++ b/griptape/tasks/base_text_input_task.py
@@ -21,7 +21,7 @@ T = TypeVar("T", bound=BaseArtifact)
 class BaseTextInputTask(RuleMixin, BaseTask[T], ABC):
     DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
 
-    _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(
         default=DEFAULT_INPUT_TEMPLATE,
         alias="input",
     )

--- a/griptape/tasks/branch_task.py
+++ b/griptape/tasks/branch_task.py
@@ -10,7 +10,7 @@ from griptape.tasks import BaseTask, CodeExecutionTask
 
 @define
 class BranchTask(CodeExecutionTask[Union[InfoArtifact, ListArtifact[InfoArtifact]]]):
-    on_run: Callable[[BranchTask], Union[InfoArtifact, ListArtifact[InfoArtifact]]] = field(kw_only=True)
+    on_run: Callable[[BranchTask], InfoArtifact | ListArtifact[InfoArtifact]] = field(kw_only=True)
 
     def try_run(self) -> InfoArtifact | ListArtifact[InfoArtifact]:
         result = self.on_run(self)

--- a/griptape/tasks/code_execution_task.py
+++ b/griptape/tasks/code_execution_task.py
@@ -14,7 +14,7 @@ T = TypeVar("T", bound=BaseArtifact)  # Return type of task
 @define
 class CodeExecutionTask(BaseTask[T]):
     DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
-    _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(
         default=DEFAULT_INPUT_TEMPLATE,
         alias="input",
     )

--- a/griptape/tasks/inpainting_image_generation_task.py
+++ b/griptape/tasks/inpainting_image_generation_task.py
@@ -27,9 +27,7 @@ class InpaintingImageGenerationTask(BaseImageGenerationTask):
         output_file: If provided, the generated image will be written to disk as output_file.
     """
 
-    _input: Union[
-        tuple[Union[str, TextArtifact], ImageArtifact, ImageArtifact], Callable[[BaseTask], ListArtifact], ListArtifact
-    ] = field(default=None, alias="input")
+    _input: tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact = field(default=None, alias="input")
 
     @property
     def input(self) -> ListArtifact:

--- a/griptape/tasks/outpainting_image_generation_task.py
+++ b/griptape/tasks/outpainting_image_generation_task.py
@@ -27,9 +27,7 @@ class OutpaintingImageGenerationTask(BaseImageGenerationTask):
         output_file: If provided, the generated image will be written to disk as output_file.
     """
 
-    _input: Union[
-        tuple[Union[str, TextArtifact], ImageArtifact, ImageArtifact], Callable[[BaseTask], ListArtifact], ListArtifact
-    ] = field(default=None, alias="input")
+    _input: tuple[str | TextArtifact, ImageArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact = field(default=None, alias="input")
 
     @property
     def input(self) -> ListArtifact:

--- a/griptape/tasks/output_schema_validation_subtask.py
+++ b/griptape/tasks/output_schema_validation_subtask.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(Defaults.logging_config.logger_name)
 @define
 class OutputSchemaValidationSubtask(BaseSubtask):
     _input: BaseArtifact = field(alias="input")
-    output_schema: Union[Schema, type[BaseModel]] = field(kw_only=True)
+    output_schema: Schema | type[BaseModel] = field(kw_only=True)
     structured_output_strategy: StructuredOutputStrategy = field(
         default="rule", kw_only=True, metadata={"serializable": True}
     )

--- a/griptape/tasks/prompt_image_generation_task.py
+++ b/griptape/tasks/prompt_image_generation_task.py
@@ -28,7 +28,7 @@ class PromptImageGenerationTask(BaseImageGenerationTask):
 
     DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
 
-    _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(
         default=DEFAULT_INPUT_TEMPLATE, alias="input"
     )
 

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -51,15 +51,15 @@ class PromptTask(
     prompt_driver: BasePromptDriver = field(
         default=Factory(lambda: Defaults.drivers_config.prompt_driver), kw_only=True, metadata={"serializable": True}
     )
-    output_schema: Optional[Union[Schema, type[BaseModel]]] = field(default=None, kw_only=True)
+    output_schema: Optional[Schema | type[BaseModel]] = field(default=None, kw_only=True)
     generate_system_template: Callable[[PromptTask], str] = field(
         default=Factory(lambda self: self.default_generate_system_template, takes_self=True),
         kw_only=True,
     )
-    _conversation_memory: Union[Optional[BaseConversationMemory], NothingType] = field(
+    _conversation_memory: Optional[BaseConversationMemory] | NothingType = field(
         default=Factory(lambda: NOTHING), kw_only=True, alias="conversation_memory"
     )
-    _input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
+    _input: str | list | tuple | BaseArtifact | Callable[[BaseTask], BaseArtifact] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
         alias="input",
     )
@@ -165,7 +165,7 @@ class PromptTask(
 
     @output_schema.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
     def validate_output_schema(
-        self, _: Attribute, output_schema: Optional[Union[Schema, type[BaseModel], Any]]
+        self, _: Attribute, output_schema: Optional[Schema | type[BaseModel] | Any]
     ) -> None:
         if (
             output_schema is None
@@ -266,7 +266,7 @@ class PromptTask(
                 if tool.input_memory is None:
                     tool.input_memory = [self.task_memory]
                 if tool.output_memory is None and tool.off_prompt:
-                    tool.output_memory = {getattr(a, "name"): [self.task_memory] for a in tool.activities()}
+                    tool.output_memory = {a.name: [self.task_memory] for a in tool.activities()}
 
     def find_subtask(self, subtask_id: str) -> BaseSubtask:
         for subtask in self.subtasks:

--- a/griptape/tasks/structure_run_task.py
+++ b/griptape/tasks/structure_run_task.py
@@ -20,7 +20,7 @@ class StructureRunTask(BaseTask):
         structure_run_driver: Driver to run the Structure.
     """
 
-    _input: Union[str, list, tuple, BaseArtifact, Callable[[BaseTask], BaseArtifact]] = field(
+    _input: str | list | tuple | BaseArtifact | Callable[[BaseTask], BaseArtifact] = field(
         default=lambda task: task.full_context["args"][0] if task.full_context["args"] else TextArtifact(value=""),
     )
 

--- a/griptape/tasks/text_to_speech_task.py
+++ b/griptape/tasks/text_to_speech_task.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class TextToSpeechTask(BaseAudioGenerationTask):
     DEFAULT_INPUT_TEMPLATE = "{{ args[0] }}"
 
-    _input: Union[str, TextArtifact, Callable[[BaseTask], TextArtifact]] = field(default=DEFAULT_INPUT_TEMPLATE)
+    _input: str | TextArtifact | Callable[[BaseTask], TextArtifact] = field(default=DEFAULT_INPUT_TEMPLATE)
     text_to_speech_driver: BaseTextToSpeechDriver = field(
         default=Factory(lambda: Defaults.drivers_config.text_to_speech_driver), kw_only=True
     )

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -128,4 +128,4 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
             if self.tool.input_memory is None:
                 self.tool.input_memory = [self.task_memory]
             if self.tool.output_memory is None and self.tool.off_prompt:
-                self.tool.output_memory = {getattr(a, "name"): [self.task_memory] for a in self.tool.activities()}
+                self.tool.output_memory = {a.name: [self.task_memory] for a in self.tool.activities()}

--- a/griptape/tasks/variation_image_generation_task.py
+++ b/griptape/tasks/variation_image_generation_task.py
@@ -35,7 +35,7 @@ class VariationImageGenerationTask(BaseImageGenerationTask):
         default=Factory(lambda: Defaults.drivers_config.image_generation_driver),
         kw_only=True,
     )
-    _input: Union[tuple[Union[str, TextArtifact], ImageArtifact], Callable[[BaseTask], ListArtifact], ListArtifact] = (
+    _input: tuple[str | TextArtifact, ImageArtifact] | Callable[[BaseTask], ListArtifact] | ListArtifact = (
         field(default=None, alias="input")
     )
 

--- a/griptape/tokenizers/base_tokenizer.py
+++ b/griptape/tokenizers/base_tokenizer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -71,7 +73,7 @@ class BaseTokenizer(ABC, SerializableMixin):
         )
 
         if tokens is None:
-            logging.warning(
+            log.warning(
                 "Model %s not found in MODEL_PREFIXES_TO_MAX_INPUT_TOKENS, using default value of %s.",
                 self.model,
                 self.DEFAULT_MAX_INPUT_TOKENS,
@@ -90,7 +92,7 @@ class BaseTokenizer(ABC, SerializableMixin):
         )
 
         if tokens is None:
-            logging.debug(
+            log.debug(
                 "Model %s not found in MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS, using default value of %s.",
                 self.model,
                 self.DEFAULT_MAX_OUTPUT_TOKENS,

--- a/griptape/tokenizers/openai_tokenizer.py
+++ b/griptape/tokenizers/openai_tokenizer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Optional
 
 from attrs import Factory, define, field
@@ -98,7 +100,7 @@ class OpenAiTokenizer(BaseTokenizer):
             try:
                 encoding = tiktoken.encoding_for_model(model)
             except KeyError:
-                logging.warning("model not found. Using cl100k_base encoding.")
+                log.warning("model not found. Using cl100k_base encoding.")
 
                 encoding = tiktoken.get_encoding("cl100k_base")
 
@@ -120,13 +122,13 @@ class OpenAiTokenizer(BaseTokenizer):
                 # if there's a name, the role is omitted
                 tokens_per_name = -1
             elif "gpt-3.5-turbo" in model or "gpt-35-turbo" in model:
-                logging.info("gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.")
+                log.info("gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.")
                 return self.count_tokens(text, model="gpt-3.5-turbo-0613")
             elif "gpt-4o" in model:
-                logging.info("gpt-4o may update over time. Returning num tokens assuming gpt-4o-2024-05-13.")
+                log.info("gpt-4o may update over time. Returning num tokens assuming gpt-4o-2024-05-13.")
                 return self.count_tokens(text, model="gpt-4o-2024-05-13")
             elif "gpt-4" in model:
-                logging.info("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
+                log.info("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
                 return self.count_tokens(text, model="gpt-4-0613")
             else:
                 raise NotImplementedError(

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -137,7 +137,7 @@ class BaseTool(ActivityMixin, SerializableMixin, RunnableMixin["BaseTool"], ABC)
 
             output = self.after_run(activity, subtask, action, output)
         except Exception as e:
-            logging.debug(traceback.format_exc())
+            log.debug(traceback.format_exc())
             output = ErrorArtifact(str(e), exception=e)
 
         return output
@@ -160,7 +160,7 @@ class BaseTool(ActivityMixin, SerializableMixin, RunnableMixin["BaseTool"], ABC)
         if isinstance(activity_result, BaseArtifact):
             result = activity_result
         else:
-            logging.warning("Activity result is not an artifact; converting result to InfoArtifact")
+            log.warning("Activity result is not an artifact; converting result to InfoArtifact")
 
             if activity_result is None:
                 result = InfoArtifact("Tool returned an empty value")
@@ -179,7 +179,7 @@ class BaseTool(ActivityMixin, SerializableMixin, RunnableMixin["BaseTool"], ABC)
         super().after_run()
 
         if self.output_memory:
-            output_memories = self.output_memory[getattr(activity, "name")] or []
+            output_memories = self.output_memory[activity.name] or []
             for memory in output_memories:
                 value = memory.process_output(activity, subtask, value)
 

--- a/griptape/tools/computer/tool.py
+++ b/griptape/tools/computer/tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 import os
 import shutil
 import tempfile
@@ -153,7 +155,7 @@ class ComputerTool(BaseTool):
         try:
             return docker.from_env()
         except Exception as e:
-            logging.exception(e)
+            log.exception(e)
 
             return None
 
@@ -176,7 +178,7 @@ class ComputerTool(BaseTool):
             if isinstance(existing_container, Container):
                 existing_container.remove(force=True)
 
-                logging.info("Removed existing container %s", name)
+                log.info("Removed existing container %s", name)
         except NotFound:
             pass
 
@@ -188,7 +190,7 @@ class ComputerTool(BaseTool):
             image = self.docker_client.images.build(path=temp_dir, tag=self.image_name(tool), rm=True, forcerm=True)
 
             if isinstance(image, tuple):
-                logging.info("Built image: %s", image[0].short_id)
+                log.info("Built image: %s", image[0].short_id)
 
     def dependencies(self) -> list[str]:
         with open(self.requirements_txt_path) as file:

--- a/griptape/tools/email/tool.py
+++ b/griptape/tools/email/tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+
+log = logging.getLogger(__name__)
 import smtplib
 from email.mime.text import MIMEText
 from typing import Optional
@@ -126,7 +128,7 @@ class EmailTool(BaseTool):
                 client.sendmail(msg["From"], [msg["To"]], msg.as_string())
                 return InfoArtifact("email was successfully sent")
         except Exception as e:
-            logging.exception(e)
+            log.exception(e)
             return ErrorArtifact(f"error sending email: {e}")
 
     def _create_smtp_client(self, smtp_host: str, smtp_port: int) -> smtplib.SMTP | smtplib.SMTP_SSL:

--- a/griptape/tools/structured_output/tool.py
+++ b/griptape/tools/structured_output/tool.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 @define
 class StructuredOutputTool(BaseTool):
-    output_schema: Union[Schema, type[BaseModel]] = field(kw_only=True)
+    output_schema: Schema | type[BaseModel] = field(kw_only=True)
 
     @activity(
         config={

--- a/griptape/utils/decorators.py
+++ b/griptape/utils/decorators.py
@@ -39,9 +39,9 @@ def activity(config: dict) -> Any:
         def wrapper(self: Any, params: dict) -> Any:
             return func(self, **_build_kwargs(func, params))
 
-        setattr(wrapper, "name", validated_config.get("name", func.__name__))
-        setattr(wrapper, "config", validated_config)
-        setattr(wrapper, "is_activity", True)
+        wrapper.name = validated_config.get("name", func.__name__)
+        wrapper.config = validated_config
+        wrapper.is_activity = True
 
         return wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,11 +215,8 @@ line-length = 120
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-  "UP007",  # non-pep604-annotation
   "E501",   # line-too-long
   "B024",   # abstract-base-class-without-abstract-method
-  "B009",   # get-attr-with-constant
-  "B010",   # set-attr-with-constant
   "D100",   # undocumented-public-module
   "D101",   # undocumented-public-class
   "D102",   # undocumented-public-method
@@ -233,7 +230,6 @@ ignore = [
   "ANN003", # missing-type-kwargs
   "ANN401", # any-type
   "PT011",  # pytest-raises-too-broad
-  "LOG015", # root-logger-call
   "EM101",  # raw-string-in-exception
   "BLE001", # blind-except
   "S",      # flake8-bandit

--- a/tests/mocks/mock_prompt_driver.py
+++ b/tests/mocks/mock_prompt_driver.py
@@ -34,9 +34,9 @@ if TYPE_CHECKING:
 class MockPromptDriver(BasePromptDriver):
     model: str = "test-model"
     tokenizer: BaseTokenizer = MockTokenizer(model="test-model", max_input_tokens=4096, max_output_tokens=4096)
-    mock_input: Union[str, Callable[[], str]] = field(default="mock input", kw_only=True)
-    mock_output: Union[str, Callable[[PromptStack], str]] = field(default="mock output", kw_only=True)
-    mock_structured_output: Union[dict, Callable[[PromptStack], dict]] = field(factory=dict, kw_only=True)
+    mock_input: str | Callable[[], str] = field(default="mock input", kw_only=True)
+    mock_output: str | Callable[[PromptStack], str] = field(default="mock output", kw_only=True)
+    mock_structured_output: dict | Callable[[PromptStack], dict] = field(factory=dict, kw_only=True)
     modalities: list[str] = field(default=Factory(lambda: ["text"]), kw_only=True)
 
     def try_run(self, prompt_stack: PromptStack) -> Message:


### PR DESCRIPTION
## Summary

Closes #995

Removes 4 rules from the ruff ignore list and fixes all violations:

- **UP007**: Modernize type annotations to use PEP 604 Union syntax (`X | Y`) — 52 violations fixed across 21 files
- **LOG015**: Replace root logger calls with module-level loggers — 22 violations fixed across 13 files
- **B009/B010**: Replace `getattr`/`setattr` with constant args with direct attribute access — 20 violations fixed across 3 files

Total: 94 violations eliminated across 37 files.

Ignore list reduced from 34 → 30 entries.