### PR TITLE
LocalVectorStoreDriver namespace match accuracy

### DIFF
--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -97,10 +97,9 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         include_vectors: bool = False,
         **kwargs,
     ) -> list[BaseVectorStoreDriver.Entry]:
-        if namespace:
-            entries = {k: v for (k, v) in self.entries.items() if v.namespace == namespace}
-        else:
-            entries = self.entries
+        entries = (
+            {k: v for k, v in self.entries.items() if v.namespace == namespace} if namespace else self.entries
+        )
 
         entries_and_relatednesses = [
             (entry, self.calculate_relatedness(vector, entry.vector)) for entry in list(entries.values())

--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -97,9 +97,7 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         include_vectors: bool = False,
         **kwargs,
     ) -> list[BaseVectorStoreDriver.Entry]:
-        entries = (
-            {k: v for k, v in self.entries.items() if v.namespace == namespace} if namespace else self.entries
-        )
+        entries = {k: v for k, v in self.entries.items() if v.namespace == namespace} if namespace else self.entries
 
         entries_and_relatednesses = [
             (entry, self.calculate_relatedness(vector, entry.vector)) for entry in list(entries.values())

--- a/griptape/drivers/vector/local_vector_store_driver.py
+++ b/griptape/drivers/vector/local_vector_store_driver.py
@@ -98,7 +98,7 @@ class LocalVectorStoreDriver(BaseVectorStoreDriver):
         **kwargs,
     ) -> list[BaseVectorStoreDriver.Entry]:
         if namespace:
-            entries = {k: v for (k, v) in self.entries.items() if k.startswith(f"{namespace}-")}
+            entries = {k: v for (k, v) in self.entries.items() if v.namespace == namespace}
         else:
             entries = self.entries
 

--- a/tests/unit/drivers/vector/test_local_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_local_vector_store_driver.py
@@ -48,6 +48,14 @@ class TestLocalVectorStoreDriver(TestBaseVectorStoreDriver):
         assert result[0].score is not None
         assert result[0].namespace == "foo"
 
+    def test_query_vector_namespace_hyphen_prefix(self, driver):
+        driver.upsert(TextArtifact("hello foo"), namespace="foo")
+        driver.upsert(TextArtifact("hello foo-bar"), namespace="foo-bar")
+
+        result = driver.query_vector([0, 1], namespace="foo")
+
+        assert {r.namespace for r in result} == {"foo"}
+
     @pytest.mark.parametrize("execution_number", range(1000))
     def test_upsert_collection_meta(self, driver, mocker, execution_number):
         spy = mocker.spy(driver, "upsert_vector")


### PR DESCRIPTION
- [X] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Summary
Fixed [issue #2241](https://github.com/griptape-ai/griptape/issues/2241): LocalVectorStoreDriver.query_vector() leaking entries across namespaces sharing a hyphenated prefix.

Root cause: query_vector() filtered entries with a key-prefix check k.startswith(f"{namespace}-") against the derived storage key (f"{namespace}-{vector_id}"). Since namespaces can contain hyphens, a query for "foo" also matched entries in "foo-bar".

Fix in [local_vector_store_driver.py:101](vscode-webview://0c5bimdqi86ou9obd49pmqt5lqucfalvknrsanmog52ml4hisai8/drivers/vector/local_vector_store_driver.py#L101): swapped the prefix check for the exact-match filter v.namespace == namespace, matching the semantics already used by the sibling load_entries() method.

Regression test added in [test_local_vector_store_driver.py](vscode-webview://0c5bimdqi86ou9obd49pmqt5lqucfalvknrsanmog52ml4hisai8/tests/unit/drivers/vector/test_local_vector_store_driver.py) reproducing the issue's scenario ("foo" vs "foo-bar").

Both query_vector tests pass.

## Issue ticket number and link
Closes https://github.com/griptape-ai/griptape/issues/2241