### PR TITLE
fix(anthropic): warn when response is truncated by max_tokens limit

### DIFF
--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -107,6 +107,13 @@ class AnthropicPromptDriver(BasePromptDriver):
 
         logger.debug(response.model_dump())
 
+        if response.stop_reason == "max_tokens":
+            logger.warning(
+                "Response reached the max_tokens limit (%d). Output may be truncated. "
+                "Increase the max_tokens parameter to get longer responses.",
+                self.max_tokens,
+            )
+
         return Message(
             content=[self.__to_prompt_stack_message_content(content) for content in response.content],
             role=Message.ASSISTANT_ROLE,
@@ -126,6 +133,12 @@ class AnthropicPromptDriver(BasePromptDriver):
             elif event.type == "message_start":
                 yield DeltaMessage(usage=DeltaMessage.Usage(input_tokens=event.message.usage.input_tokens))
             elif event.type == "message_delta":
+                if event.delta.stop_reason == "max_tokens":
+                    logger.warning(
+                        "Response reached the max_tokens limit (%d). Output may be truncated. "
+                        "Increase the max_tokens parameter to get longer responses.",
+                        self.max_tokens,
+                    )
                 yield DeltaMessage(usage=DeltaMessage.Usage(output_tokens=event.usage.output_tokens))
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:

--- a/griptape/drivers/prompt/anthropic_prompt_driver.py
+++ b/griptape/drivers/prompt/anthropic_prompt_driver.py
@@ -106,6 +106,13 @@ class AnthropicPromptDriver(BasePromptDriver):
 
         logger.debug(response.model_dump())
 
+        if response.stop_reason == "max_tokens":
+            logger.warning(
+                "Response reached the max_tokens limit (%d). Output may be truncated. "
+                "Increase the max_tokens parameter to get longer responses.",
+                self.max_tokens,
+            )
+
         return Message(
             content=[self.__to_prompt_stack_message_content(content) for content in response.content],
             role=Message.ASSISTANT_ROLE,
@@ -125,6 +132,12 @@ class AnthropicPromptDriver(BasePromptDriver):
             elif event.type == "message_start":
                 yield DeltaMessage(usage=DeltaMessage.Usage(input_tokens=event.message.usage.input_tokens))
             elif event.type == "message_delta":
+                if event.delta.stop_reason == "max_tokens":
+                    logger.warning(
+                        "Response reached the max_tokens limit (%d). Output may be truncated. "
+                        "Increase the max_tokens parameter to get longer responses.",
+                        self.max_tokens,
+                    )
                 yield DeltaMessage(usage=DeltaMessage.Usage(output_tokens=event.usage.output_tokens))
 
     def _base_params(self, prompt_stack: PromptStack) -> dict:

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -524,3 +524,63 @@ class TestAnthropicPromptDriver:
         assert "temperature" not in call_kwargs.kwargs
         assert "top_p" not in call_kwargs.kwargs
         assert "top_k" not in call_kwargs.kwargs
+
+    def test_try_run_warns_on_max_tokens(self, mocker, prompt_stack, caplog):
+        import logging
+
+        # Given
+        mock_client = mocker.patch("anthropic.Anthropic")
+        mock_client.return_value = Mock(
+            messages=Mock(
+                create=Mock(
+                    return_value=Mock(
+                        stop_reason="max_tokens",
+                        usage=Mock(input_tokens=5, output_tokens=10),
+                        content=[Mock(type="text", text="truncated-output")],
+                    )
+                )
+            )
+        )
+        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", max_tokens=10)
+
+        # When
+        with caplog.at_level(logging.WARNING, logger="griptape"):
+            driver.try_run(prompt_stack)
+
+        # Then
+        assert any("max_tokens" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+    def test_try_stream_warns_on_max_tokens(self, mocker, prompt_stack, caplog):
+        import logging
+
+        # Given
+        mock_client = mocker.patch("anthropic.Anthropic")
+        mock_client.return_value = Mock(
+            messages=Mock(
+                create=Mock(
+                    return_value=iter(
+                        [
+                            Mock(type="message_start", message=Mock(usage=Mock(input_tokens=5))),
+                            Mock(
+                                type="content_block_start",
+                                index=0,
+                                content_block=Mock(type="text", text="truncated"),
+                            ),
+                            Mock(
+                                type="message_delta",
+                                usage=Mock(output_tokens=10),
+                                delta=Mock(stop_reason="max_tokens"),
+                            ),
+                        ]
+                    )
+                )
+            )
+        )
+        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", stream=True, max_tokens=10)
+
+        # When
+        with caplog.at_level(logging.WARNING, logger="griptape"):
+            list(driver.try_stream(prompt_stack))
+
+        # Then
+        assert any("max_tokens" in r.message for r in caplog.records if r.levelno == logging.WARNING)

--- a/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_anthropic_prompt_driver.py
@@ -559,3 +559,63 @@ class TestAnthropicPromptDriver:
         call_kwargs = mock_client.return_value.messages.create.call_args
         assert call_kwargs.kwargs["temperature"] == driver.temperature
         assert call_kwargs.kwargs["top_k"] == 100
+
+    def test_try_run_warns_on_max_tokens(self, mocker, prompt_stack, caplog):
+        import logging
+
+        # Given
+        mock_client = mocker.patch("anthropic.Anthropic")
+        mock_client.return_value = Mock(
+            messages=Mock(
+                create=Mock(
+                    return_value=Mock(
+                        stop_reason="max_tokens",
+                        usage=Mock(input_tokens=5, output_tokens=10),
+                        content=[Mock(type="text", text="truncated-output")],
+                    )
+                )
+            )
+        )
+        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", max_tokens=10)
+
+        # When
+        with caplog.at_level(logging.WARNING, logger="griptape"):
+            driver.try_run(prompt_stack)
+
+        # Then
+        assert any("max_tokens" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+    def test_try_stream_warns_on_max_tokens(self, mocker, prompt_stack, caplog):
+        import logging
+
+        # Given
+        mock_client = mocker.patch("anthropic.Anthropic")
+        mock_client.return_value = Mock(
+            messages=Mock(
+                create=Mock(
+                    return_value=iter(
+                        [
+                            Mock(type="message_start", message=Mock(usage=Mock(input_tokens=5))),
+                            Mock(
+                                type="content_block_start",
+                                index=0,
+                                content_block=Mock(type="text", text="truncated"),
+                            ),
+                            Mock(
+                                type="message_delta",
+                                usage=Mock(output_tokens=10),
+                                delta=Mock(stop_reason="max_tokens"),
+                            ),
+                        ]
+                    )
+                )
+            )
+        )
+        driver = AnthropicPromptDriver(model="claude-3-haiku", api_key="api-key", stream=True, max_tokens=10)
+
+        # When
+        with caplog.at_level(logging.WARNING, logger="griptape"):
+            list(driver.try_stream(prompt_stack))
+
+        # Then
+        assert any("max_tokens" in r.message for r in caplog.records if r.levelno == logging.WARNING)


### PR DESCRIPTION
## Summary

Closes #1982

When the Anthropic API stops generation because the response hit the `max_tokens` limit, users currently receive silently truncated output with no indication of what happened. This PR adds a `WARNING`-level log message in both the streaming and non-streaming paths so the problem is immediately visible.

- In `try_run`: checks `response.stop_reason == "max_tokens"` and logs a warning with the current `max_tokens` value.
- In `try_stream`: checks `event.delta.stop_reason == "max_tokens"` in the `message_delta` event and logs the same warning.

No behaviour changes — the message is still returned as-is; users who want longer output can simply increase `max_tokens`.

## Test plan

- [ ] `test_try_run_warns_on_max_tokens` — mocks a response with `stop_reason="max_tokens"`, asserts a WARNING containing `"max_tokens"` is emitted.
- [ ] `test_try_stream_warns_on_max_tokens` — mocks a stream with a `message_delta` whose `delta.stop_reason="max_tokens"`, asserts same warning.
- [ ] Existing `test_try_run` / `test_try_stream_run` tests are unaffected (mock responses have a non-string `stop_reason` that never equals `"max_tokens"`).

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2212.org.readthedocs.build//2212/

<!-- readthedocs-preview griptape end -->