### PR TITLE
fix(drivers-prompt-amazon-bedrock): omit unsupported temperature

### DIFF
--- a/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
+++ b/griptape/drivers/prompt/amazon_bedrock_prompt_driver.py
@@ -72,6 +72,13 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
     def client(self) -> Any:
         return self.session.client("bedrock-runtime")
 
+    @property
+    def supports_temperature(self) -> bool:
+        # claude-opus-4-7 and its dated variants deprecate sampling parameters. Bedrock model
+        # identifiers can be plain aliases, provider-prefixed IDs, geographic inference profile
+        # IDs, or ARNs, so match the model family anywhere in the identifier.
+        return "claude-opus-4-7" not in self.model
+
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:
         params = self._base_params(prompt_stack)
@@ -130,7 +137,7 @@ class AmazonBedrockPromptDriver(BasePromptDriver):
             "messages": messages,
             "system": system_messages,
             "inferenceConfig": {
-                "temperature": self.temperature,
+                **({"temperature": self.temperature} if self.supports_temperature else {}),
                 **({"maxTokens": self.max_tokens} if self.max_tokens is not None else {}),
             },
             "additionalModelRequestFields": self.additional_model_request_fields,

--- a/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_amazon_bedrock_prompt_driver.py
@@ -451,6 +451,47 @@ class TestAmazonBedrockPromptDriver:
         ):
             AmazonBedrockPromptDriver(model="foo", structured_output_strategy="native")
 
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("ai21.j2", True),
+            ("anthropic.claude-3-haiku-20240307-v1:0", True),
+            ("anthropic.claude-sonnet-4-5-20250929-v1:0", True),
+            ("claude-opus-4-7", False),
+            ("anthropic.claude-opus-4-7-20251101-v1:0", False),
+            ("us.anthropic.claude-opus-4-7-20251101-v1:0", False),
+            ("global.anthropic.claude-opus-4-7-20251101-v1:0", False),
+            (
+                "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-opus-4-7-20251101-v1:0",
+                False,
+            ),
+        ],
+    )
+    def test_supports_temperature(self, model, expected):
+        driver = AmazonBedrockPromptDriver(model=model)
+        assert driver.supports_temperature == expected
+
+    @pytest.mark.parametrize(
+        ("model", "expected_has_temperature"),
+        [
+            ("ai21.j2", True),
+            ("anthropic.claude-sonnet-4-5-20250929-v1:0", True),
+            ("claude-opus-4-7", False),
+            ("us.anthropic.claude-opus-4-7-20251101-v1:0", False),
+        ],
+    )
+    def test_base_params_temperature(self, model, expected_has_temperature):
+        driver = AmazonBedrockPromptDriver(model=model, temperature=0.7)
+        prompt_stack = PromptStack()
+        prompt_stack.add_user_message("test")
+
+        params = driver._base_params(prompt_stack)
+
+        if expected_has_temperature:
+            assert params["inferenceConfig"]["temperature"] == driver.temperature
+        else:
+            assert "temperature" not in params["inferenceConfig"]
+
     def test_try_run_with_reasoning_content(self, mocker):
         mock_converse = mocker.patch("boto3.Session").return_value.client.return_value.converse
         mock_converse.return_value = {


### PR DESCRIPTION
Claude Opus 4.7 rejects `temperature` in Bedrock Converse requests, while `BasePromptDriver` supplies `0.1` by default. Calls routed through Bedrock therefore fail before generation even when callers did not explicitly configure sampling.

Bedrock can represent a model through plain IDs, geographic inference profile IDs, or ARNs, so capability detection needs to recognize the model family across those forms. This aligns the Bedrock path with the direct `AnthropicPromptDriver` behavior introduced in #2163.

A live invocation against `global.anthropic.claude-opus-4-7` confirmed that the previous payload produces the reported `ValidationException`, while the fixed driver omits `temperature` and successfully returns a response. Related to griptape-ai/griptape-cloud#2104.

> [!NOTE]
> Beep boop. This PR description was written by AI.
