### PR TITLE
chore: bump v1.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape"
-version = "1.10.2"
+version = "1.10.3"
 description = "Modular Python framework for LLM workflows, tools, memory, and data."
 authors = [{ name = "Griptape", email = "hello@griptape.ai" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -1378,7 +1378,7 @@ wheels = [
 
 [[package]]
 name = "griptape"
-version = "1.10.2"
+version = "1.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Cuts the 1.10.3 release. Since 1.10.2, the DuckDuckGo web search driver migrated from `duckduckgo_search` to `ddgs` and the Exa web search driver stopped sending the removed `use_autoprompt` parameter, both of which restore working web search against the latest upstream APIs.