### PR TITLE
fix: pass GH_RELEASE_PAT via token input in release workflow

### DIFF
--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.10.0)"
+        required: true
 
 permissions:
   contents: write
@@ -17,6 +22,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           make_latest: true
           prerelease: false

--- a/.github/workflows/create-stable-release.yml
+++ b/.github/workflows/create-stable-release.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - name: Create release
         uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
           generate_release_notes: true
           make_latest: true
           prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The stable release workflow was passing the PAT via the `GITHUB_TOKEN` env var, but `softprops/action-gh-release@v3` reads its token from the `with.token` input. The env var was being ignored, so releases were being created under the default `GITHUB_TOKEN` (github-actions bot) instead of the intended PAT identity, which is why v1.10.0 went out with github-actions permissions.

Mirrors the fix applied in `griptape-nodes` in 6b2dba8.