### PR TITLE
feat: add Astraflow prompt driver (OpenAI-compatible)

### DIFF
--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -14,6 +14,7 @@ from .prompt.google import GooglePromptDriver
 from .prompt.dummy import DummyPromptDriver
 from .prompt.ollama import OllamaPromptDriver
 from .prompt.grok import GrokPromptDriver
+from .prompt.astraflow import AstraflowPromptDriver
 from .prompt.griptape_cloud import GriptapeCloudPromptDriver
 from .prompt.perplexity import PerplexityPromptDriver
 
@@ -144,6 +145,7 @@ __all__ = [
     "AmazonSageMakerJumpstartEmbeddingDriver",
     "AmazonSageMakerJumpstartPromptDriver",
     "AmazonSqsEventListenerDriver",
+    "AstraflowPromptDriver",
     "AnthropicPromptDriver",
     "AstraDbVectorStoreDriver",
     "AwsIotCoreEventListenerDriver",

--- a/griptape/drivers/prompt/astraflow/__init__.py
+++ b/griptape/drivers/prompt/astraflow/__init__.py
@@ -1,0 +1,5 @@
+from griptape.drivers.prompt.astraflow_prompt_driver import AstraflowPromptDriver
+
+__all__ = [
+    "AstraflowPromptDriver",
+]

--- a/griptape/drivers/prompt/astraflow_prompt_driver.py
+++ b/griptape/drivers/prompt/astraflow_prompt_driver.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from attrs import define, field
+
+from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
+
+
+@define
+class AstraflowPromptDriver(OpenAiChatPromptDriver):
+    """Prompt Driver for Astraflow (UCloud / 优刻得).
+
+    Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+    Set ``base_url`` to ``https://api.modelverse.cn/v1`` and use ``ASTRAFLOW_CN_API_KEY``
+    to use the China endpoint instead of the global endpoint.
+    """
+
+    base_url: str = field(default="https://api-us-ca.umodelverse.ai/v1", kw_only=True, metadata={"serializable": True})


### PR DESCRIPTION
## Summary

Adds support for [Astraflow](https://www.modelverse.cn/) (by UCloud / 优刻得), an OpenAI-compatible AI model aggregation platform supporting 200+ models.

## What's added

- `griptape/drivers/prompt/astraflow_prompt_driver.py` — `AstraflowPromptDriver`, a thin subclass of `OpenAiChatPromptDriver` that defaults `base_url` to Astraflow's global endpoint (`https://api-us-ca.umodelverse.ai/v1`).
- `griptape/drivers/prompt/astraflow/__init__.py` — provider subpackage following the existing convention (mirrors the layout used by `grok`, `perplexity`, etc.).
- Registers `AstraflowPromptDriver` in the legacy `griptape.drivers` re-export module for parity with other providers.

## Why a thin subclass?

Astraflow exposes an OpenAI-compatible REST API, so — like the existing `GrokPromptDriver` and `PerplexityPromptDriver` — the integration is just a different `base_url`. No new SDK or transport code is needed.

## Usage

```python
import os
from griptape.drivers.prompt.astraflow import AstraflowPromptDriver

# Global endpoint (default)
driver = AstraflowPromptDriver(
    api_key=os.environ["ASTRAFLOW_API_KEY"],
    model="gpt-4o-mini",
)

# China endpoint
driver = AstraflowPromptDriver(
    api_key=os.environ["ASTRAFLOW_CN_API_KEY"],
    base_url="https://api.modelverse.cn/v1",
    model="gpt-4o-mini",
)
```

## Endpoints

| Region | Base URL | API key env var |
|---|---|---|
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |
