### PR TITLE
fix(drivers-prompt-openai): pass valid URI-reference as tool schema `$id`

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -316,7 +316,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                 "function": {
                     "name": tool.to_native_tool_name(activity),
                     "description": tool.activity_description(activity),
-                    "parameters": tool.to_activity_json_schema(activity, "Parameters Schema"),
+                    "parameters": tool.to_activity_json_schema(activity, "http://json-schema.org/draft-07/schema#"),
                 },
                 "type": "function",
             }

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -32,7 +32,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description: foo",
                 "name": "MockTool_test",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {
@@ -67,7 +67,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                     },
                     "required": ["values"],
                     "additionalProperties": False,
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                 },
             },
@@ -78,7 +78,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description: foo",
                 "name": "MockTool_test_error",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {
@@ -101,7 +101,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description: foo",
                 "name": "MockTool_test_exception",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {
@@ -124,7 +124,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description",
                 "name": "MockTool_test_list_output",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {},
@@ -139,7 +139,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description",
                 "name": "MockTool_test_no_schema",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {},
@@ -154,7 +154,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description: foo",
                 "name": "MockTool_test_str_output",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {
@@ -177,7 +177,7 @@ class TestOpenAiChatPromptDriverFixtureMixin:
                 "description": "test description",
                 "name": "MockTool_test_without_default_memory",
                 "parameters": {
-                    "$id": "Parameters Schema",
+                    "$id": "http://json-schema.org/draft-07/schema#",
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "additionalProperties": False,
                     "properties": {


### PR DESCRIPTION
Closes #2150.

OpenAI's API validates the `$id` field of tool `parameters` schemas as a URI-reference and rejects values like `"Parameters Schema"` that contain spaces. The `OpenAiChatPromptDriver` now passes `"http://json-schema.org/draft-07/schema#"` as the `schema_id` when building tool schemas, matching the value already used by `AmazonBedrockPromptDriver`. Test fixtures were updated to reflect the new `$id`.