### PR TITLE
fix(anthropic): accept ImageUrlArtifact in tool results

### DIFF
--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -238,6 +238,11 @@ class AnthropicPromptDriver(BasePromptDriver):
                 "type": "image",
                 "source": {"type": "base64", "media_type": artifact.mime_type, "data": artifact.base64},
             }
+        if isinstance(artifact, ImageUrlArtifact):
+            return {
+                "type": "image",
+                "source": {"type": "url", "url": artifact.value},
+            }
         if isinstance(artifact, (TextArtifact, ErrorArtifact, InfoArtifact)):
             return {"type": "text", "text": artifact.to_text()}
         raise ValueError(f"Unsupported tool result artifact type: {type(artifact)}")

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -211,6 +211,7 @@ class TestAnthropicPromptDriver:
                                 [
                                     TextArtifact("tool-output"),
                                     ImageArtifact(value=b"image-data", format="png", width=100, height=100),
+                                    ImageUrlArtifact(value="tool-image-url"),
                                 ]
                             ),
                         )
@@ -284,6 +285,10 @@ class TestAnthropicPromptDriver:
                             {"text": "tool-output", "type": "text"},
                             {
                                 "source": {"data": "aW1hZ2UtZGF0YQ==", "media_type": "image/png", "type": "base64"},
+                                "type": "image",
+                            },
+                            {
+                                "source": {"type": "url", "url": "tool-image-url"},
                                 "type": "image",
                             },
                         ],


### PR DESCRIPTION
Closes #2186

The user-message image path in `AnthropicPromptDriver` already serializes `ImageUrlArtifact` as an `{"type": "image", "source": {"type": "url", ...}}` block, but the tool-result path only accepted `ImageArtifact`, so any tool that returned a hosted-image artifact (image generation tools, anything that hands back a static-files URL) crashed the turn the moment Claude tried to read the result. Mirroring the existing user-message branch keeps the two code paths in lockstep and avoids forcing tool authors to download-and-base64 every URL they want to surface back to the model.

Anthropic's tool_result content blocks accept the same image schema as user content, so the URL source is valid against the API; no inlining required.
