### PR TITLE
feat(drivers-memory-conversation-dakera): add DakeraConversationMemoryDriver

### DIFF
--- a/docs/griptape-framework/drivers/conversation-memory-drivers.md
+++ b/docs/griptape-framework/drivers/conversation-memory-drivers.md
@@ -82,3 +82,17 @@ The [RedisConversationMemoryDriver](../../reference/griptape/drivers/memory/conv
     ```text
     --8<-- "docs/griptape-framework/drivers/logs/conversation_memory_drivers_3.txt"
     ```
+
+### Dakera
+
+!!! info
+
+    This driver requires the `drivers-memory-conversation-dakera` [extra](../index.md#extras).
+
+The [DakeraConversationMemoryDriver](../../reference/griptape/drivers/memory/conversation/dakera_conversation_memory_driver.md) allows you to persist Conversation Memory in [Dakera](https://dakera.ai/), a self-hosted memory server. Each conversation is stored under its own `conversation_id`, so conversations remain isolated from one another. Run the server locally with the [`dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) Docker Compose stack (defaults to `http://localhost:3000`).
+
+=== "Code"
+
+    ```python
+    --8<-- "docs/griptape-framework/drivers/src/conversation_memory_drivers_dakera.py"
+    ```

--- a/docs/griptape-framework/drivers/src/conversation_memory_drivers_dakera.py
+++ b/docs/griptape-framework/drivers/src/conversation_memory_drivers_dakera.py
@@ -1,0 +1,18 @@
+import os
+import uuid
+
+from griptape.drivers.memory.conversation.dakera import DakeraConversationMemoryDriver
+from griptape.memory.structure import ConversationMemory
+from griptape.structures import Agent
+
+conversation_id = uuid.uuid4().hex
+dakera_conversation_driver = DakeraConversationMemoryDriver(
+    base_url=os.environ["DAKERA_BASE_URL"],
+    api_key=os.environ["DAKERA_API_KEY"],
+    conversation_id=conversation_id,
+)
+
+agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=dakera_conversation_driver))
+
+agent.run("My name is Jeff.")
+agent.run("What is my name?")

--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -22,6 +22,7 @@ from .memory.conversation.local import LocalConversationMemoryDriver
 from .memory.conversation.amazon_dynamodb import AmazonDynamoDbConversationMemoryDriver
 from .memory.conversation.redis import RedisConversationMemoryDriver
 from .memory.conversation.griptape_cloud import GriptapeCloudConversationMemoryDriver
+from .memory.conversation.dakera import DakeraConversationMemoryDriver
 
 from .embedding import BaseEmbeddingDriver
 from .embedding.openai import OpenAiEmbeddingDriver
@@ -179,6 +180,7 @@ __all__ = [
     "CohereEmbeddingDriver",
     "CoherePromptDriver",
     "CohereRerankDriver",
+    "DakeraConversationMemoryDriver",
     "DatadogObservabilityDriver",
     "DuckDuckGoWebSearchDriver",
     "DummyAudioTranscriptionDriver",

--- a/griptape/drivers/memory/conversation/dakera/__init__.py
+++ b/griptape/drivers/memory/conversation/dakera/__init__.py
@@ -1,0 +1,3 @@
+from griptape.drivers.memory.conversation.dakera_conversation_memory_driver import DakeraConversationMemoryDriver
+
+__all__ = ["DakeraConversationMemoryDriver"]

--- a/griptape/drivers/memory/conversation/dakera_conversation_memory_driver.py
+++ b/griptape/drivers/memory/conversation/dakera_conversation_memory_driver.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from attrs import Attribute, Factory, define, field
+
+from griptape.drivers.memory.conversation import BaseConversationMemoryDriver
+from griptape.utils import import_optional_dependency
+
+if TYPE_CHECKING:
+    from dakera import DakeraClient
+
+    from griptape.memory.structure import Run
+
+
+@define(kw_only=True)
+class DakeraConversationMemoryDriver(BaseConversationMemoryDriver):
+    """A Conversation Memory Driver for Dakera.
+
+    Dakera is a self-hosted memory server that persists conversation state across sessions. Each
+    conversation is stored under its own ``conversation_id``, which is used as the Dakera ``agent_id``
+    so that a conversation's memories are isolated from every other conversation. On ``store`` the
+    previous snapshot is replaced with the latest one, mirroring the semantics of the other
+    Conversation Memory Drivers.
+
+    Attributes:
+        base_url: The base URL of the Dakera server. Defaults to the value of the environment
+            variable ``DAKERA_BASE_URL`` or ``http://localhost:3000``.
+        api_key: The API key used to authenticate with the Dakera server. Defaults to the value of
+            the environment variable ``DAKERA_API_KEY``. May be ``None`` for a server that does not
+            require authentication.
+        conversation_id: The id of the conversation. Used as the Dakera ``agent_id``.
+    """
+
+    base_url: str = field(
+        default=Factory(lambda: os.getenv("DAKERA_BASE_URL", "http://localhost:3000")),
+        metadata={"serializable": True},
+    )
+    api_key: str | None = field(
+        default=Factory(lambda: os.getenv("DAKERA_API_KEY")),
+        metadata={"serializable": False},
+    )
+    conversation_id: str = field(
+        default=Factory(lambda: uuid.uuid4().hex),
+        metadata={"serializable": True},
+    )
+    client: DakeraClient = field(
+        default=Factory(
+            lambda self: import_optional_dependency("dakera").DakeraClient(
+                base_url=self.base_url,
+                api_key=self.api_key,
+            ),
+            takes_self=True,
+        ),
+        metadata={"serializable": False},
+    )
+
+    @conversation_id.validator  # pyright: ignore[reportAttributeAccessIssue]
+    def validate_conversation_id(self, _: Attribute, value: str) -> str:
+        if not value:
+            raise ValueError(f"{self.__class__.__name__} requires a non-empty conversation_id")
+        return value
+
+    def store(self, runs: list[Run], metadata: dict[str, Any]) -> None:
+        content = json.dumps(self._to_params_dict(runs, metadata))
+
+        # Replace the previous snapshot so that load() only ever returns the latest conversation state.
+        for memory in self.client.agent_memories(agent_id=self.conversation_id):
+            memory_id = memory.get("id")
+            if memory_id is not None:
+                self.client.forget(agent_id=self.conversation_id, memory_id=memory_id)
+
+        self.client.store_memory(
+            agent_id=self.conversation_id,
+            content=content,
+            memory_type="episodic",
+            importance=1.0,
+        )
+
+    def load(self) -> tuple[list[Run], dict[str, Any]]:
+        memories = self.client.agent_memories(agent_id=self.conversation_id, limit=1)
+        if memories:
+            return self._from_params_dict(json.loads(memories[0]["content"]))
+        return [], {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ drivers-sql-snowflake = [
 ]
 drivers-memory-conversation-amazon-dynamodb = ["boto3>=1.34.119"]
 drivers-memory-conversation-redis = ["redis>=5.1.0"]
+drivers-memory-conversation-dakera = ["dakera>=0.12.8"]
 drivers-vector-marqo = ["marqo>=3.9.2"]
 drivers-vector-pinecone = ["pinecone>=6.0.1"]
 drivers-vector-mongodb = ["pymongo>=4.8.0"]
@@ -154,6 +155,7 @@ all = [
   "pandas>=2.2",
   "pypdf>=5.0.1",
   "mail-parser>=4.0.0",
+  "dakera>=0.12.8",
 ]
 
 [project.urls]

--- a/tests/unit/drivers/memory/conversation/test_dakera_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_dakera_conversation_memory_driver.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from griptape.drivers.memory.conversation.dakera import DakeraConversationMemoryDriver
+from griptape.memory.structure.base_conversation_memory import BaseConversationMemory
+
+TEST_DATA = '{"runs": [{"input": {"type": "TextArtifact", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "value": "Hello! How can I assist you today?"}}], "metadata": {"foo": "bar"}}'
+TEST_MEMORY = '{"type": "ConversationMemory", "runs": [{"type": "Run", "id": "729ca6be5d79433d9762eb06dfd677e2", "input": {"type": "TextArtifact", "id": "1234", "value": "Hi There, Hello"}, "output": {"type": "TextArtifact", "id": "123", "value": "Hello! How can I assist you today?"}}], "max_runs": 2}'
+CONVERSATION_ID = "117151897f344ff684b553d0655d8f39"
+
+
+class TestDakeraConversationMemoryDriver:
+    @pytest.fixture()
+    def client(self, mocker):
+        mock_client = mocker.MagicMock()
+        mock_client.agent_memories.return_value = [{"id": "mem_1", "content": TEST_DATA}]
+        return mock_client
+
+    @pytest.fixture()
+    def driver(self, client):
+        return DakeraConversationMemoryDriver(
+            base_url="http://localhost:3000",
+            api_key="dk-test",
+            conversation_id=CONVERSATION_ID,
+            client=client,
+        )
+
+    def test_conversation_id_is_used_as_agent_id(self, driver):
+        assert driver.conversation_id == CONVERSATION_ID
+
+    def test_requires_non_empty_conversation_id(self, client):
+        with pytest.raises(ValueError, match="requires a non-empty conversation_id"):
+            DakeraConversationMemoryDriver(conversation_id="", client=client)
+
+    def test_store(self, driver, client):
+        memory = BaseConversationMemory.from_json(TEST_MEMORY)
+
+        assert driver.store(memory.runs, memory.meta) is None
+
+        client.store_memory.assert_called_once()
+        _, kwargs = client.store_memory.call_args
+        assert kwargs["agent_id"] == CONVERSATION_ID
+        stored = json.loads(kwargs["content"])
+        assert len(stored["runs"]) == 1
+
+    def test_store_replaces_previous_snapshot(self, driver, client):
+        client.agent_memories.return_value = [{"id": "old_1"}, {"id": "old_2"}]
+        memory = BaseConversationMemory.from_json(TEST_MEMORY)
+
+        driver.store(memory.runs, memory.meta)
+
+        assert client.forget.call_count == 2
+        client.forget.assert_any_call(agent_id=CONVERSATION_ID, memory_id="old_1")
+        client.forget.assert_any_call(agent_id=CONVERSATION_ID, memory_id="old_2")
+        client.store_memory.assert_called_once()
+
+    def test_load(self, driver):
+        runs, metadata = driver.load()
+
+        assert len(runs) == 1
+        assert metadata == {"foo": "bar"}
+
+    def test_load_empty(self, driver, client):
+        client.agent_memories.return_value = []
+
+        runs, metadata = driver.load()
+
+        assert len(runs) == 0
+        assert metadata == {}

--- a/tests/unit/drivers/memory/conversation/test_dakera_conversation_memory_driver.py
+++ b/tests/unit/drivers/memory/conversation/test_dakera_conversation_memory_driver.py
@@ -68,3 +68,14 @@ class TestDakeraConversationMemoryDriver:
 
         assert len(runs) == 0
         assert metadata == {}
+
+    def test_store_skips_memories_without_id(self, driver, client):
+        # A memory row with a null id or no "id" key is skipped (no forget),
+        # covering the `memory_id is not None` guard's false branch.
+        client.agent_memories.return_value = [{"id": None}, {"content": "no id key"}]
+        memory = BaseConversationMemory.from_json(TEST_MEMORY)
+
+        driver.store(memory.runs, memory.meta)
+
+        client.forget.assert_not_called()
+        client.store_memory.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -893,34 +893,47 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
+]
+
+[[package]]
+name = "dakera"
+version = "0.12.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/ef/adbb92495aa9661f393764d7adc1571be0a938304c89bccac3dfeb0c9524/dakera-0.12.8.tar.gz", hash = "sha256:d72b9fed847a6685af5e87f885fff8ceed7ce4db6423834380bf802e9cc19512", size = 136918, upload-time = "2026-06-26T10:39:07.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/72/3dd493ac6ae4c3e456519b6316f32d371d298318aa91a458bf061808f9b0/dakera-0.12.8-py3-none-any.whl", hash = "sha256:fdd460b2c52870df7e5631e72b635d32169302da57029f4f1a740fa66b6cfc75", size = 88834, upload-time = "2026-06-26T10:39:05.164Z" },
 ]
 
 [[package]]
