### PR TITLE
fix: LocalVectorStoreDriver.query_vector leaks entries across hyphen-prefixed namespaces

### DIFF
--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -97,10 +97,7 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         include_vectors: bool = False,
         **kwargs,
     ) -> list[BaseVectorStoreDriver.Entry]:
-        if namespace:
-            entries = {k: v for (k, v) in self.entries.items() if k.startswith(f"{namespace}-")}
-        else:
-            entries = self.entries
+        entries = {k: v for k, v in self.entries.items() if v.namespace == namespace} if namespace else self.entries
 
         entries_and_relatednesses = [
             (entry, self.calculate_relatedness(vector, entry.vector)) for entry in list(entries.values())

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -48,6 +48,18 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert result[0].score is not None
         assert result[0].namespace == "foo"
 
+    def test_query_vector_namespace_does_not_leak_hyphenated_sibling_namespace(self, driver):
+        # A namespace filter based on string-prefix matching (e.g. `key.startswith(f"{namespace}-")`)
+        # incorrectly matches entries from an unrelated namespace whenever one namespace name is a
+        # hyphen-prefix of another (e.g. "foo" is a prefix of "foo-bar-baz-summary").
+        driver.upsert_collection(
+            {"foo": [TextArtifact("hello foo")], "foo-bar-baz-summary": [TextArtifact("hello sibling")]}
+        )
+
+        result = driver.query_vector([1.0, 1.0], namespace="foo", include_vectors=True)
+
+        assert {entry.namespace for entry in result} == {"foo"}
+
     @pytest.mark.parametrize("execution_number", range(1000))
     def test_upsert_collection_meta(self, driver, mocker, execution_number):
         spy = mocker.spy(driver, "upsert_vector")


### PR DESCRIPTION
<!-- Title: fix: LocalVectorStoreDriver.query_vector leaks entries across hyphen-prefixed namespaces -->
<!-- Follows .github/pull_request_template.md -->

- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

`LocalVectorStoreDriver.query_vector()` filters entries for a requested namespace
by checking whether the entry's internal storage key starts with
`f"{namespace}-"`:

```python
# griptape/drivers/vector/local_vector_store_driver.py (pre-fix)
entries = {k: v for (k, v) in self.entries.items() if k.startswith(f"{namespace}-")}
```

Storage keys are built as `f"{namespace}-{vector_id}"`
(`__namespaced_vector_id`, same file). Since namespace strings are free-form and
may contain hyphens, this prefix check is not scoped to the namespace boundary:
a query for namespace `"foo"` also matches any entry whose namespace happens to
start with `"foo-"`, for example `"foo-bar-baz-summary"`. The result is that
`query_vector(namespace="foo")` silently returns entries from an unrelated
namespace, with no error or warning.

Repro:

```python
from griptape.artifacts import TextArtifact
from griptape.drivers.vector.local import LocalVectorStoreDriver
from tests.mocks.mock_embedding_driver import MockEmbeddingDriver

driver = LocalVectorStoreDriver(embedding_driver=MockEmbeddingDriver())
driver.upsert_text("hello foo", namespace="foo")
driver.upsert_text("hello foo-bar", namespace="foo-bar")

result = driver.query_vector([0, 1], namespace="foo", include_vectors=True)
print({r.namespace for r in result})
# {'foo-bar', 'foo'}  -- "foo-bar" should not be here
```

The same class already implements the identical namespace filter correctly one
method away, in `load_entries()`:

```python
# griptape/drivers/vector/local_vector_store_driver.py
return [entry for key, entry in self.entries.items() if namespace is None or entry.namespace == namespace]
```

`load_entries()` compares the entry's own `namespace` field for equality rather
than pattern-matching the derived storage key, so it has no prefix-collision
exposure.

**The fix** uses the same exact-match filter `load_entries()` already uses,
instead of a key-prefix heuristic:

```diff
-        if namespace:
-            entries = {k: v for (k, v) in self.entries.items() if k.startswith(f"{namespace}-")}
-        else:
-            entries = self.entries
+        entries = {k: v for k, v in self.entries.items() if v.namespace == namespace} if namespace else self.entries
```

One source line changed, plus a regression test in
`tests/unit/drivers/vector/test_local_vector_store_driver.py` covering the
hyphenated-sibling-namespace case
(`test_query_vector_namespace_does_not_leak_hyphenated_sibling_namespace`).

Test evidence:
- The new test fails on the current code (`AssertionError: assert {'foo', 'foo-bar-baz-summary'} == {'foo'}`)
  and passes after the fix.
- Full `tests/unit/drivers/vector/test_local_vector_store_driver.py` suite with the
  fix: 1012 passed, 0 failed.

## Issue ticket number and link

Fixes https://github.com/griptape-ai/griptape/issues/2242
