### PR TITLE
fix(drivers-prompt-anthropic): omit sampling params for claude-opus-4-7

### DIFF
--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -121,13 +121,20 @@ class AnthropicPromptDriver(BasePromptDriver):
         system_messages = prompt_stack.system_messages
         system_message = system_messages[0].to_text() if system_messages else None
 
+        # Some models (e.g. claude-opus-4-7) deprecate all sampling parameters
+        _no_sampling = self.model == "claude-opus-4-7"
+
         params = {
             "model": self.model,
             "stop_sequences": self.tokenizer.stop_sequences,
             "max_tokens": self.max_tokens,
             "messages": messages,
-            **({"top_p": self.top_p} if self.top_p is not None else {"temperature": self.temperature}),
-            **({"top_k": self.top_k} if self.top_k is not None else {}),
+            **(
+                {}
+                if _no_sampling
+                else ({"top_p": self.top_p} if self.top_p is not None else {"temperature": self.temperature})
+            ),
+            **({"top_k": self.top_k} if (self.top_k is not None and not _no_sampling) else {}),
             **({"system": system_message} if system_message else {}),
             **self.extra_params,
         }

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -86,6 +86,19 @@ class AnthropicPromptDriver(BasePromptDriver):
 
         return value
 
+    @property
+    def supports_temperature(self) -> bool:
+        # claude-opus-4-7 and its dated variants deprecate sampling parameters
+        return not self.model.startswith("claude-opus-4-7")
+
+    @property
+    def supports_top_p(self) -> bool:
+        return not self.model.startswith("claude-opus-4-7")
+
+    @property
+    def supports_top_k(self) -> bool:
+        return not self.model.startswith("claude-opus-4-7")
+
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         params = self._base_params(prompt_stack)
@@ -121,20 +134,20 @@ class AnthropicPromptDriver(BasePromptDriver):
         system_messages = prompt_stack.system_messages
         system_message = system_messages[0].to_text() if system_messages else None
 
-        # Some models (e.g. claude-opus-4-7) deprecate all sampling parameters
-        _no_sampling = self.model == "claude-opus-4-7"
+        if self.top_p is not None and self.supports_top_p:
+            sampling_params = {"top_p": self.top_p}
+        elif self.supports_temperature:
+            sampling_params = {"temperature": self.temperature}
+        else:
+            sampling_params = {}
 
         params = {
             "model": self.model,
             "stop_sequences": self.tokenizer.stop_sequences,
             "max_tokens": self.max_tokens,
             "messages": messages,
-            **(
-                {}
-                if _no_sampling
-                else ({"top_p": self.top_p} if self.top_p is not None else {"temperature": self.temperature})
-            ),
-            **({"top_k": self.top_k} if (self.top_k is not None and not _no_sampling) else {}),
+            **sampling_params,
+            **({"top_k": self.top_k} if self.top_k is not None and self.supports_top_k else {}),
             **({"system": system_message} if system_message else {}),
             **self.extra_params,
         }

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -459,3 +459,63 @@ class TestAnthropicPromptDriver:
             ValueError, match="AnthropicPromptDriver does not support `native` structured output strategy."
         ):
             AnthropicPromptDriver(model="foo", structured_output_strategy="native")
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-3-haiku", True),
+            ("claude-3-opus", True),
+            ("claude-sonnet-4-5", True),
+            ("claude-opus-4-7", False),
+            ("claude-opus-4-7-20251101", False),
+        ],
+    )
+    def test_supports_temperature(self, model, expected):
+        driver = AnthropicPromptDriver(model=model, api_key="api-key")
+        assert driver.supports_temperature == expected
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-3-haiku", True),
+            ("claude-3-opus", True),
+            ("claude-sonnet-4-5", True),
+            ("claude-opus-4-7", False),
+            ("claude-opus-4-7-20251101", False),
+        ],
+    )
+    def test_supports_top_p(self, model, expected):
+        driver = AnthropicPromptDriver(model=model, api_key="api-key")
+        assert driver.supports_top_p == expected
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-3-haiku", True),
+            ("claude-3-opus", True),
+            ("claude-sonnet-4-5", True),
+            ("claude-opus-4-7", False),
+            ("claude-opus-4-7-20251101", False),
+        ],
+    )
+    def test_supports_top_k(self, model, expected):
+        driver = AnthropicPromptDriver(model=model, api_key="api-key")
+        assert driver.supports_top_k == expected
+
+    def test_try_run_omits_sampling_params_for_opus_4_7(self, mock_client, prompt_stack, messages):
+        # Given
+        driver = AnthropicPromptDriver(
+            model="claude-opus-4-7",
+            api_key="api-key",
+            top_p=0.9,
+            top_k=100,
+        )
+
+        # When
+        driver.try_run(prompt_stack)
+
+        # Then
+        call_kwargs = mock_client.return_value.messages.create.call_args
+        assert "temperature" not in call_kwargs.kwargs
+        assert "top_p" not in call_kwargs.kwargs
+        assert "top_k" not in call_kwargs.kwargs


### PR DESCRIPTION
## Summary

- `AnthropicPromptDriver._base_params()` unconditionally emits either `top_p` or `temperature` (and optionally `top_k`) regardless of which model is in use
- Claude Opus 4.7 deprecates all three sampling parameters and returns a 400 error if any are set to a non-default value (per [Anthropic migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide))
- This fix skips all sampling params when the model is `claude-opus-4-7`

## Test plan

- [ ] Run existing `AnthropicPromptDriver` tests
- [ ] Verify a request with `model="claude-opus-4-7"` no longer sends `temperature`, `top_p`, or `top_k`
- [ ] Verify other models (e.g. `claude-sonnet-4-6`) still send sampling params as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)