### PR TITLE
docs: clarify SummaryConversationMemory interaction with Chat/Conversation

### DIFF
--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -32,18 +32,18 @@ class SummaryConversationMemory(BaseConversationMemory):
       by the generated summary. This is expected behavior -- the runs list preserves the
       full history for inspection, while the summary is used internally for prompt context.
 
-    - **Chat utility** (``griptape.utils.Chat``): Calls ``agent.run()`` which uses
+    - **Chat utility** (``griptape.utils.Chat``): Calls ``Structure.run()``, which invokes
       ``to_prompt_stack()`` internally. This means only the summary and the unsummarized
       recent runs (those within ``offset``) are sent to the LLM as context.
 
     Attributes:
-        offset: Number of recent runs to keep unsummarized. When a new run is added,
-            runs older than ``offset`` beyond the current summary index are summarized
+        offset: Maximum number of recent runs to keep unsummarized. When a new run is
+            added and the count of unsummarized runs exceeds ``offset``, the oldest excess runs are summarized
             into a single condensed summary string. Defaults to 1.
-        autoprune: Inherited from ``BaseConversationMemory``. When enabled, the system
-            automatically limits the number of runs included in the prompt stack to fit
-            within the token limit. This does **not** remove runs from ``self.runs`` -- it
-            only controls how many are sent to the LLM.
+        autoprune: Inherited from ``BaseConversationMemory``. When enabled,
+            ``add_to_prompt_stack()`` further trims the prompt context to fit within
+            the model's token limit, on top of the summary/offset pruning already
+            performed by ``to_prompt_stack()``. Does not remove runs from ``self.runs``.
     """
 
     offset: int = field(default=1, kw_only=True, metadata={"serializable": True})

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -44,6 +44,7 @@ class SummaryConversationMemory(BaseConversationMemory):
             ``add_to_prompt_stack()`` further trims the prompt context to fit within
             the model's token limit, on top of the summary/offset pruning already
             performed by ``to_prompt_stack()``. Does not remove runs from ``self.runs``.
+
     """
 
     offset: int = field(default=1, kw_only=True, metadata={"serializable": True})

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 
 @define
 class SummaryConversationMemory(BaseConversationMemory):
-    """Summary conversation memory that maintains a condensed summary of historical conversation
-    runs while keeping a configurable number of the most recent runs in full detail.
+    """Conversation memory that automatically summarizes older runs, keeping a configurable number of recent runs in full detail.
 
     The memory stores **all** runs in ``self.runs`` and automatically generates an LLM-powered
     summary of older runs as new ones are added. Only the summary and the most recent runs

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -44,7 +44,6 @@ class SummaryConversationMemory(BaseConversationMemory):
             ``add_to_prompt_stack()`` further trims the prompt context to fit within
             the model's token limit, on top of the summary/offset pruning already
             performed by ``to_prompt_stack()``. Does not remove runs from ``self.runs``.
-
     """
 
     offset: int = field(default=1, kw_only=True, metadata={"serializable": True})

--- a/griptape/memory/structure/summary_conversation_memory.py
+++ b/griptape/memory/structure/summary_conversation_memory.py
@@ -17,6 +17,35 @@ if TYPE_CHECKING:
 
 @define
 class SummaryConversationMemory(BaseConversationMemory):
+    """Summary conversation memory that maintains a condensed summary of historical conversation
+    runs while keeping a configurable number of the most recent runs in full detail.
+
+    The memory stores **all** runs in ``self.runs`` and automatically generates an LLM-powered
+    summary of older runs as new ones are added. Only the summary and the most recent runs
+    (controlled by ``offset``) are included in the prompt context via ``to_prompt_stack()``.
+
+    Note on display utilities:
+
+    - **Conversation utility** (``griptape.utils.Conversation``): Displays **all** runs stored
+      in memory, not just the summary or the unsummarized portion. When used with
+      ``SummaryConversationMemory``, it prints every Q/A pair from ``self.runs`` followed
+      by the generated summary. This is expected behavior -- the runs list preserves the
+      full history for inspection, while the summary is used internally for prompt context.
+
+    - **Chat utility** (``griptape.utils.Chat``): Calls ``agent.run()`` which uses
+      ``to_prompt_stack()`` internally. This means only the summary and the unsummarized
+      recent runs (those within ``offset``) are sent to the LLM as context.
+
+    Attributes:
+        offset: Number of recent runs to keep unsummarized. When a new run is added,
+            runs older than ``offset`` beyond the current summary index are summarized
+            into a single condensed summary string. Defaults to 1.
+        autoprune: Inherited from ``BaseConversationMemory``. When enabled, the system
+            automatically limits the number of runs included in the prompt stack to fit
+            within the token limit. This does **not** remove runs from ``self.runs`` -- it
+            only controls how many are sent to the LLM.
+    """
+
     offset: int = field(default=1, kw_only=True, metadata={"serializable": True})
     prompt_driver: BasePromptDriver = field(
         kw_only=True, default=Factory(lambda: Defaults.drivers_config.prompt_driver)


### PR DESCRIPTION
## Summary
- Clarified that `Conversation` utility displays the full stored history, not just the summary
- Explained how `offset` and `autoprune` parameters work internally
- Addressed user confusion reported in the issue

Fixes #1217

## Test Plan
- [x] Docstring renders correctly in help()
- [x] No code logic changes — docs only