### PR TITLE
Create parent directories for local memory persistence

### DIFF
--- a/griptape/drivers/memory/conversation/local_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/local_conversation_memory_driver.py
@@ -19,7 +19,9 @@ class LocalConversationMemoryDriver(BaseConversationMemoryDriver):
 
     def store(self, runs: list[Run], metadata: dict[str, Any]) -> None:
         if self.persist_file is not None:
-            Path(self.persist_file).write_text(json.dumps(self._to_params_dict(runs, metadata)))
+            persist_file = Path(self.persist_file)
+            persist_file.parent.mkdir(parents=True, exist_ok=True)
+            persist_file.write_text(json.dumps(self._to_params_dict(runs, metadata)))
 
     def load(self) -> tuple[list[Run], dict[str, Any]]:
         if (

--- a/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py
@@ -34,6 +34,17 @@ class TestLocalConversationMemoryDriver:
 
         assert os.path.exists(self.MEMORY_FILE_PATH)
 
+    def test_store_creates_parent_directory(self, tmp_path):
+        persist_file = tmp_path / "memory" / self.MEMORY_FILE_PATH
+        memory_driver = LocalConversationMemoryDriver(persist_file=str(persist_file))
+        memory = ConversationMemory(conversation_memory_driver=memory_driver, autoload=False)
+        pipeline = Pipeline(conversation_memory=memory)
+
+        pipeline.add_task(PromptTask("test"))
+        pipeline.run()
+
+        assert persist_file.exists()
+
     def test_load(self):
         memory_driver = LocalConversationMemoryDriver(persist_file=self.MEMORY_FILE_PATH)
         memory = ConversationMemory(


### PR DESCRIPTION
﻿## Summary

This updates `LocalConversationMemoryDriver.store()` to create the parent directory for `persist_file` before writing persisted conversation memory.

Previously, using a nested path such as `memory/test_memory.json` raised `FileNotFoundError` if the parent directory did not already exist.

## Changes

- Create `persist_file.parent` with `parents=True, exist_ok=True` before writing.
- Add a unit test covering nested local conversation memory persistence paths.

## Tests

- `D:\简历\griptape\.venv\Scripts\python.exe -m pytest tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py -q`
- `D:\简历\griptape\.venv\Scripts\python.exe -m pytest tests/unit/drivers/memory/conversation -q`
- `D:\简历\griptape\.venv\Scripts\python.exe -m ruff check griptape/drivers/memory/conversation/local_conversation_memory_driver.py tests/unit/drivers/memory/conversation/test_local_conversation_memory_driver.py`
- `git diff --check`
