### PR TITLE
fix(tokenizers): add Claude 4.x token limits to AmazonBedrockTokenizer

### DIFF
--- a/griptape/tokenizers/amazon_bedrock_tokenizer.py
+++ b/griptape/tokenizers/amazon_bedrock_tokenizer.py
@@ -8,6 +8,9 @@ from griptape.tokenizers.base_tokenizer import BaseTokenizer
 @define()
 class AmazonBedrockTokenizer(BaseTokenizer):
     MODEL_PREFIXES_TO_MAX_INPUT_TOKENS = {
+        "anthropic.claude-opus-4": 200000,
+        "anthropic.claude-sonnet-4": 200000,
+        "anthropic.claude-haiku-4": 200000,
         "anthropic.claude-3": 200000,
         "anthropic.claude-v2:1": 200000,
         "anthropic.claude": 100000,
@@ -33,6 +36,9 @@ class AmazonBedrockTokenizer(BaseTokenizer):
         "amazon.titan-text-premier-v1": 32000,
     }
     MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS = {
+        "anthropic.claude-opus-4": 16384,
+        "anthropic.claude-sonnet-4": 16384,
+        "anthropic.claude-haiku-4": 16384,
         "anthropic.claude-3-7": 8192,
         "anthropic.claude-3-5": 8192,
         "anthropic.claude": 4096,

--- a/tests/unit/tokenizers/test_amazon_bedrock_tokenizer.py
+++ b/tests/unit/tokenizers/test_amazon_bedrock_tokenizer.py
@@ -16,6 +16,10 @@ class TestAmazonBedrockTokenizer:
             ("anthropic.claude-3-sonnet-20240229-v1:0", 4),
             ("anthropic.claude-3-haiku-20240307-v1:0", 4),
             ("us.anthropic.claude-3-haiku-20240307-v1:0", 4),
+            ("anthropic.claude-sonnet-4-20250514-v1:0", 4),
+            ("anthropic.claude-opus-4-1-20250805-v1:0", 4),
+            ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", 4),
+            ("eu.anthropic.claude-opus-4-5-20251101-v1:0", 4),
         ],
         indirect=["tokenizer"],
     )
@@ -30,6 +34,10 @@ class TestAmazonBedrockTokenizer:
             ("anthropic.claude-3-sonnet-20240229-v1:0", 199996),
             ("anthropic.claude-3-haiku-20240307-v1:0", 199996),
             ("us.anthropic.claude-3-haiku-20240307-v1:0", 199996),
+            ("anthropic.claude-sonnet-4-20250514-v1:0", 199996),
+            ("anthropic.claude-opus-4-1-20250805-v1:0", 199996),
+            ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", 199996),
+            ("eu.anthropic.claude-opus-4-5-20251101-v1:0", 199996),
         ],
         indirect=["tokenizer"],
     )
@@ -44,6 +52,10 @@ class TestAmazonBedrockTokenizer:
             ("anthropic.claude-3-sonnet-20240229-v1:0", 4092),
             ("anthropic.claude-3-haiku-20240307-v1:0", 4092),
             ("us.anthropic.claude-3-haiku-20240307-v1:0", 4092),
+            ("anthropic.claude-sonnet-4-20250514-v1:0", 16380),
+            ("anthropic.claude-opus-4-1-20250805-v1:0", 16380),
+            ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", 16380),
+            ("eu.anthropic.claude-opus-4-5-20251101-v1:0", 16380),
         ],
         indirect=["tokenizer"],
     )


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

Thanks again for griptape. This fills a gap left by #2077.

### Describe your changes

`AmazonBedrockTokenizer`'s prefix tables stop at `anthropic.claude-3-*`, so Claude 4.x Bedrock model IDs match the generic `anthropic.claude` fallback and resolve to **100K input / 4K output**. #2077 fixed the same gap on the sibling `AnthropicTokenizer` (first-party API) by adding `claude-opus-4` / `claude-sonnet-4` / `claude-haiku-4` prefixes; the Bedrock tokenizer was not given the matching update. This PR adds the equivalent prefixes (200000 input, 16384 output — the same values #2077 used) **before** the generic `anthropic.claude` fallback. Substring matching means the cross-region inference profile IDs (`us.` / `eu.` / `apac.` / `global.anthropic.claude-...`) are covered automatically.

### Before / After

| Model ID | Field | Before | After |
|---|---|---|---|
| `anthropic.claude-sonnet-4-20250514-v1:0` | max_input_tokens | ❌ 100000 | ✅ 200000 |
| `anthropic.claude-sonnet-4-20250514-v1:0` | max_output_tokens | ❌ 4096 | ✅ 16384 |
| `anthropic.claude-opus-4-1-20250805-v1:0` | max_input_tokens | ❌ 100000 | ✅ 200000 |
| `us.anthropic.claude-sonnet-4-5-...` (CRIS) | max_input_tokens | ❌ 100000 | ✅ 200000 |
| `eu.anthropic.claude-opus-4-5-...` (CRIS) | max_output_tokens | ❌ 4096 | ✅ 16384 |
| `anthropic.claude-3-*`, `claude-v2*`, all non-Claude rows | all limits | ✅ unchanged | ✅ unchanged |
| public API / `count_tokens` / table key order semantics | — | ✅ unchanged | ✅ unchanged |

AWS Bedrock model cards confirm 200K context for these models (Sonnet 4 / Sonnet 4.5 / Opus 4.5: 200K/64K; Opus 4.1: 200K/32K). **16384 output matches #2077's deliberate conservative value** and is a safe lower bound vs. the real per-model max, so it never over-promises output capacity.

### Diff

```diff
     MODEL_PREFIXES_TO_MAX_INPUT_TOKENS = {
+        "anthropic.claude-opus-4": 200000,
+        "anthropic.claude-sonnet-4": 200000,
+        "anthropic.claude-haiku-4": 200000,
         "anthropic.claude-3": 200000,
         "anthropic.claude-v2:1": 200000,
         "anthropic.claude": 100000,
...
     MODEL_PREFIXES_TO_MAX_OUTPUT_TOKENS = {
+        "anthropic.claude-opus-4": 16384,
+        "anthropic.claude-sonnet-4": 16384,
+        "anthropic.claude-haiku-4": 16384,
         "anthropic.claude-3-7": 8192,
         "anthropic.claude-3-5": 8192,
         "anthropic.claude": 4096,
```

### Test plan / results

Added Claude 4.x cases (including `us.`/`eu.` cross-region inference profiles) to all three parametrized tests in `tests/unit/tokenizers/test_amazon_bedrock_tokenizer.py`.

To prove the new tests actually catch the bug, the source fix was reverted (tests kept):

```
FAILED ... test_input_tokens_left[anthropic.claude-sonnet-4-20250514-v1:0-199996]
FAILED ... test_output_tokens_left[anthropic.claude-sonnet-4-20250514-v1:0-16380]
  AssertionError: assert 4092 == 16380
   +  where 4092 = count_output_tokens_left('foo bar huzzah')
   +    where ... _max_input_tokens=100000, _max_output_tokens=4096, model='eu.anthropic.claude-opus-4-5-20251101-v1:0'
8 failed, 19 passed
```

With the fix restored, all pass:

```
27 passed in 0.03s
```

Local gates all clean:

```
uv run ruff format --check ...   → 2 files already formatted
uv run ruff check ...            → All checks passed!
uv run pyright amazon_bedrock_tokenizer.py → 0 errors, 0 warnings
```

### Issue ticket number and link

Closes #2206

---

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the rationale, and the test results before submission._
