### PR TITLE
chore: enable ruff B009 and B010 rules

### DIFF
--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -434,8 +434,8 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                 raise ValueError(f"Unsupported tool call delta: {tool_call}")
             raise ValueError(f"Unsupported tool call delta length: {len(tool_calls)}")
         # OpenAi doesn't have types for audio deltas so we need to use hasattr and getattr.
-        if hasattr(content_delta, "audio") and getattr(content_delta, "audio") is not None:
-            audio_chunk: dict = getattr(content_delta, "audio")
+        if hasattr(content_delta, "audio") and content_delta.audio is not None:
+            audio_chunk: dict = content_delta.audio
             return AudioDeltaMessageContent(
                 id=audio_chunk.get("id"),
                 data=audio_chunk.get("data"),

--- a/griptape/memory/task/task_memory.py
+++ b/griptape/memory/task/task_memory.py
@@ -66,8 +66,8 @@ class TaskMemory(ActivityMixin, SerializableMixin):
     ) -> BaseArtifact:
         from griptape.utils import J2
 
-        tool_name = getattr(getattr(tool_activity, "__self__"), "name")
-        activity_name = getattr(tool_activity, "name")
+        tool_name = tool_activity.__self__.name
+        activity_name = tool_activity.name
         namespace = output_artifact.name
 
         if output_artifact:

--- a/griptape/mixins/activity_mixin.py
+++ b/griptape/mixins/activity_mixin.py
@@ -66,7 +66,7 @@ class ActivityMixin:
 
     def find_activity(self, name: str) -> Callable | None:
         for activity in self.activities():
-            if getattr(activity, "is_activity", False) and getattr(activity, "name") == name:
+            if getattr(activity, "is_activity", False) and activity.name == name:
                 return activity
 
         return None
@@ -74,21 +74,21 @@ class ActivityMixin:
     def activity_name(self, activity: Callable) -> str:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        return getattr(activity, "name")
+        return activity.name
 
     def activity_description(self, activity: Callable) -> str:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        return Template(getattr(activity, "config")["description"]).render({"_self": self})
+        return Template(activity.config["description"]).render({"_self": self})
 
     def activity_schema(self, activity: Callable) -> Schema | type[BaseModel] | None:
         if activity is None or not getattr(activity, "is_activity", False):
             raise Exception("This method is not an activity.")
-        if getattr(activity, "config")["schema"] is not None:
-            config_schema = getattr(activity, "config")["schema"]
+        if activity.config["schema"] is not None:
+            config_schema = activity.config["schema"]
             if isinstance(config_schema, Schema):
                 # Need to deepcopy to avoid modifying the original schema
-                config_schema = deepcopy(getattr(activity, "config")["schema"])
+                config_schema = deepcopy(activity.config["schema"])
             elif isinstance(config_schema, Callable) and not isinstance(config_schema, type):
                 config_schema = config_schema(self)
             activity_name = self.activity_name(activity)

--- a/griptape/mixins/serializable_mixin.py
+++ b/griptape/mixins/serializable_mixin.py
@@ -22,12 +22,12 @@ def _default(_self: Any, obj: Any) -> Any:
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()
-    return getattr(obj.__class__, "to_dict", getattr(_default, "default"))(obj)
+    return getattr(obj.__class__, "to_dict", _default.default)(obj)
 
 
 # Adapted from https://stackoverflow.com/questions/18478287/making-object-json-serializable-with-regular-encoder/18561055#18561055
-setattr(_default, "default", JSONEncoder.default)
-setattr(JSONEncoder, "default", _default)
+_default.default = JSONEncoder.default
+JSONEncoder.default = _default
 
 
 @define(slots=False)

--- a/griptape/tasks/prompt_task.py
+++ b/griptape/tasks/prompt_task.py
@@ -265,7 +265,7 @@ class PromptTask(
                 if tool.input_memory is None:
                     tool.input_memory = [self.task_memory]
                 if tool.output_memory is None and tool.off_prompt:
-                    tool.output_memory = {getattr(a, "name"): [self.task_memory] for a in tool.activities()}
+                    tool.output_memory = {a.name: [self.task_memory] for a in tool.activities()}
 
     def find_subtask(self, subtask_id: str) -> BaseSubtask:
         for subtask in self.subtasks:

--- a/griptape/tasks/tool_task.py
+++ b/griptape/tasks/tool_task.py
@@ -128,4 +128,4 @@ class ToolTask(PromptTask, ActionsSubtaskOriginMixin):
             if self.tool.input_memory is None:
                 self.tool.input_memory = [self.task_memory]
             if self.tool.output_memory is None and self.tool.off_prompt:
-                self.tool.output_memory = {getattr(a, "name"): [self.task_memory] for a in self.tool.activities()}
+                self.tool.output_memory = {a.name: [self.task_memory] for a in self.tool.activities()}

--- a/griptape/tools/base_tool.py
+++ b/griptape/tools/base_tool.py
@@ -184,7 +184,7 @@ class BaseTool(ActivityMixin, SerializableMixin, RunnableMixin["BaseTool"], ABC)
         super().after_run()
 
         if self.output_memory:
-            output_memories = self.output_memory[getattr(activity, "name")] or []
+            output_memories = self.output_memory[activity.name] or []
             for memory in output_memories:
                 value = memory.process_output(activity, subtask, value)
 

--- a/griptape/utils/decorators.py
+++ b/griptape/utils/decorators.py
@@ -41,9 +41,9 @@ def activity(config: dict) -> Any:
         def wrapper(self: Any, params: dict) -> Any:
             return func(self, **_build_kwargs(func, params))
 
-        setattr(wrapper, "name", validated_config.get("name", func.__name__))
-        setattr(wrapper, "config", validated_config)
-        setattr(wrapper, "is_activity", True)
+        wrapper.name = validated_config.get("name", func.__name__)
+        wrapper.config = validated_config
+        wrapper.is_activity = True
 
         return wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,8 +218,6 @@ select = ["ALL"]
 ignore = [
   "E501",   # line-too-long
   "B024",   # abstract-base-class-without-abstract-method
-  "B009",   # get-attr-with-constant
-  "B010",   # set-attr-with-constant
   "D100",   # undocumented-public-module
   "D101",   # undocumented-public-class
   "D102",   # undocumented-public-method


### PR DESCRIPTION
## Summary

Incremental step toward [#995](https://github.com/griptape-ai/griptape/issues/995).

Enables two additional ruff rules that were auto-fixable:

- **B009** (get-attr-with-constant): Replace `getattr(x, "attr")` with `x.attr` (15 auto-fixes)
- **B010** (set-attr-with-constant): Replace `setattr(x, "attr", v)` with `x.attr = v` (5 auto-fixes)

## Changes

- Removed B009 and B010 from the ruff ignore list in `pyproject.toml`
- Applied auto-fixes to 8 Python files (20 replacements total)
- `ruff check` passes cleanly

## Verification

```
$ ruff check
All checks passed!
```