### PR TITLE
docs: point Data Source requests to Discord instead of email

### DIFF
--- a/docs/griptape-cloud/data-sources/create-data-source.md
+++ b/docs/griptape-cloud/data-sources/create-data-source.md
@@ -39,7 +39,7 @@ You can specify a [Structure](../structures/create-structure.md) to run as a Dat
 
 ### Other Data Source Types
 
-If you do not see a Data Source configuration you'd wish to use, you can submit a request via [Discord](https://discord.gg/gnWRz88eym) or `hello@griptape.ai`.
+If you do not see a Data Source configuration you'd wish to use, you can submit a request via [Discord](https://discord.com/invite/griptape).
 
 ## Adding Structure as Transform to Data Source (Experimental)
 


### PR DESCRIPTION
The "Other Data Source Types" note offered `hello@griptape.ai` alongside Discord as a way to request new configurations. This drops the email so the docs route people to the community channel we want them using, and normalizes the invite to the canonical `discord.com/invite/griptape` link.

Part of griptape-ai/internal#129.


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2229.org.readthedocs.build//2229/

<!-- readthedocs-preview griptape end -->