### PR TITLE
refactor(google): migrate all Google drivers to google-genai SDK

### DIFF
--- a/docs/recipes/src/talk_to_a_video_1.py
+++ b/docs/recipes/src/talk_to_a_video_1.py
@@ -1,20 +1,20 @@
 import time
 
-from google.generativeai.files import get_file, upload_file
-
 from griptape.artifacts import GenericArtifact, TextArtifact
 from griptape.configs import Defaults
 from griptape.configs.drivers import GoogleDriversConfig
 from griptape.structures import Agent
 
 Defaults.drivers_config = GoogleDriversConfig()
+client = Defaults.drivers_config.prompt_driver.client
 
-video_file = upload_file(path="tests/resources/griptape-comfyui.mp4")
-while video_file.state.name == "PROCESSING":
+video_file = client.files.upload(file="tests/resources/griptape-comfyui.mp4")
+while video_file.state and video_file.state.name == "PROCESSING":
     time.sleep(2)
-    video_file = get_file(video_file.name)
+    if video_file.name:
+        video_file = client.files.get(name=video_file.name)
 
-if video_file.state.name == "FAILED":
+if video_file.state and video_file.state.name == "FAILED":
     raise ValueError(video_file.state.name)
 
 agent = Agent(

--- a/griptape/drivers/embedding/google_embedding_driver.py
+++ b/griptape/drivers/embedding/google_embedding_driver.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from attrs import define, field
 
 from griptape.drivers.embedding import BaseEmbeddingDriver
 from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    from google.genai import Client
 
 
 @define
@@ -13,7 +19,8 @@ class GoogleEmbeddingDriver(BaseEmbeddingDriver):
     Attributes:
         api_key: Google API key.
         model: Google model name.
-        task_type: Embedding model task type (https://ai.google.dev/tutorials/python_quickstart#use_embeddings). Defaults to `retrieval_document`.
+        client: Custom `google.genai.Client`.
+        task_type: Embedding model task type (https://ai.google.dev/gemini-api/docs/embeddings#task-types). Defaults to `retrieval_document`.
         title: Optional title for the content. Only works with `retrieval_document` task type.
     """
 
@@ -23,14 +30,24 @@ class GoogleEmbeddingDriver(BaseEmbeddingDriver):
     api_key: str | None = field(default=None, kw_only=True, metadata={"serializable": False})
     task_type: str = field(default="retrieval_document", kw_only=True, metadata={"serializable": True})
     title: str | None = field(default=None, kw_only=True, metadata={"serializable": True})
+    _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Client:
+        genai = import_optional_dependency("google.genai")
+
+        return genai.Client(api_key=self.api_key)
 
     def try_embed_chunk(self, chunk: str, **kwargs) -> list[float]:
-        genai = import_optional_dependency("google.generativeai")
-        genai.configure(api_key=self.api_key)
+        types = import_optional_dependency("google.genai.types")
 
-        result = genai.embed_content(model=self.model, content=chunk, task_type=self.task_type, title=self.title)
+        response = self.client.models.embed_content(
+            model=self.model,
+            contents=chunk,
+            config=types.EmbedContentConfig(task_type=self.task_type, title=self.title),
+        )
 
-        return result["embedding"]
+        return cast("list[float]", response.embeddings[0].values)  # pyright: ignore[reportOptionalSubscript]
 
     def _params(self, chunk: str) -> dict:
         return {"input": chunk, "model": self.model}

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -36,9 +36,12 @@ from griptape.utils.decorators import lazy_property
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from google.generativeai.generative_models import GenerativeModel
-    from google.generativeai.protos import Part
-    from google.generativeai.types import ContentDict, ContentsType, GenerateContentResponse
+    from google.genai import Client
+    from google.genai.types import (
+        Content,
+        GenerateContentResponse,
+        Part,
+    )
 
     from griptape.drivers.prompt.base_prompt_driver import StructuredOutputStrategy
     from griptape.tools import BaseTool
@@ -53,7 +56,7 @@ class GooglePromptDriver(BasePromptDriver):
     Attributes:
         api_key: Google API key.
         model: Google model name.
-        client: Custom `GenerativeModel` client.
+        client: Custom `google.genai.Client`.
         top_p: Optional value for top_p.
         top_k: Optional value for top_k.
     """
@@ -71,9 +74,7 @@ class GooglePromptDriver(BasePromptDriver):
         default="tool", kw_only=True, metadata={"serializable": True}
     )
     tool_choice: str = field(default="auto", kw_only=True, metadata={"serializable": True})
-    _client: GenerativeModel | None = field(
-        default=None, kw_only=True, alias="client", metadata={"serializable": False}
-    )
+    _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @structured_output_strategy.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
     def validate_structured_output_strategy(self, _: Attribute, value: str) -> str:
@@ -83,49 +84,66 @@ class GooglePromptDriver(BasePromptDriver):
         return value
 
     @lazy_property()
-    def client(self) -> GenerativeModel:
-        genai = import_optional_dependency("google.generativeai")
-        genai.configure(api_key=self.api_key)
+    def client(self) -> Client:
+        genai = import_optional_dependency("google.genai")
 
-        return genai.GenerativeModel(self.model)
+        return genai.Client(api_key=self.api_key)
 
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
+        types = import_optional_dependency("google.genai.types")
+
         messages = self.__to_google_messages(prompt_stack)
         params = self._base_params(prompt_stack)
-        logger.debug((messages, params["generation_config"].__dict__))
-        response: GenerateContentResponse = self.client.generate_content(messages, **params)
-        logger.debug(response.to_dict())
+        config = types.GenerateContentConfig(**params)
+        logger.debug((messages, params))
+        response: GenerateContentResponse = self.client.models.generate_content(
+            model=self.model,
+            contents=messages,
+            config=config,
+        )
+        logger.debug(response.model_dump())
 
         usage_metadata = response.usage_metadata
+        parts = response.candidates[0].content.parts if response.candidates and response.candidates[0].content else []
 
         return Message(
-            content=[self.__to_prompt_stack_message_content(part) for part in response.parts],
+            content=[self.__to_prompt_stack_message_content(part) for part in (parts or [])],
             role=Message.ASSISTANT_ROLE,
             usage=Message.Usage(
-                input_tokens=usage_metadata.prompt_token_count,
-                output_tokens=usage_metadata.candidates_token_count,
+                input_tokens=usage_metadata.prompt_token_count if usage_metadata else None,
+                output_tokens=usage_metadata.candidates_token_count if usage_metadata else None,
             ),
         )
 
     @observable
     def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+        types = import_optional_dependency("google.genai.types")
+
         messages = self.__to_google_messages(prompt_stack)
-        params = {**self._base_params(prompt_stack), "stream": True}
+        params = self._base_params(prompt_stack)
+        config = types.GenerateContentConfig(**params)
         logger.debug((messages, params))
-        response: GenerateContentResponse = self.client.generate_content(
-            messages,
-            **params,
+        response = self.client.models.generate_content_stream(
+            model=self.model,
+            contents=messages,
+            config=config,
         )
 
         prompt_token_count = None
         for chunk in response:
-            logger.debug(chunk.to_dict())
+            logger.debug(chunk.model_dump())
             usage_metadata = chunk.usage_metadata
 
-            content = self.__to_prompt_stack_delta_message_content(chunk.parts[0]) if chunk.parts else None
+            parts = (
+                chunk.candidates[0].content.parts
+                if chunk.candidates and chunk.candidates[0].content
+                else None
+            )
+            content = self.__to_prompt_stack_delta_message_content(parts[0]) if parts else None
+
             # Only want to output the prompt token count once since it is static each chunk
-            if prompt_token_count is None:
+            if prompt_token_count is None and usage_metadata is not None:
                 prompt_token_count = usage_metadata.prompt_token_count
                 yield DeltaMessage(
                     content=content,
@@ -137,54 +155,54 @@ class GooglePromptDriver(BasePromptDriver):
             else:
                 yield DeltaMessage(
                     content=content,
-                    usage=DeltaMessage.Usage(output_tokens=usage_metadata.candidates_token_count),
+                    usage=DeltaMessage.Usage(
+                        output_tokens=usage_metadata.candidates_token_count if usage_metadata else None,
+                    ),
                 )
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:
-        types = import_optional_dependency("google.generativeai.types")
-        protos = import_optional_dependency("google.generativeai.protos")
+        types = import_optional_dependency("google.genai.types")
 
         system_messages = prompt_stack.system_messages
+        system_instruction = None
         if system_messages:
-            self.client._system_instruction = types.ContentDict(
+            system_instruction = types.Content(
                 role="system",
-                parts=[protos.Part(text=system_message.to_text()) for system_message in system_messages],
+                parts=[types.Part.from_text(text=system_message.to_text()) for system_message in system_messages],
             )
 
         params = {
-            "generation_config": types.GenerationConfig(
-                **{
-                    # For some reason, providing stop sequences when streaming breaks native functions
-                    # https://github.com/google-gemini/generative-ai-python/issues/446
-                    "stop_sequences": [] if self.stream and self.use_native_tools else self.tokenizer.stop_sequences,
-                    "max_output_tokens": self.max_tokens,
-                    "temperature": self.temperature,
-                    "top_p": self.top_p,
-                    "top_k": self.top_k,
-                    **self.extra_params,
-                },
-            ),
+            # For some reason, providing stop sequences when streaming breaks native functions
+            # https://github.com/google-gemini/generative-ai-python/issues/446
+            "stop_sequences": [] if self.stream and self.use_native_tools else self.tokenizer.stop_sequences,
+            "max_output_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            **({"system_instruction": system_instruction} if system_instruction is not None else {}),
+            **self.extra_params,
         }
 
         if prompt_stack.tools and self.use_native_tools:
-            params["tool_config"] = {"function_calling_config": {"mode": self.tool_choice}}
+            mode = self.tool_choice.upper()
 
             if prompt_stack.output_schema is not None and self.structured_output_strategy == "tool":
-                params["tool_config"]["function_calling_config"]["mode"] = "auto"
+                mode = "AUTO"
 
+            params["tool_config"] = types.ToolConfig(
+                function_calling_config=types.FunctionCallingConfig(mode=mode),
+            )
             params["tools"] = self.__to_google_tools(prompt_stack.tools)
 
         return params
 
-    def __to_google_messages(self, prompt_stack: PromptStack) -> ContentsType:
-        types = import_optional_dependency("google.generativeai.types")
+    def __to_google_messages(self, prompt_stack: PromptStack) -> list[Content]:
+        types = import_optional_dependency("google.genai.types")
 
         return [
-            types.ContentDict(
-                {
-                    "role": self.__to_google_role(message),
-                    "parts": [self.__to_google_message_content(content) for content in message.content],
-                },
+            types.Content(
+                role=self.__to_google_role(message),
+                parts=[self.__to_google_message_content(content) for content in message.content],
             )
             for message in prompt_stack.messages
             if not message.is_system()
@@ -195,10 +213,10 @@ class GooglePromptDriver(BasePromptDriver):
             return "model"
         return "user"
 
-    def __to_google_tools(self, tools: list[BaseTool]) -> list[dict]:
-        types = import_optional_dependency("google.generativeai.types")
+    def __to_google_tools(self, tools: list[BaseTool]) -> list:
+        types = import_optional_dependency("google.genai.types")
 
-        tool_declarations = []
+        function_declarations = []
         for tool in tools:
             for activity in tool.activities():
                 schema = tool.to_activity_json_schema(activity, "Parameters Schema")
@@ -208,7 +226,7 @@ class GooglePromptDriver(BasePromptDriver):
 
                 schema = remove_key_in_dict_recursively(schema, "additionalProperties")
                 schema = remove_key_in_dict_recursively(schema, "title", preserve_under_key="properties")
-                tool_declaration = types.FunctionDeclaration(
+                function_declaration = types.FunctionDeclaration(
                     name=tool.to_native_tool_name(activity),
                     description=tool.activity_description(activity),
                     **(
@@ -224,68 +242,66 @@ class GooglePromptDriver(BasePromptDriver):
                     ),
                 )
 
-                tool_declarations.append(tool_declaration)
+                function_declarations.append(function_declaration)
 
-        return tool_declarations
+        return [types.Tool(function_declarations=function_declarations)]
 
-    def __to_google_message_content(self, content: BaseMessageContent) -> ContentDict | Part | str:
-        types = import_optional_dependency("google.generativeai.types")
-        protos = import_optional_dependency("google.generativeai.protos")
+    def __to_google_message_content(self, content: BaseMessageContent) -> Part:
+        types = import_optional_dependency("google.genai.types")
 
         if isinstance(content, TextMessageContent):
-            return content.artifact.to_text()
+            return types.Part.from_text(text=content.artifact.to_text())
         if isinstance(content, ImageMessageContent):
             if isinstance(content.artifact, ImageArtifact):
-                return types.ContentDict(mime_type=content.artifact.mime_type, data=content.artifact.value)
+                return types.Part.from_bytes(data=content.artifact.value, mime_type=content.artifact.mime_type)
             # TODO: Google requires uploading to the files endpoint: https://ai.google.dev/gemini-api/docs/image-understanding#upload-image
             # Can be worked around by using GenericMessageContent, similar to videos.
             raise ValueError(f"Unsupported image artifact type: {type(content.artifact)}")
         if isinstance(content, ActionCallMessageContent):
             action = content.artifact.value
 
-            return protos.Part(function_call=protos.FunctionCall(name=action.tag, args=action.input))
+            return types.Part.from_function_call(name=action.tag, args=action.input)
         if isinstance(content, ActionResultMessageContent):
             artifact = content.artifact
 
-            return protos.Part(
-                function_response=protos.FunctionResponse(
-                    name=content.action.to_native_tool_name(),
-                    response=artifact.to_dict(),
-                ),
+            return types.Part.from_function_response(
+                name=content.action.to_native_tool_name(),
+                response=artifact.to_dict(),
             )
         if isinstance(content, GenericMessageContent):
-            return content.artifact.value
+            value = content.artifact.value
+            if isinstance(value, str):
+                return types.Part.from_text(text=value)
+            return value
         raise ValueError(f"Unsupported prompt stack content type: {type(content)}")
 
     def __to_prompt_stack_message_content(self, content: Part) -> BaseMessageContent:
-        json_format = import_optional_dependency("google.protobuf.json_format")
-
         if content.text:
             return TextMessageContent(TextArtifact(content.text))
         if content.function_call:
             function_call = content.function_call
+            tag = function_call.name or ""
 
-            name, path = ToolAction.from_native_tool_name(function_call.name)
+            name, path = ToolAction.from_native_tool_name(tag)
 
-            args = json_format.MessageToDict(function_call._pb).get("args", {})
+            args = function_call.args or {}
             return ActionCallMessageContent(
-                artifact=ActionArtifact(value=ToolAction(tag=function_call.name, name=name, path=path, input=args)),
+                artifact=ActionArtifact(value=ToolAction(tag=tag, name=name, path=path, input=args)),
             )
         raise ValueError(f"Unsupported message content type {content}")
 
     def __to_prompt_stack_delta_message_content(self, content: Part) -> BaseDeltaMessageContent:
-        json_format = import_optional_dependency("google.protobuf.json_format")
-
         if content.text:
             return TextDeltaMessageContent(content.text)
         if content.function_call:
             function_call = content.function_call
+            tag = function_call.name or ""
 
-            name, path = ToolAction.from_native_tool_name(function_call.name)
+            name, path = ToolAction.from_native_tool_name(tag)
 
-            args = json_format.MessageToDict(function_call._pb).get("args", {})
+            args = function_call.args or {}
             return ActionCallDeltaMessageContent(
-                tag=function_call.name,
+                tag=tag,
                 name=name,
                 path=path,
                 partial_input=json.dumps(args),

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -135,11 +135,7 @@ class GooglePromptDriver(BasePromptDriver):
             logger.debug(chunk.model_dump())
             usage_metadata = chunk.usage_metadata
 
-            parts = (
-                chunk.candidates[0].content.parts
-                if chunk.candidates and chunk.candidates[0].content
-                else None
-            )
+            parts = chunk.candidates[0].content.parts if chunk.candidates and chunk.candidates[0].content else None
             content = self.__to_prompt_stack_delta_message_content(parts[0]) if parts else None
 
             # Only want to output the prompt token count once since it is static each chunk

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from attrs import Attribute, Factory, define, field
+from attrs import Factory, define, field
 
 from griptape.artifacts import ActionArtifact, TextArtifact
 from griptape.artifacts.image_artifact import ImageArtifact
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from google.genai import Client
     from google.genai.types import (
         Content,
+        ContentListUnionDict,
         GenerateContentResponse,
         Part,
     )
@@ -76,13 +77,6 @@ class GooglePromptDriver(BasePromptDriver):
     tool_choice: str = field(default="auto", kw_only=True, metadata={"serializable": True})
     _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
-    @structured_output_strategy.validator  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
-    def validate_structured_output_strategy(self, _: Attribute, value: str) -> str:
-        if value == "native":
-            raise ValueError(f"{__class__.__name__} does not support `{value}` structured output strategy.")
-
-        return value
-
     @lazy_property()
     def client(self) -> Client:
         genai = import_optional_dependency("google.genai")
@@ -99,7 +93,7 @@ class GooglePromptDriver(BasePromptDriver):
         logger.debug((messages, params))
         response: GenerateContentResponse = self.client.models.generate_content(
             model=self.model,
-            contents=messages,
+            contents=cast("ContentListUnionDict", messages),
             config=config,
         )
         logger.debug(response.model_dump())
@@ -130,7 +124,7 @@ class GooglePromptDriver(BasePromptDriver):
         logger.debug((messages, params))
         response = self.client.models.generate_content_stream(
             model=self.model,
-            contents=messages,
+            contents=cast("ContentListUnionDict", messages),
             config=config,
         )
 
@@ -198,6 +192,10 @@ class GooglePromptDriver(BasePromptDriver):
                 function_calling_config=types.FunctionCallingConfig(mode=mode),
             )
             params["tools"] = self.__to_google_tools(prompt_stack.tools)
+
+        if prompt_stack.output_schema is not None and self.structured_output_strategy == "native":
+            params["response_mime_type"] = "application/json"
+            params["response_json_schema"] = prompt_stack.to_output_json_schema()
 
         return params
 

--- a/griptape/drivers/prompt/google_prompt_driver.py
+++ b/griptape/drivers/prompt/google_prompt_driver.py
@@ -108,7 +108,11 @@ class GooglePromptDriver(BasePromptDriver):
         parts = response.candidates[0].content.parts if response.candidates and response.candidates[0].content else []
 
         return Message(
-            content=[self.__to_prompt_stack_message_content(part) for part in (parts or [])],
+            content=[
+                self.__to_prompt_stack_message_content(part)
+                for part in (parts or [])
+                if not self.__is_thought_part(part)
+            ],
             role=Message.ASSISTANT_ROLE,
             usage=Message.Usage(
                 input_tokens=usage_metadata.prompt_token_count if usage_metadata else None,
@@ -136,7 +140,12 @@ class GooglePromptDriver(BasePromptDriver):
             usage_metadata = chunk.usage_metadata
 
             parts = chunk.candidates[0].content.parts if chunk.candidates and chunk.candidates[0].content else None
-            content = self.__to_prompt_stack_delta_message_content(parts[0]) if parts else None
+            # Gemini thinking models emit reasoning-only chunks (e.g. a bare `thought_signature`)
+            # with no text or function_call; skip them since Griptape has no thought content type.
+            non_thought_part = (
+                next((part for part in parts if not self.__is_thought_part(part)), None) if parts else None
+            )
+            content = self.__to_prompt_stack_delta_message_content(non_thought_part) if non_thought_part else None
 
             # Only want to output the prompt token count once since it is static each chunk
             if prompt_token_count is None and usage_metadata is not None:
@@ -270,6 +279,11 @@ class GooglePromptDriver(BasePromptDriver):
                 return types.Part.from_text(text=value)
             return value
         raise ValueError(f"Unsupported prompt stack content type: {type(content)}")
+
+    def __is_thought_part(self, content: Part) -> bool:
+        # Gemini thinking models emit reasoning-only parts (e.g. a bare `thought_signature`)
+        # with no text or function_call; Griptape has no thought content type, so callers skip them.
+        return bool((content.thought or content.thought_signature) and not content.text and not content.function_call)
 
     def __to_prompt_stack_message_content(self, content: Part) -> BaseMessageContent:
         if content.text:

--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -334,9 +334,6 @@ class BaseSchema(Schema):
                 # Third party modules
                 "Client": import_optional_dependency("cohere").Client if is_dependency_installed("cohere") else Any,
                 "ClientV2": import_optional_dependency("cohere").ClientV2 if is_dependency_installed("cohere") else Any,
-                "GenerativeModel": import_optional_dependency("google.generativeai").GenerativeModel
-                if is_dependency_installed("google.generativeai")
-                else Any,
                 "boto3": import_optional_dependency("boto3") if is_dependency_installed("boto3") else Any,
                 "Anthropic": import_optional_dependency("anthropic").Anthropic
                 if is_dependency_installed("anthropic")

--- a/griptape/tokenizers/google_tokenizer.py
+++ b/griptape/tokenizers/google_tokenizer.py
@@ -9,7 +9,7 @@ from griptape.utils import import_optional_dependency
 from griptape.utils.decorators import lazy_property
 
 if TYPE_CHECKING:
-    from google.generativeai.generative_models import GenerativeModel
+    from google.genai import Client
 
 
 @define()
@@ -18,16 +18,13 @@ class GoogleTokenizer(BaseTokenizer):
     MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS = {"gemini": 8192}
 
     api_key: str = field(kw_only=True, metadata={"serializable": True})
-    _client: GenerativeModel | None = field(
-        default=None, kw_only=True, alias="client", metadata={"serializable": False}
-    )
+    _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
-    def client(self) -> GenerativeModel:
-        genai = import_optional_dependency("google.generativeai")
-        genai.configure(api_key=self.api_key)
+    def client(self) -> Client:
+        genai = import_optional_dependency("google.genai")
 
-        return genai.GenerativeModel(self.model)
+        return genai.Client(api_key=self.api_key)
 
     def count_tokens(self, text: str) -> int:
-        return self.client.count_tokens(text).total_tokens
+        return self.client.models.count_tokens(model=self.model, contents=text).total_tokens or 0

--- a/griptape/utils/import_utils.py
+++ b/griptape/utils/import_utils.py
@@ -10,7 +10,7 @@ INSTALL_MAPPING = {
     "huggingface_hub": "huggingface-hub",
     "pinecone": "pinecone-client",
     "opensearchpy": "opensearch-py",
-    "google.generativeai": "google-generativeai",
+    "google.genai": "google-genai",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ drivers-prompt-huggingface-hub = [
 drivers-prompt-huggingface-pipeline = ["transformers>=4.41.1"]
 drivers-prompt-amazon-bedrock = ["boto3>=1.34.119", "anthropic>=0.45.1"]
 drivers-prompt-amazon-sagemaker = ["boto3>=1.34.119", "transformers>=4.41.1"]
-drivers-prompt-google = ["google-generativeai>=0.8.2"]
+drivers-prompt-google = ["google-generativeai>=0.8.2", "google-genai>=1.0.0"]
 drivers-prompt-ollama = ["ollama>=0.4.1"]
 drivers-sql = ["sqlalchemy>=2.0.31"]
 drivers-sql-amazon-redshift = ["boto3>=1.34.119"]
@@ -132,6 +132,7 @@ all = [
   "pgvector>=0.3.4",
   "psycopg2-binary>=2.9.9",
   "google-generativeai>=0.8.2",
+  "google-genai>=1.0.0",
   "trafilatura>=2.0",
   "playwright>=1.42",
   "beautifulsoup4>=4.12.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ drivers-prompt-huggingface-hub = [
 drivers-prompt-huggingface-pipeline = ["transformers>=4.41.1"]
 drivers-prompt-amazon-bedrock = ["boto3>=1.34.119", "anthropic>=0.45.1"]
 drivers-prompt-amazon-sagemaker = ["boto3>=1.34.119", "transformers>=4.41.1"]
-drivers-prompt-google = ["google-generativeai>=0.8.2", "google-genai>=1.0.0"]
+drivers-prompt-google = ["google-genai>=1.73.1"]
 drivers-prompt-ollama = ["ollama>=0.4.1"]
 drivers-sql = ["sqlalchemy>=2.0.31"]
 drivers-sql-amazon-redshift = ["boto3>=1.34.119"]
@@ -132,7 +132,7 @@ all = [
   "pgvector>=0.3.4",
   "psycopg2-binary>=2.9.9",
   "google-generativeai>=0.8.2",
-  "google-genai>=1.0.0",
+  "google-genai>=1.73.1",
   "trafilatura>=2.0",
   "playwright>=1.42",
   "beautifulsoup4>=4.12.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ drivers-embedding-huggingface = [
   "transformers>=4.41.1",
 ]
 drivers-embedding-voyageai = ["voyageai>=0.2.1"]
-drivers-embedding-google = ["google-generativeai>=0.8.2"]
+drivers-embedding-google = ["google-genai>=1.73.1"]
 drivers-embedding-cohere = ["cohere>=5.11.2"]
 drivers-embedding-ollama = ["ollama>=0.4.1"]
 drivers-web-scraper-trafilatura = ["trafilatura>=2.0"]
@@ -131,7 +131,6 @@ all = [
   "opensearch-py>=2.3.1",
   "pgvector>=0.3.4",
   "psycopg2-binary>=2.9.9",
-  "google-generativeai>=0.8.2",
   "google-genai>=1.73.1",
   "trafilatura>=2.0",
   "playwright>=1.42",

--- a/tests/unit/configs/drivers/test_google_drivers_config.py
+++ b/tests/unit/configs/drivers/test_google_drivers_config.py
@@ -5,7 +5,8 @@ from griptape.configs.drivers import GoogleDriversConfig
 
 class TestGoogleDriversConfig:
     @pytest.fixture(autouse=True)
-    def mock_openai(self, mocker):
+    def mock_google_clients(self, mocker):
+        mocker.patch("google.genai.Client")
         return mocker.patch("google.generativeai.GenerativeModel")
 
     @pytest.fixture()

--- a/tests/unit/configs/drivers/test_google_drivers_config.py
+++ b/tests/unit/configs/drivers/test_google_drivers_config.py
@@ -6,8 +6,7 @@ from griptape.configs.drivers import GoogleDriversConfig
 class TestGoogleDriversConfig:
     @pytest.fixture(autouse=True)
     def mock_google_clients(self, mocker):
-        mocker.patch("google.genai.Client")
-        return mocker.patch("google.generativeai.GenerativeModel")
+        return mocker.patch("google.genai.Client")
 
     @pytest.fixture()
     def config(self):

--- a/tests/unit/drivers/embedding/test_google_embedding_driver.py
+++ b/tests/unit/drivers/embedding/test_google_embedding_driver.py
@@ -9,15 +9,13 @@ from griptape.drivers.embedding.google import GoogleEmbeddingDriver
 
 class TestGoogleEmbeddingDriver:
     @pytest.fixture(autouse=True)
-    def mock_genai(self, mocker):
-        mock_embed_content = mocker.patch("google.generativeai.embed_content")
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("google.genai.Client")
+        mock_client.return_value.models.embed_content.return_value = MagicMock(
+            embeddings=[MagicMock(values=[0, 1, 0])],
+        )
 
-        mock_value = MagicMock()
-        value = {"embedding": [0, 1, 0]}
-        mock_value.__getitem__.side_effect = value.__getitem__
-        mock_embed_content.return_value = mock_value
-
-        return mock_embed_content
+        return mock_client
 
     def test_init(self):
         assert GoogleEmbeddingDriver()

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -202,9 +202,7 @@ class TestGooglePromptDriver:
         if use_native_tools:
             tools = config.tools
             assert len(tools) == 1
-            declarations = [
-                declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations
-            ]
+            declarations = [declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations]
             assert declarations == self.GOOGLE_TOOLS
 
             if driver.structured_output_strategy == "tool":
@@ -224,9 +222,7 @@ class TestGooglePromptDriver:
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["tool", "rule", "foo"])
-    def test_try_stream(
-        self, mock_stream_client, prompt_stack, messages, use_native_tools, structured_output_strategy
-    ):
+    def test_try_stream(self, mock_stream_client, prompt_stack, messages, use_native_tools, structured_output_strategy):
         # Given
         driver = GooglePromptDriver(
             model="gemini-2.0-flash",
@@ -259,9 +255,7 @@ class TestGooglePromptDriver:
         if use_native_tools:
             tools = config.tools
             assert len(tools) == 1
-            declarations = [
-                declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations
-            ]
+            declarations = [declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations]
             assert declarations == self.GOOGLE_TOOLS
 
             if driver.structured_output_strategy == "tool":

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -1,9 +1,15 @@
 from unittest.mock import MagicMock, Mock
 
 import pytest
-from google.generativeai.protos import FunctionCall, FunctionResponse, Part
-from google.generativeai.types import ContentDict, GenerationConfig
-from google.protobuf.json_format import MessageToDict
+from google.genai.types import (
+    Content,
+    FunctionCall,
+    FunctionCallingConfig,
+    FunctionResponse,
+    GenerateContentConfig,
+    Part,
+    ToolConfig,
+)
 from schema import Schema
 
 from griptape.artifacts import ActionArtifact, GenericArtifact, ImageArtifact, TextArtifact
@@ -50,53 +56,43 @@ class TestGooglePromptDriver:
     ]
 
     @pytest.fixture()
-    def mock_generative_model(self, mocker):
-        mock_generative_model = mocker.patch("google.generativeai.GenerativeModel")
-        mocker.patch("google.protobuf.json_format.MessageToDict").return_value = {
-            "args": {"foo": "bar"},
-        }
-        mock_function_call = MagicMock(
-            type="tool_use", name="bar", id="MockTool_test", _pb=MagicMock(args={"foo": "bar"})
-        )
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("google.genai.Client")
+        mock_function_call = MagicMock(args={"foo": "bar"})
         mock_function_call.name = "MockTool_test"
-        mock_generative_model.return_value.generate_content.return_value = Mock(
-            parts=[
-                Mock(text="model-output", function_call=None),
-                MagicMock(name="foo", text=None, function_call=mock_function_call),
-            ],
+        mock_text_part = MagicMock(text="model-output", function_call=None)
+        mock_function_call_part = MagicMock(text=None, function_call=mock_function_call)
+        mock_candidate = MagicMock(content=MagicMock(parts=[mock_text_part, mock_function_call_part]))
+        mock_client.return_value.models.generate_content.return_value = Mock(
+            candidates=[mock_candidate],
             usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=10),
         )
 
-        return mock_generative_model
+        return mock_client
 
     @pytest.fixture()
-    def mock_stream_generative_model(self, mocker):
-        mock_generative_model = mocker.patch("google.generativeai.GenerativeModel")
-        mocker.patch("google.protobuf.json_format.MessageToDict").return_value = {
-            "args": {"foo": "bar"},
-        }
-        mock_function_call_delta = MagicMock(
-            type="tool_use", name="func call", id="MockTool_test", _pb=MagicMock(args={"foo": "bar"})
-        )
+    def mock_stream_client(self, mocker):
+        mock_client = mocker.patch("google.genai.Client")
+        mock_function_call_delta = MagicMock(args={"foo": "bar"})
         mock_function_call_delta.name = "MockTool_test"
-        mock_generative_model.return_value.generate_content.return_value = iter(
+
+        def make_chunk(*, text, function_call):
+            part = MagicMock(text=text, function_call=function_call)
+            candidate = MagicMock(content=MagicMock(parts=[part]))
+            return MagicMock(
+                candidates=[candidate],
+                usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=5),
+            )
+
+        mock_client.return_value.models.generate_content_stream.return_value = iter(
             [
-                MagicMock(
-                    parts=[MagicMock(text="model-output")],
-                    usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=5),
-                ),
-                MagicMock(
-                    parts=[MagicMock(text=None, function_call=mock_function_call_delta)],
-                    usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=5),
-                ),
-                MagicMock(
-                    parts=[MagicMock(text="model-output", id="3")],
-                    usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=5),
-                ),
+                make_chunk(text="model-output", function_call=None),
+                make_chunk(text=None, function_call=mock_function_call_delta),
+                make_chunk(text="model-output", function_call=None),
             ]
         )
 
-        return mock_generative_model
+        return mock_client
 
     @pytest.fixture(params=[True, False])
     def prompt_stack(self, request):
@@ -141,26 +137,29 @@ class TestGooglePromptDriver:
     @pytest.fixture()
     def messages(self):
         return [
-            {"parts": ["user-input"], "role": "user"},
-            {"parts": ["user-input"], "role": "user"},
-            {"parts": [{"data": b"image-data", "mime_type": "image/png"}], "role": "user"},
-            {"parts": ["assistant-input"], "role": "model"},
-            {
-                "parts": ["thought", Part(function_call=FunctionCall(name="MockTool_test", args={"foo": "bar"}))],
-                "role": "model",
-            },
-            {
-                "parts": [
+            Content(role="user", parts=[Part.from_text(text="user-input")]),
+            Content(role="user", parts=[Part.from_text(text="user-input")]),
+            Content(role="user", parts=[Part.from_bytes(data=b"image-data", mime_type="image/png")]),
+            Content(role="model", parts=[Part.from_text(text="assistant-input")]),
+            Content(
+                role="model",
+                parts=[
+                    Part.from_text(text="thought"),
+                    Part(function_call=FunctionCall(name="MockTool_test", args={"foo": "bar"})),
+                ],
+            ),
+            Content(
+                role="user",
+                parts=[
                     Part(
                         function_response=FunctionResponse(
                             name="MockTool_test", response=TextArtifact("tool-output", id="output").to_dict()
                         )
                     ),
-                    "keep-going",
+                    Part.from_text(text="keep-going"),
                 ],
-                "role": "user",
-            },
-            {"parts": ["video-file"], "role": "user"},
+            ),
+            Content(role="user", parts=[Part.from_text(text="video-file")]),
         ]
 
     def test_init(self):
@@ -169,7 +168,7 @@ class TestGooglePromptDriver:
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["tool", "rule", "foo"])
-    def test_try_run(self, mock_generative_model, prompt_stack, messages, use_native_tools, structured_output_strategy):
+    def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools, structured_output_strategy):
         # Given
         driver = GooglePromptDriver(
             model="gemini-2.0-flash",
@@ -185,25 +184,33 @@ class TestGooglePromptDriver:
         message = driver.try_run(prompt_stack)
 
         # Then
+        mock_client.return_value.models.generate_content.assert_called_once()
+        call_args = mock_client.return_value.models.generate_content.call_args
+        assert call_args.kwargs["model"] == "gemini-2.0-flash"
+        assert messages == call_args.kwargs["contents"]
+        config = call_args.kwargs["config"]
+        assert isinstance(config, GenerateContentConfig)
+        assert config.temperature == 0.1
+        assert config.top_p == 0.5
+        assert config.top_k == 50
+        assert config.stop_sequences == []
+        assert config.max_output_tokens == 10
         if prompt_stack.system_messages:
-            assert mock_generative_model.return_value._system_instruction == ContentDict(
-                role="system", parts=[Part(text="system-input")]
-            )
-        mock_generative_model.return_value.generate_content.assert_called_once()
-        # We can't use assert_called_once_with because we can't compare the FunctionDeclaration objects
-        call_args = mock_generative_model.return_value.generate_content.call_args
-        assert messages == call_args.args[0]
-        generation_config = call_args.kwargs["generation_config"]
-        assert generation_config == GenerationConfig(
-            temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[], max_output_tokens=10
-        )
+            assert config.system_instruction == Content(role="system", parts=[Part.from_text(text="system-input")])
+        else:
+            assert config.system_instruction is None
         if use_native_tools:
-            tool_declarations = call_args.kwargs["tools"]
-            tools = self.GOOGLE_TOOLS
-            assert [MessageToDict(tool_declaration.to_proto()._pb) for tool_declaration in tool_declarations] == tools
+            tools = config.tools
+            assert len(tools) == 1
+            declarations = [
+                declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations
+            ]
+            assert declarations == self.GOOGLE_TOOLS
 
             if driver.structured_output_strategy == "tool":
-                assert call_args.kwargs["tool_config"] == {"function_calling_config": {"mode": "auto"}}
+                assert config.tool_config == ToolConfig(
+                    function_calling_config=FunctionCallingConfig(mode="AUTO"),
+                )
 
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
@@ -218,7 +225,7 @@ class TestGooglePromptDriver:
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["tool", "rule", "foo"])
     def test_try_stream(
-        self, mock_stream_generative_model, prompt_stack, messages, use_native_tools, structured_output_strategy
+        self, mock_stream_client, prompt_stack, messages, use_native_tools, structured_output_strategy
     ):
         # Given
         driver = GooglePromptDriver(
@@ -237,26 +244,30 @@ class TestGooglePromptDriver:
 
         # Then
         event = next(stream)
-        if prompt_stack.system_messages:
-            assert mock_stream_generative_model.return_value._system_instruction == ContentDict(
-                role="system", parts=[Part(text="system-input")]
-            )
-        # We can't use assert_called_once_with because we can't compare the FunctionDeclaration objects
-        mock_stream_generative_model.return_value.generate_content.assert_called_once()
-        call_args = mock_stream_generative_model.return_value.generate_content.call_args
+        mock_stream_client.return_value.models.generate_content_stream.assert_called_once()
+        call_args = mock_stream_client.return_value.models.generate_content_stream.call_args
 
-        assert messages == call_args.args[0]
-        assert call_args.kwargs["stream"] is True
-        assert call_args.kwargs["generation_config"] == GenerationConfig(
-            temperature=0.1, top_p=0.5, top_k=50, stop_sequences=[], max_output_tokens=10
-        )
+        assert call_args.kwargs["model"] == "gemini-2.0-flash"
+        assert messages == call_args.kwargs["contents"]
+        config = call_args.kwargs["config"]
+        assert isinstance(config, GenerateContentConfig)
+        assert config.temperature == 0.1
+        assert config.top_p == 0.5
+        assert config.top_k == 50
+        assert config.stop_sequences == []
+        assert config.max_output_tokens == 10
         if use_native_tools:
-            tool_declarations = call_args.kwargs["tools"]
-            tools = self.GOOGLE_TOOLS
-            assert [MessageToDict(tool_declaration.to_proto()._pb) for tool_declaration in tool_declarations] == tools
+            tools = config.tools
+            assert len(tools) == 1
+            declarations = [
+                declaration.model_dump(exclude_none=True) for declaration in tools[0].function_declarations
+            ]
+            assert declarations == self.GOOGLE_TOOLS
 
             if driver.structured_output_strategy == "tool":
-                assert call_args.kwargs["tool_config"] == {"function_calling_config": {"mode": "auto"}}
+                assert config.tool_config == ToolConfig(
+                    function_calling_config=FunctionCallingConfig(mode="AUTO"),
+                )
         assert isinstance(event.content, TextDeltaMessageContent)
         assert event.content.text == "model-output"
         assert event.usage.input_tokens == 5

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -277,6 +277,57 @@ class TestGooglePromptDriver:
         event = next(stream)
         assert event.usage.output_tokens == 5
 
+    def test_try_run_skips_thought_parts(self, mocker):
+        """Gemini thinking models emit reasoning-only parts (bare `thought_signature`); they must
+        be skipped so they do not appear in `Message.content` and do not raise on conversion."""
+        # Given
+        mock_client = mocker.patch("google.genai.Client")
+        mock_text_part = MagicMock(text="model-output", function_call=None, thought=None, thought_signature=None)
+        mock_thought_part = MagicMock(text="", function_call=None, thought=None, thought_signature=b"sig-bytes")
+        mock_candidate = MagicMock(content=MagicMock(parts=[mock_thought_part, mock_text_part]))
+        mock_client.return_value.models.generate_content.return_value = Mock(
+            candidates=[mock_candidate],
+            usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=10),
+        )
+        driver = GooglePromptDriver(model="gemini-3-pro", api_key="api-key")
+
+        # When
+        message = driver.try_run(PromptStack())
+
+        # Then
+        assert len(message.content) == 1
+        assert message.content[0].artifact.value == "model-output"
+
+    def test_try_stream_skips_thought_chunks(self, mocker):
+        """A chunk whose only part is a thought-only part should yield `content=None` rather than raise."""
+        # Given
+        mock_client = mocker.patch("google.genai.Client")
+
+        def make_chunk(*, text, thought_signature):
+            part = MagicMock(text=text, function_call=None, thought=None, thought_signature=thought_signature)
+            candidate = MagicMock(content=MagicMock(parts=[part]))
+            return MagicMock(
+                candidates=[candidate],
+                usage_metadata=MagicMock(prompt_token_count=5, candidates_token_count=5),
+            )
+
+        mock_client.return_value.models.generate_content_stream.return_value = iter(
+            [
+                make_chunk(text="", thought_signature=b"sig-bytes"),
+                make_chunk(text="model-output", thought_signature=None),
+            ]
+        )
+        driver = GooglePromptDriver(model="gemini-3-pro", api_key="api-key", stream=True)
+
+        # When
+        events = list(driver.try_stream(PromptStack()))
+
+        # Then
+        assert len(events) == 2
+        assert events[0].content is None
+        assert isinstance(events[1].content, TextDeltaMessageContent)
+        assert events[1].content.text == "model-output"
+
     def test_verify_structured_output_strategy(self):
         assert GooglePromptDriver(model="foo", structured_output_strategy="tool")
 

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -293,8 +293,11 @@ class TestGooglePromptDriver:
         assert event.usage.output_tokens == 5
 
     def test_try_run_skips_thought_parts(self, mocker):
-        """Gemini thinking models emit reasoning-only parts (bare `thought_signature`); they must
-        be skipped so they do not appear in `Message.content` and do not raise on conversion."""
+        """Skip reasoning-only parts emitted by Gemini thinking models.
+
+        Such parts carry only a `thought_signature`; they must not appear in `Message.content`
+        and must not raise on conversion.
+        """
         # Given
         mock_client = mocker.patch("google.genai.Client")
         mock_text_part = MagicMock(text="model-output", function_call=None, thought=None, thought_signature=None)
@@ -314,7 +317,7 @@ class TestGooglePromptDriver:
         assert message.content[0].artifact.value == "model-output"
 
     def test_try_stream_skips_thought_chunks(self, mocker):
-        """A chunk whose only part is a thought-only part should yield `content=None` rather than raise."""
+        """A chunk whose only part is thought-only should yield `content=None` rather than raise."""
         # Given
         mock_client = mocker.patch("google.genai.Client")
 

--- a/tests/unit/drivers/prompt/test_google_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_google_prompt_driver.py
@@ -167,7 +167,7 @@ class TestGooglePromptDriver:
         assert driver
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    @pytest.mark.parametrize("structured_output_strategy", ["tool", "rule", "foo"])
+    @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
     def test_try_run(self, mock_client, prompt_stack, messages, use_native_tools, structured_output_strategy):
         # Given
         driver = GooglePromptDriver(
@@ -210,6 +210,13 @@ class TestGooglePromptDriver:
                     function_calling_config=FunctionCallingConfig(mode="AUTO"),
                 )
 
+        if driver.structured_output_strategy == "native":
+            assert config.response_mime_type == "application/json"
+            assert config.response_json_schema == prompt_stack.to_output_json_schema()
+        else:
+            assert config.response_mime_type is None
+            assert config.response_json_schema is None
+
         assert isinstance(message.value[0], TextArtifact)
         assert message.value[0].value == "model-output"
         assert isinstance(message.value[1], ActionArtifact)
@@ -221,7 +228,7 @@ class TestGooglePromptDriver:
         assert message.usage.output_tokens == 10
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
-    @pytest.mark.parametrize("structured_output_strategy", ["tool", "rule", "foo"])
+    @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
     def test_try_stream(self, mock_stream_client, prompt_stack, messages, use_native_tools, structured_output_strategy):
         # Given
         driver = GooglePromptDriver(
@@ -262,6 +269,14 @@ class TestGooglePromptDriver:
                 assert config.tool_config == ToolConfig(
                     function_calling_config=FunctionCallingConfig(mode="AUTO"),
                 )
+
+        if driver.structured_output_strategy == "native":
+            assert config.response_mime_type == "application/json"
+            assert config.response_json_schema == prompt_stack.to_output_json_schema()
+        else:
+            assert config.response_mime_type is None
+            assert config.response_json_schema is None
+
         assert isinstance(event.content, TextDeltaMessageContent)
         assert event.content.text == "model-output"
         assert event.usage.input_tokens == 5
@@ -327,11 +342,3 @@ class TestGooglePromptDriver:
         assert events[0].content is None
         assert isinstance(events[1].content, TextDeltaMessageContent)
         assert events[1].content.text == "model-output"
-
-    def test_verify_structured_output_strategy(self):
-        assert GooglePromptDriver(model="foo", structured_output_strategy="tool")
-
-        with pytest.raises(
-            ValueError, match="GooglePromptDriver does not support `native` structured output strategy."
-        ):
-            GooglePromptDriver(model="foo", structured_output_strategy="native")

--- a/tests/unit/tokenizers/test_google_tokenizer.py
+++ b/tests/unit/tokenizers/test_google_tokenizer.py
@@ -9,11 +9,11 @@ from griptape.tokenizers import GoogleTokenizer
 
 class TestGoogleTokenizer:
     @pytest.fixture(autouse=True)
-    def mock_generative_model(self, mocker):
-        mock_generative_model = mocker.patch("google.generativeai.GenerativeModel")
-        mock_generative_model.return_value.count_tokens.return_value = Mock(total_tokens=5)
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("google.genai.Client")
+        mock_client.return_value.models.count_tokens.return_value = Mock(total_tokens=5)
 
-        return mock_generative_model
+        return mock_client
 
     @pytest.fixture()
     def tokenizer(self, request):

--- a/uv.lock
+++ b/uv.lock
@@ -1518,7 +1518,6 @@ drivers-prompt-cohere = [
 ]
 drivers-prompt-google = [
     { name = "google-genai" },
-    { name = "google-generativeai" },
 ]
 drivers-prompt-huggingface-hub = [
     { name = "huggingface-hub" },
@@ -1682,11 +1681,10 @@ requires-dist = [
     { name = "exa-py", marker = "extra == 'all'", specifier = ">=1.1.4" },
     { name = "exa-py", marker = "extra == 'drivers-web-search-exa'", specifier = ">=1.1.4" },
     { name = "filetype", specifier = ">=1.2" },
-    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
-    { name = "google-genai", marker = "extra == 'drivers-prompt-google'", specifier = ">=1.0.0" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.73.1" },
+    { name = "google-genai", marker = "extra == 'drivers-prompt-google'", specifier = ">=1.73.1" },
     { name = "google-generativeai", marker = "extra == 'all'", specifier = ">=0.8.2" },
     { name = "google-generativeai", marker = "extra == 'drivers-embedding-google'", specifier = ">=0.8.2" },
-    { name = "google-generativeai", marker = "extra == 'drivers-prompt-google'", specifier = ">=0.8.2" },
     { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'drivers-embedding-huggingface'", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'drivers-prompt-huggingface-hub'", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -152,8 +152,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -180,8 +179,7 @@ dependencies = [
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/4a/96f99a61ae299f9e5aa3e765d7342d95ab2e2ba5b69a3ffedb00ef779651/anthropic-0.51.0.tar.gz", hash = "sha256:6f824451277992af079554430d5b2c8ff5bc059cc2c968cdc3f06824437da201", size = 219063, upload-time = "2025-05-07T15:39:22.348Z" }
 wheels = [
@@ -196,8 +194,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126, upload-time = "2025-01-05T13:13:11.095Z" }
 wheels = [
@@ -222,8 +219,7 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "pymongo" },
     { name = "toml" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "uuid6" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/c9/5c9488664f99f2b9738d8e4823f8a0474897f39a17c0676430f548834adb/astrapy-2.0.1.tar.gz", hash = "sha256:3a35ebd7af5c24f0abe400f9b2778dc5e8812c78ae247f97704be27e6cb9dc5a", size = 252460, upload-time = "2025-03-27T17:23:55.462Z" }
@@ -286,8 +282,7 @@ version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
@@ -315,8 +310,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/3b/d99ca10af6cf7d88052bf75b398847dd50eb1603ad73ccfb5a647a15af6d/boto3_stubs-1.37.12.tar.gz", hash = "sha256:3c7974a3c8ad464334d7e6f5a092b9308cb82f23683d2e259c1d8a7dad271c17", size = 98884, upload-time = "2025-03-13T19:29:46.951Z" }
 wheels = [
@@ -376,15 +370,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/6f/710664aac77cf91a663dcb291c2bbdcfe796909115aa5bb03382521359b1/botocore_stubs-1.37.11.tar.gz", hash = "sha256:9b89ba9a98eb9f088a5f82c52488013858092777c17b56265574bbf2d21da422", size = 42119, upload-time = "2025-03-11T20:16:38.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/89/c8a6497055f9ecd0af5c16434c277635a4b365793d54f2d8f2b28aeeb58e/botocore_stubs-1.37.11-py3-none-any.whl", hash = "sha256:bec458a0d054892cdf82466b4d075f30a36fa03ce34f9becbcace5f36ec674bf", size = 65384, upload-time = "2025-03-11T20:16:36.574Z" },
-]
-
-[[package]]
-name = "cachetools"
-version = "5.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
 ]
 
 [[package]]
@@ -573,8 +558,7 @@ dependencies = [
     { name = "requests" },
     { name = "tokenizers" },
     { name = "types-requests" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/33/69c7d1b25a20eafef4197a1444c7f87d5241e936194e54876ea8996157e6/cohere-5.15.0.tar.gz", hash = "sha256:e802d4718ddb0bb655654382ebbce002756a3800faac30296cde7f1bdc6ff2cc", size = 135021, upload-time = "2025-04-15T13:39:51.404Z" }
 wheels = [
@@ -729,7 +713,7 @@ version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
@@ -987,8 +971,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-core" },
     { name = "requests" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/5f/01197145be5be258abdce254010eb300868b85fbf6cf1c6c1538a68caef4/elevenlabs-1.59.0.tar.gz", hash = "sha256:16e735bd594e86d415dd445d249c8cc28b09996cfd627fbc10102c0a84698859", size = 200549, upload-time = "2025-05-15T12:19:28.868Z" }
@@ -1014,8 +997,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytest-mock" },
     { name = "requests" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/c7/bd38d17970d6cbc22693a930dc75168a603c69f3d04a688e4dd18340c757/exa_py-1.13.1.tar.gz", hash = "sha256:c1e8ee82a458a7344102293e0fa272aa3b39a698115e9058f99dda76aa1c2747", size = 22895, upload-time = "2025-05-14T06:25:41.604Z" }
 wheels = [
@@ -1244,16 +1226,20 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.38.0"
+version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/eb/d504ba1daf190af6b204a9d4714d457462b486043744901a6eeea711f913/google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4", size = 270866, upload-time = "2025-01-23T01:05:29.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/47/603554949a37bca5b7f894d51896a9c534b9eab808e2520a748e081669d0/google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a", size = 210770, upload-time = "2025-01-23T01:05:26.572Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
@@ -1270,6 +1256,27 @@ wheels = [
 ]
 
 [[package]]
+name = "google-genai"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+]
+
+[[package]]
 name = "google-generativeai"
 version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1281,8 +1288,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "tqdm" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/40/c42ff9ded9f09ec9392879a8e6538a00b2dc185e834a3392917626255419/google_generativeai-0.8.5-py3-none-any.whl", hash = "sha256:22b420817fb263f8ed520b33285f45976d5b21e904da32b80d4fd20c055123a2", size = 155427, upload-time = "2025-04-17T00:40:00.67Z" },
@@ -1399,6 +1405,7 @@ all = [
     { name = "duckduckgo-search" },
     { name = "elevenlabs" },
     { name = "exa-py" },
+    { name = "google-genai" },
     { name = "google-generativeai" },
     { name = "huggingface-hub" },
     { name = "mail-parser" },
@@ -1510,6 +1517,7 @@ drivers-prompt-cohere = [
     { name = "cohere" },
 ]
 drivers-prompt-google = [
+    { name = "google-genai" },
     { name = "google-generativeai" },
 ]
 drivers-prompt-huggingface-hub = [
@@ -1674,6 +1682,8 @@ requires-dist = [
     { name = "exa-py", marker = "extra == 'all'", specifier = ">=1.1.4" },
     { name = "exa-py", marker = "extra == 'drivers-web-search-exa'", specifier = ">=1.1.4" },
     { name = "filetype", specifier = ">=1.2" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "google-genai", marker = "extra == 'drivers-prompt-google'", specifier = ">=1.0.0" },
     { name = "google-generativeai", marker = "extra == 'all'", specifier = ">=0.8.2" },
     { name = "google-generativeai", marker = "extra == 'drivers-embedding-google'", specifier = ">=0.8.2" },
     { name = "google-generativeai", marker = "extra == 'drivers-prompt-google'", specifier = ">=0.8.2" },
@@ -1987,8 +1997,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tqdm" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/a0/7445e07427a917399db619e3c7383de3cd723c20d3b3a8a527a096c49a44/huggingface_hub-0.31.4.tar.gz", hash = "sha256:5a7bc710b9f9c028aee5b1476867b4ec5c1b92f043cb364d5fdc54354757e4ce", size = 407736, upload-time = "2025-05-19T09:37:13.73Z" }
 wheels = [
@@ -2738,7 +2747,7 @@ dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/81/3575e451682e0ed3c39e9b57d1fd30590cd28a965131ead14bf2efe34a1b/mkdocstrings_python-1.16.5.tar.gz", hash = "sha256:706b28dd0f59249a7c22cc5d517c9521e06c030b57e2a5478e1928a58f900abb", size = 426979, upload-time = "2025-03-10T18:02:48.774Z" }
 wheels = [
@@ -2808,7 +2817,7 @@ name = "multidict"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/be/504b89a5e9ca731cd47487e91c469064f8ae5af93b7259758dcfc2b9c848/multidict-6.1.0.tar.gz", hash = "sha256:22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a", size = 64002, upload-time = "2024-09-09T23:49:38.163Z" }
 wheels = [
@@ -2880,8 +2889,7 @@ name = "mypy-boto3-bedrock-runtime"
 version = "1.37.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/29/9c23ceb80af9d028ddf2bbaea3469017049f1693a620e1ee472482f3ee39/mypy_boto3_bedrock_runtime-1.37.30.tar.gz", hash = "sha256:0dfc1d9910eb14900ca4ae88f09e37dd57ec56a95d355b56f4da3139823dec99", size = 26176, upload-time = "2025-04-08T22:33:21.083Z" }
 wheels = [
@@ -2893,8 +2901,7 @@ name = "mypy-boto3-dynamodb"
 version = "1.37.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/fc/95068ae41a63c19e43e0774dcbeec70523dcf35f948ad66f3375a887c614/mypy_boto3_dynamodb-1.37.12.tar.gz", hash = "sha256:0e4d7a16fb9dba7aab7ac9ba8ff3721f9696a8484b1eed693b7949164b7805ba", size = 47470, upload-time = "2025-03-13T19:24:59.194Z" }
 wheels = [
@@ -2906,8 +2913,7 @@ name = "mypy-boto3-iam"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/8c/48b46381bfe3f1a07e5edaf17b751101e7267d92908525eee4ca28ec3599/mypy_boto3_iam-1.37.0.tar.gz", hash = "sha256:165183194bc79af84f96b8d787bd78d5820e261d8fe2af1b69620d6104dfc4e5", size = 86264, upload-time = "2025-02-24T22:25:03.807Z" }
 wheels = [
@@ -2919,8 +2925,7 @@ name = "mypy-boto3-iot-data"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/6d/1afdb4aa24ac441f0ee0d17c88fdd6268ebfaba50c232eef3d325bb9449d/mypy_boto3_iot_data-1.37.0.tar.gz", hash = "sha256:11979ad2fa37ab015b93512f56908904f022cfff0fd3259e4442abee67d99e58", size = 16791, upload-time = "2025-02-24T22:25:30.554Z" }
 wheels = [
@@ -2932,8 +2937,7 @@ name = "mypy-boto3-opensearch"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/81/41bb75a7f9c0c729bcdbba71768b78dcf5a03fddf4476cef728dc316e0e6/mypy_boto3_opensearch-1.37.0.tar.gz", hash = "sha256:8be101095e0020e6926a6d0c62bb67a83f813efaf90ab683ccea309c9d7c5662", size = 44898, upload-time = "2025-02-24T22:32:24.169Z" }
 wheels = [
@@ -2945,8 +2949,7 @@ name = "mypy-boto3-redshift-data"
 version = "1.37.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/45/e3ecccd97a1bb9a57ae75cba6991423f68688abc112bd609a3b3e9b72036/mypy_boto3_redshift_data-1.37.8.tar.gz", hash = "sha256:03b95a80e88032196c26a83bc10426ef997974050adb6c77a8adcff7caf881b8", size = 19463, upload-time = "2025-03-06T21:11:01.258Z" }
 wheels = [
@@ -2958,8 +2961,7 @@ name = "mypy-boto3-s3"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/51/14726c0bef944a8a6833bf1aae1c78f60868ffb4461869b387c0648bc325/mypy_boto3_s3-1.37.0.tar.gz", hash = "sha256:bc6ec4cbbd8e0206143d9b1f24927e086a2467a2c6a641feb978599d75954e82", size = 73697, upload-time = "2025-02-24T22:37:21.679Z" }
 wheels = [
@@ -2971,8 +2973,7 @@ name = "mypy-boto3-sagemaker-runtime"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/92/6b14ddbd41de8893a119214f4fef27ccbc591132daae0edd8303d03b2147/mypy_boto3_sagemaker_runtime-1.37.0.tar.gz", hash = "sha256:1503eeae9a1f131c0c4d6e309845f90c083c8eadb80f80ad4444876815efd477", size = 15764, upload-time = "2025-02-24T22:37:46.97Z" }
 wheels = [
@@ -2984,8 +2985,7 @@ name = "mypy-boto3-sqs"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/c9/ebbd0efd7225b3eac16b409ac9a6f14250bc00d123b04c9255e7a482afa3/mypy_boto3_sqs-1.37.0.tar.gz", hash = "sha256:ed56df72494425d4e7d0e048f2321cc17514fa3bbedfc410bbb8b709c4bff564", size = 23508, upload-time = "2025-02-24T22:38:47.194Z" }
 wheels = [
@@ -3290,8 +3290,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/cf/4901077dbbfd0d82a814d721600fa0c3a61a093d7f0bf84d0e4732448dc9/openai-1.79.0.tar.gz", hash = "sha256:e3b627aa82858d3e42d16616edc22aa9f7477ee5eb3e6819e9f44a961d899a4c", size = 444736, upload-time = "2025-05-16T19:49:59.738Z" }
 wheels = [
@@ -3405,8 +3404,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/12/909b98a7d9b110cce4b28d49b2e311797cffdce180371f35eba13a72dd00/opentelemetry_sdk-1.33.1.tar.gz", hash = "sha256:85b9fcf7c3d23506fbc9692fd210b8b025a1920535feec50bd54ce203d57a531", size = 161885, upload-time = "2025-05-16T18:52:52.832Z" }
 wheels = [
@@ -3619,8 +3617,7 @@ dependencies = [
     { name = "certifi" },
     { name = "pinecone-plugin-interface" },
     { name = "python-dateutil" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/acbfc236698c2b11d53711a86a35f533423b3553e0859255cdd2ced3c6c3/pinecone-6.0.1.tar.gz", hash = "sha256:2fbca13153d32d1a012a12eb10472bd5dbb645be8e441381ad88349d8b2198bb", size = 174677, upload-time = "2025-02-10T14:57:22.839Z" }
@@ -3993,8 +3990,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540, upload-time = "2025-04-29T20:38:55.02Z" }
@@ -4007,8 +4003,7 @@ name = "pydantic-core"
 version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -4095,8 +4090,7 @@ name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
@@ -4231,8 +4225,7 @@ version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
 wheels = [
@@ -4253,7 +4246,7 @@ name = "pypdf"
 version = "6.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b8/9f/ca96abf18683ca12602065e4ed2bec9050b672c87d317f1079abc7b6d993/pypdf-6.10.0.tar.gz", hash = "sha256:4c5a48ba258c37024ec2505f7e8fd858525f5502784a2e1c8d415604af29f6ef", size = 5314833, upload-time = "2026-04-10T09:34:57.102Z" }
 wheels = [
@@ -4266,8 +4259,7 @@ version = "1.1.408"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
@@ -4640,23 +4632,11 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711, upload-time = "2022-07-20T10:28:36.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315, upload-time = "2022-07-20T10:28:34.978Z" },
 ]
 
 [[package]]
@@ -4925,8 +4905,7 @@ dependencies = [
     { name = "requests" },
     { name = "sortedcontainers" },
     { name = "tomlkit" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/b1/11c03e05bd2a2da590c1b77c8455f40eb505888a2683c4e41b487d79568c/snowflake_connector_python-4.4.0.tar.gz", hash = "sha256:648f49029d699591af0f253e81c5bf60efc4411c7b0149ef074a59a038210a3b", size = 924803, upload-time = "2026-03-25T23:31:27.368Z" }
 wheels = [
@@ -5015,8 +4994,7 @@ version = "2.0.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }
 wheels = [
@@ -5295,8 +5273,7 @@ dependencies = [
     { name = "setuptools" },
     { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/f2/c1690994afe461aae2d0cac62251e6802a703dec0a6c549c02ecd0de92a9/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e", size = 80526521, upload-time = "2026-03-23T18:12:06.86Z" },
@@ -5453,25 +5430,8 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
-]
-
-[[package]]
-name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -5482,8 +5442,7 @@ name = "typing-inspection"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
 wheels = [
@@ -5563,7 +5522,7 @@ dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1172,59 +1172,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-ai-generativelanguage"
-version = "0.6.15"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d1/48fe5d7a43d278e9f6b5ada810b0a3530bbeac7ed7fcbcd366f932f05316/google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3", size = 1375443, upload-time = "2025-01-13T21:50:47.459Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/a3/67b8a6ff5001a1d8864922f2d6488dc2a14367ceb651bc3f09a947f2f306/google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c", size = 1327356, upload-time = "2025-01-13T21:50:44.174Z" },
-]
-
-[[package]]
-name = "google-api-core"
-version = "2.24.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/5c/085bcb872556934bb119e5e09de54daa07873f6866b8f0303c49e72287f7/google_api_core-2.24.2.tar.gz", hash = "sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696", size = 163516, upload-time = "2025-03-10T15:55:26.201Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/95/f472d85adab6e538da2025dfca9e976a0d125cc0af2301f190e77b76e51c/google_api_core-2.24.2-py3-none-any.whl", hash = "sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9", size = 160061, upload-time = "2025-03-10T15:55:24.386Z" },
-]
-
-[package.optional-dependencies]
-grpc = [
-    { name = "grpcio" },
-    { name = "grpcio-status" },
-]
-
-[[package]]
-name = "google-api-python-client"
-version = "2.164.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-auth-httplib2" },
-    { name = "httplib2" },
-    { name = "uritemplate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/5b/4ed16fac5ef6928d0c1ca0fba42f27e73938f04729ef97e63d7a7bb5fd6d/google_api_python_client-2.164.0.tar.gz", hash = "sha256:116f5a05dfb95ed7f7ea0d0f561fc5464146709c583226cc814690f9bb221492", size = 12595711, upload-time = "2025-03-12T22:20:51.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/0d/4eacf5bff40a42e6be3086b85164f0624fee9724c11bb2c79305fbc2f355/google_api_python_client-2.164.0-py2.py3-none-any.whl", hash = "sha256:b2037c3d280793c8d5180b04317b16be4acd5f77af5dfa7213ace32d140a9ffe", size = 13106781, upload-time = "2025-03-12T22:20:47.947Z" },
-]
-
-[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,19 +1187,6 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
-]
-
-[[package]]
-name = "google-auth-httplib2"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "httplib2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842, upload-time = "2023-12-12T17:40:30.722Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/8a/fe34d2f3f9470a27b01c9e76226965863f153d5fbe276f83608562e49c04/google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d", size = 9253, upload-time = "2023-12-12T17:40:13.055Z" },
 ]
 
 [[package]]
@@ -1274,24 +1208,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
-]
-
-[[package]]
-name = "google-generativeai"
-version = "0.8.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-ai-generativelanguage" },
-    { name = "google-api-core" },
-    { name = "google-api-python-client" },
-    { name = "google-auth" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/40/c42ff9ded9f09ec9392879a8e6538a00b2dc185e834a3392917626255419/google_generativeai-0.8.5-py3-none-any.whl", hash = "sha256:22b420817fb263f8ed520b33285f45976d5b21e904da32b80d4fd20c055123a2", size = 155427, upload-time = "2025-04-17T00:40:00.67Z" },
 ]
 
 [[package]]
@@ -1406,7 +1322,6 @@ all = [
     { name = "elevenlabs" },
     { name = "exa-py" },
     { name = "google-genai" },
-    { name = "google-generativeai" },
     { name = "huggingface-hub" },
     { name = "mail-parser" },
     { name = "markdownify" },
@@ -1447,7 +1362,7 @@ drivers-embedding-cohere = [
     { name = "cohere" },
 ]
 drivers-embedding-google = [
-    { name = "google-generativeai" },
+    { name = "google-genai" },
 ]
 drivers-embedding-huggingface = [
     { name = "huggingface-hub" },
@@ -1682,9 +1597,8 @@ requires-dist = [
     { name = "exa-py", marker = "extra == 'drivers-web-search-exa'", specifier = ">=1.1.4" },
     { name = "filetype", specifier = ">=1.2" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.73.1" },
+    { name = "google-genai", marker = "extra == 'drivers-embedding-google'", specifier = ">=1.73.1" },
     { name = "google-genai", marker = "extra == 'drivers-prompt-google'", specifier = ">=1.73.1" },
-    { name = "google-generativeai", marker = "extra == 'all'", specifier = ">=0.8.2" },
-    { name = "google-generativeai", marker = "extra == 'drivers-embedding-google'", specifier = ">=0.8.2" },
     { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'drivers-embedding-huggingface'", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'drivers-prompt-huggingface-hub'", specifier = ">=0.28.1" },
@@ -1870,20 +1784,6 @@ wheels = [
 ]
 
 [[package]]
-name = "grpcio-status"
-version = "1.71.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/53/a911467bece076020456401f55a27415d2d70d3bc2c37af06b44ea41fc5c/grpcio_status-1.71.0.tar.gz", hash = "sha256:11405fed67b68f406b3f3c7c5ae5104a79d2d309666d10d61b152e91d28fb968", size = 13669, upload-time = "2025-03-10T19:29:00.901Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/d6/31fbc43ff097d8c4c9fc3df741431b8018f67bf8dfbe6553a555f6e5f675/grpcio_status-1.71.0-py3-none-any.whl", hash = "sha256:843934ef8c09e3e858952887467f8256aac3910c55f077a359a65b2b3cde3e68", size = 14424, upload-time = "2025-03-10T19:27:04.967Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1941,18 +1841,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httplib2"
-version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116, upload-time = "2023-03-21T22:29:37.214Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854, upload-time = "2023-03-21T22:29:35.683Z" },
 ]
 
 [[package]]
@@ -3844,18 +3732,6 @@ wheels = [
 ]
 
 [[package]]
-name = "proto-plus"
-version = "1.26.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
-]
-
-[[package]]
 name = "protobuf"
 version = "5.29.6"
 source = { registry = "https://pypi.org/simple" }
@@ -4228,15 +4104,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a", size = 1067694, upload-time = "2024-12-31T20:59:46.157Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1", size = 107716, upload-time = "2024-12-31T20:59:42.738Z" },
 ]
 
 [[package]]
@@ -5483,15 +5350,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
-]
-
-[[package]]
-name = "uritemplate"
-version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0", size = 273898, upload-time = "2021-10-13T11:15:14.84Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c0/7461b49cd25aeece13766f02ee576d1db528f1c37ce69aee300e075b485b/uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e", size = 10356, upload-time = "2021-10-13T11:15:12.316Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrates every Google-backed driver off the deprecated `google-generativeai` package and onto the unified `google-genai` SDK (`from google import genai`), which is now the single Google dependency. `google-generativeai` is dropped from all extras, the `all` extra, the base schema resolver's `localns`, and the `INSTALL_MAPPING` for optional-dependency error messages.

`GooglePromptDriver` now uses `genai.Client(api_key=...)` and drives requests through `client.models.generate_content` / `generate_content_stream`, passing config via `types.GenerateContentConfig` (which also carries `system_instruction`, `tools`, and `tool_config`). This removes the `_system_instruction` mutation hack and the `MessageToDict` dance for `function_call.args`. `FunctionCallingConfig.mode` is uppercase in the new SDK. Native structured output is wired up too: when `structured_output_strategy="native"`, the driver sets `response_mime_type="application/json"` and forwards the prompt stack's JSON schema via `response_json_schema`. Gemini thinking models sometimes emit reasoning-only parts carrying just a `thought_signature`; those are filtered out in both `try_run` and `try_stream` since Griptape has no thought content type.

`GoogleTokenizer` uses the same client and calls `client.models.count_tokens(model=..., contents=...)`.

`GoogleEmbeddingDriver` moves to `client.models.embed_content(..., config=types.EmbedContentConfig(task_type=..., title=...))` and reads the vector from `response.embeddings[0].values`. It also gains a lazy `client` attribute mirroring the prompt driver and tokenizer, so callers can inject a custom `Client` for Vertex AI. End-to-end verified against Vertex with `gemini-embedding-001` returning 3072-dim vectors for `str`, `TextArtifact`, and both `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY` task types.

The `talk_to_a_video` recipe switches from `google.generativeai.files.{upload_file,get_file}` to `client.files.{upload,get}` via the prompt driver's client. Public attrs surfaces of all three drivers are unchanged.

Closes #1624