### PR TITLE
fix(tests): stop hitting network and register .webp mime type

### DIFF
--- a/griptape/utils/file_utils.py
+++ b/griptape/utils/file_utils.py
@@ -7,6 +7,10 @@ import mimetypes
 
 import filetype
 
+# Some platforms (notably Windows) do not register `.webp` as `image/webp` by default,
+# so add it explicitly to keep `mimetypes.guess_type` consistent across platforms.
+mimetypes.add_type("image/webp", ".webp")
+
 
 def get_mime_type(file_path_or_bytes: str | bytes) -> str:
     """Attempt to determine the MIME type of a file or bytes.

--- a/tests/unit/tools/test_web_scraper.py
+++ b/tests/unit/tools/test_web_scraper.py
@@ -4,6 +4,10 @@ from griptape.artifacts import ListArtifact
 
 
 class TestWebScraper:
+    @pytest.fixture(autouse=True)
+    def _mock_trafilatura_fetch_url(self, mocker):
+        mocker.patch("trafilatura.fetch_url", return_value="<html>foobar</html>")
+
     @pytest.fixture()
     def scraper(self):
         from griptape.tools import WebScraperTool


### PR DESCRIPTION
Two unit test failures were red on `main` for the same SHA (`b2af96c6`), one on Linux and one on Windows. Both are flaky/environmental rather than real product bugs, but they keep the required check status red on every push.

`tests/unit/tools/test_web_scraper.py::TestWebScraper::test_get_content` was making a real HTTP request to `https://github.com/griptape-ai/griptape` through trafilatura. When github.com returned 502s (as it did in the failing run), the tool returned an `ErrorArtifact` and the assertion blew up. The sibling `tests/unit/loaders/test_web_loader.py` already covers this exact path with `mocker.patch("trafilatura.fetch_url", ...)`, so this change adopts the same fixture so the tool test stays a unit test and never depends on the network.

`tests/unit/utils/test_file_utils.py::TestFileUtils::test_get_mime_type_file_path[small.webp-image/webp]` was failing only on Windows with `'application/octet-stream' == 'image/webp'`. `get_mime_type` uses `mimetypes.guess_type` for paths, which on Windows reads from the registry and does not always know about `.webp`. Registering `image/webp` once at module import time via `mimetypes.add_type` is the standard fix and keeps the mapping consistent across platforms without changing the function's contract.

Scope is intentionally limited to these two flakes. The `Docs Integration Tests` workflow has been red for weeks for separate reasons (auth/secret drift on third-party providers plus a couple of stale doc snippets), and is not addressed here.