@@ -1411,6 +1424,7 @@ all = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cohere" },
+    { name = "dakera" },
     { name = "ddgs" },
     { name = "diffusers" },
     { name = "elevenlabs" },
@@ -1486,6 +1500,9 @@ drivers-image-generation-huggingface = [
 ]
 drivers-memory-conversation-amazon-dynamodb = [
     { name = "boto3" },
+]
+drivers-memory-conversation-dakera = [
+    { name = "dakera" },
 ]
 drivers-memory-conversation-redis = [
     { name = "redis" },
@@ -1685,6 +1702,8 @@ requires-dist = [
     { name = "cohere", marker = "extra == 'drivers-embedding-cohere'", specifier = ">=5.11.2" },
     { name = "cohere", marker = "extra == 'drivers-prompt-cohere'", specifier = ">=5.11.2" },
     { name = "cohere", marker = "extra == 'drivers-rerank-cohere'", specifier = ">=5.11.2" },
+    { name = "dakera", marker = "extra == 'all'", specifier = ">=0.12.8" },
+    { name = "dakera", marker = "extra == 'drivers-memory-conversation-dakera'", specifier = ">=0.12.8" },
     { name = "ddgs", marker = "extra == 'all'", specifier = ">=9.0.0" },
     { name = "ddgs", marker = "extra == 'drivers-web-search-duckduckgo'", specifier = ">=9.0.0" },
     { name = "diffusers", marker = "extra == 'all'", specifier = ">=0.32.0" },
@@ -1793,7 +1812,7 @@ requires-dist = [
     { name = "voyageai", marker = "extra == 'drivers-embedding-voyageai'", specifier = ">=0.2.1" },
     { name = "wrapt", specifier = ">=1.16.0" },
 ]
-provides-extras = ["drivers-prompt-cohere", "drivers-prompt-anthropic", "drivers-prompt-huggingface-hub", "drivers-prompt-huggingface-pipeline", "drivers-prompt-amazon-bedrock", "drivers-prompt-amazon-sagemaker", "drivers-prompt-google", "drivers-prompt-ollama", "drivers-sql", "drivers-sql-amazon-redshift", "drivers-sql-snowflake", "drivers-memory-conversation-amazon-dynamodb", "drivers-memory-conversation-redis", "drivers-vector-marqo", "drivers-vector-pinecone", "drivers-vector-mongodb", "drivers-vector-redis", "drivers-vector-opensearch", "drivers-vector-amazon-opensearch", "drivers-vector-pgvector", "drivers-vector-qdrant", "drivers-vector-astra-db", "drivers-vector-pgai", "drivers-embedding-amazon-bedrock", "drivers-embedding-amazon-sagemaker", "drivers-embedding-huggingface", "drivers-embedding-voyageai", "drivers-embedding-google", "drivers-embedding-cohere", "drivers-embedding-ollama", "drivers-web-scraper-trafilatura", "drivers-web-scraper-markdownify", "drivers-web-search-duckduckgo", "drivers-web-search-tavily", "drivers-web-search-exa", "drivers-event-listener-amazon-sqs", "drivers-event-listener-amazon-iot", "drivers-event-listener-pusher", "drivers-text-to-speech-elevenlabs", "drivers-rerank-cohere", "drivers-rerank-amazon-bedrock", "drivers-observability-opentelemetry", "drivers-observability-griptape-cloud", "drivers-observability-datadog", "drivers-image-generation-huggingface", "drivers-file-manager-amazon-s3", "loaders-pdf", "loaders-image", "loaders-email", "loaders-sql", "all"]
+provides-extras = ["drivers-prompt-cohere", "drivers-prompt-anthropic", "drivers-prompt-huggingface-hub", "drivers-prompt-huggingface-pipeline", "drivers-prompt-amazon-bedrock", "drivers-prompt-amazon-sagemaker", "drivers-prompt-google", "drivers-prompt-ollama", "drivers-sql", "drivers-sql-amazon-redshift", "drivers-sql-snowflake", "drivers-memory-conversation-amazon-dynamodb", "drivers-memory-conversation-redis", "drivers-memory-conversation-dakera", "drivers-vector-marqo", "drivers-vector-pinecone", "drivers-vector-mongodb", "drivers-vector-redis", "drivers-vector-opensearch", "drivers-vector-amazon-opensearch", "drivers-vector-pgvector", "drivers-vector-qdrant", "drivers-vector-astra-db", "drivers-vector-pgai", "drivers-embedding-amazon-bedrock", "drivers-embedding-amazon-sagemaker", "drivers-embedding-huggingface", "drivers-embedding-voyageai", "drivers-embedding-google", "drivers-embedding-cohere", "drivers-embedding-ollama", "drivers-web-scraper-trafilatura", "drivers-web-scraper-markdownify", "drivers-web-search-duckduckgo", "drivers-web-search-tavily", "drivers-web-search-exa", "drivers-event-listener-amazon-sqs", "drivers-event-listener-amazon-iot", "drivers-event-listener-pusher", "drivers-text-to-speech-elevenlabs", "drivers-rerank-cohere", "drivers-rerank-amazon-bedrock", "drivers-observability-opentelemetry", "drivers-observability-griptape-cloud", "drivers-observability-datadog", "drivers-image-generation-huggingface", "drivers-file-manager-amazon-s3", "loaders-pdf", "loaders-image", "loaders-email", "loaders-sql", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem

Griptape's `BaseConversationMemoryDriver` lets applications persist Conversation Memory to an external store (Local JSON, Amazon DynamoDB, Redis, Griptape Cloud). There's currently no driver for [Dakera](https://dakera.ai/), a self-hosted memory server that a number of Griptape users run alongside their agents. Today they have to write their own glue to persist conversations to it.

## Design

This PR adds `DakeraConversationMemoryDriver`, mirroring the structure of the existing `RedisConversationMemoryDriver` and `GriptapeCloudConversationMemoryDriver`:

- Each conversation is stored under its own `conversation_id`, which is used as the Dakera `agent_id`, so conversations stay isolated from one another.
- `store(runs, metadata)` serializes the conversation via the base class's `_to_params_dict` and **replaces** the previous snapshot (deletes prior entries, then writes the latest one), matching the overwrite semantics of the Redis/DynamoDB drivers.
- `load()` reads back the most recent snapshot and reconstructs it with `_from_params_dict`, returning `([], {})` when nothing is stored.
- The Dakera client is a lazily-constructed optional dependency (`import_optional_dependency("dakera")`), gated behind the new `drivers-memory-conversation-dakera` extra. `base_url` / `api_key` fall back to `DAKERA_BASE_URL` (default `http://localhost:3000`) and `DAKERA_API_KEY`.

Dakera is self-hosted via the [`dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) Docker Compose stack; the Python SDK is [`dakera`](https://pypi.org/project/dakera/).

## Usage

```python
import os
import uuid

from griptape.drivers.memory.conversation.dakera import DakeraConversationMemoryDriver
from griptape.memory.structure import ConversationMemory
from griptape.structures import Agent

dakera_conversation_driver = DakeraConversationMemoryDriver(
    base_url=os.environ["DAKERA_BASE_URL"],  # e.g. http://localhost:3000
    api_key=os.environ["DAKERA_API_KEY"],
    conversation_id=uuid.uuid4().hex,
)

agent = Agent(conversation_memory=ConversationMemory(conversation_memory_driver=dakera_conversation_driver))
agent.run("My name is Jeff.")
agent.run("What is my name?")  # a fresh Agent with the same conversation_id reloads the history
```

## Testing

- New unit tests in `tests/unit/drivers/memory/conversation/test_dakera_conversation_memory_driver.py` (store, snapshot replacement, load, empty-load, and validation) — all pass, following the same mocked-client pattern as the Redis driver tests.
- `ruff format --check`, `ruff check`, `pyright`, `typos`, and `mdformat --check` all clean locally against the pinned versions in `uv.lock`.
- `uv.lock` regenerated to include the new optional dependency.

## Checklist

- [x] New driver mirrors an existing sibling (`RedisConversationMemoryDriver`) and its base class
- [x] Registered in `griptape/drivers/__init__.py` (`__all__`) and re-exported from the `dakera` subpackage
- [x] `drivers-memory-conversation-dakera` extra added; included in `all`; `uv.lock` updated
- [x] Unit tests added and passing
- [x] Docs section + runnable example added to `conversation-memory-drivers.md`
- [x] Lint / format / type / spell checks pass locally


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2228.org.readthedocs.build//2228/

<!-- readthedocs-preview griptape end -->