### PR TITLE
fix: pin pymdown-extensions>=10.17 for pygments 2.20.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ docs = [
   "mkdocs-gen-files>=0.5.0",
   "mkdocs-literate-nav>=0.6.0",
   "mkdocs-section-index>=0.3.6",
-  "pymdown-extensions>=10.3",
+  "pymdown-extensions>=10.17",
   "mkdocs-autorefs>=1.3.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1630,7 +1630,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.2.8" },
     { name = "mkdocs-section-index", specifier = ">=0.3.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.28.0" },
-    { name = "pymdown-extensions", specifier = ">=10.3" },
+    { name = "pymdown-extensions", specifier = ">=10.17" },
 ]
 test = [
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
@@ -3921,15 +3921,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.16.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pygments 2.20.0 introduced stricter handling of the `filename` parameter in `HtmlFormatter`, no longer accepting `None`. `pymdown-extensions` 10.16.1 had a bug where it passed `title=None` as `filename` to the Pygments formatter when processing indented code blocks, causing `html.escape(None)` to crash with `AttributeError: 'NoneType' object has no attribute 'replace'`. This broke the docs build.

Bumping the `pymdown-extensions` minimum from `>=10.3` to `>=10.17` resolves the incompatibility. Equivalent to griptape-ai/griptape-nodes#4328.