### PR TITLE
fix: enforce workdir confinement in LocalFileManagerDriver to prevent path traversal

### DIFF
--- a/griptape/drivers/file_manager/local_file_manager_driver.py
+++ b/griptape/drivers/file_manager/local_file_manager_driver.py
@@ -49,11 +49,19 @@ class LocalFileManagerDriver(BaseFileManagerDriver):
         return full_path
 
     def _full_path(self, path: str) -> str:
-        full_path = path if os.path.isabs(path) else os.path.join(self.workdir, path.lstrip("/"))
-        # Need to keep the trailing slash if it was there,
-        # because it means the path is a directory.
+        # Always join with workdir; stripping a leading '/' prevents os.path.join
+        # from discarding the workdir when the caller supplies an absolute path.
+        full_path = os.path.join(self.workdir, path.lstrip("/"))
+        # Preserve trailing separator — it signals a directory vs. a file.
         ended_with_sep = path.endswith("/")
         full_path = os.path.normpath(full_path)
+        # Enforce workdir boundary: reject absolute-path bypasses and '../' escapes.
+        workdir_real = os.path.realpath(self.workdir)
+        full_path_real = os.path.realpath(full_path)
+        if not (full_path_real == workdir_real or full_path_real.startswith(workdir_real + os.sep)):
+            raise ValueError(
+                f"Path {path!r} resolves outside the working directory {self.workdir!r}"
+            )
         if ended_with_sep:
             full_path = full_path.rstrip("/") + "/"
         return full_path


### PR DESCRIPTION
## Problem

`LocalFileManagerDriver._full_path()` (`griptape/drivers/file_manager/local_file_manager_driver.py:52`) contains two path traversal vectors that allow an AI agent to read or write arbitrary files outside the configured `workdir`:

**Vector 1 — Absolute path bypass:**
```python
full_path = path if os.path.isabs(path) else os.path.join(self.workdir, path.lstrip("/"))
```
If `path = "/etc/passwd"`, `os.path.isabs()` returns True and `full_path = "/etc/passwd"` — the workdir is completely skipped.

**Vector 2 — `..` traversal via normpath:**
`../../../etc/passwd` is not absolute, so it joins with workdir: `/workdir/../../../etc/passwd`. `os.path.normpath()` then resolves `..` sequences, producing `/etc/passwd` — outside the workdir with no boundary check.

**Exploit scenario:** An adversarial document processed by a griptape agent can use prompt injection to instruct the LLM to call `FileManagerTool.load_files_from_disk` with a traversal path, leaking SSH private keys, `.env` files, AWS credentials, or other sensitive files.

**Confirmed by test:**
```python
import os
workdir = '/tmp/safe'
for path in ['/etc/passwd', '../../../etc/passwd']:
    full = path if os.path.isabs(path) else os.path.join(workdir, path.lstrip('/'))
    full = os.path.normpath(full)
    print(f'{path!r} → {full!r}')  # both resolve to /etc/passwd
```

**Severity:** High (CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:N — 8.7)

## Fix

Remove the `isabs` short-circuit so all paths go through `os.path.join(workdir, path.lstrip('/'))`, then add a `realpath`-based boundary check:

```python
def _full_path(self, path: str) -> str:
    full_path = os.path.join(self.workdir, path.lstrip("/"))
    ended_with_sep = path.endswith("/")
    full_path = os.path.normpath(full_path)
    workdir_real = os.path.realpath(self.workdir)
    full_path_real = os.path.realpath(full_path)
    if not (full_path_real == workdir_real or full_path_real.startswith(workdir_real + os.sep)):
        raise ValueError(f"Path {path!r} resolves outside the working directory {self.workdir!r}")
    if ended_with_sep:
        full_path = full_path.rstrip("/") + "/"
    return full_path
```

## Test Plan
- [ ] Existing test suite passes
- [ ] `_full_path("/etc/passwd")` raises `ValueError` (was: returned `/etc/passwd`)
- [ ] `_full_path("../../../etc/passwd")` raises `ValueError` (was: returned `/etc/passwd`)
- [ ] `_full_path("uploads/file.txt")` returns `<workdir>/uploads/file.txt` (no regression)
- [ ] `_full_path("subdir/")` returns `<workdir>/subdir/` with trailing slash preserved

## Security Note

Severity: High. Exploitable via prompt injection in any griptape agent that uses `FileManagerTool` with `LocalFileManagerDriver` (the default). Filed via GitHub Private Vulnerability Reporting.

<!-- failsafe-scan-id: tob-fallback-2026-06-10 -->
