### PR TITLE
feat(ollama): expose api_key and headers on Ollama clients

### DIFF
--- a/griptape/drivers/embedding/ollama_embedding_driver.py
+++ b/griptape/drivers/embedding/ollama_embedding_driver.py
@@ -24,11 +24,18 @@ class OllamaEmbeddingDriver(BaseEmbeddingDriver):
 
     model: str = field(kw_only=True, metadata={"serializable": True})
     host: str | None = field(default=None, kw_only=True, metadata={"serializable": True})
+    api_key: str | None = field(default=None, kw_only=True, metadata={"serializable": False})
+    headers: dict[str, str] | None = field(default=None, kw_only=True, metadata={"serializable": False})
     _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
     @lazy_property()
     def client(self) -> Client:
-        return import_optional_dependency("ollama").Client(host=self.host)
+        client_kwargs: dict = {"host": self.host}
+        if self.headers is not None:
+            client_kwargs["headers"] = self.headers
+        if self.api_key is not None:
+            client_kwargs["api_key"] = self.api_key
+        return import_optional_dependency("ollama").Client(**client_kwargs)
 
     def try_embed_chunk(self, chunk: str, **kwargs) -> list[float]:
         return list(self.client.embeddings(model=self.model, prompt=chunk)["embedding"])

--- a/griptape/drivers/prompt/ollama_prompt_driver.py
+++ b/griptape/drivers/prompt/ollama_prompt_driver.py
@@ -46,10 +46,15 @@ class OllamaPromptDriver(BasePromptDriver):
 
     Attributes:
         model: Model name.
+        host: Optional Ollama host URL.
+        api_key: Optional API key forwarded to ``ollama.Client`` (Authorization header).
+        headers: Optional extra HTTP headers for auth reverse proxies.
     """
 
     model: str = field(kw_only=True, metadata={"serializable": True})
     host: str | None = field(default=None, kw_only=True, metadata={"serializable": True})
+    api_key: str | None = field(default=None, kw_only=True, metadata={"serializable": False})
+    headers: dict[str, str] | None = field(default=None, kw_only=True, metadata={"serializable": False})
     tokenizer: BaseTokenizer = field(
         default=Factory(
             lambda self: SimpleTokenizer(
@@ -77,7 +82,12 @@ class OllamaPromptDriver(BasePromptDriver):
 
     @lazy_property()
     def client(self) -> Client:
-        return import_optional_dependency("ollama").Client(host=self.host)
+        client_kwargs: dict[str, Any] = {"host": self.host}
+        if self.headers is not None:
+            client_kwargs["headers"] = self.headers
+        if self.api_key is not None:
+            client_kwargs["api_key"] = self.api_key
+        return import_optional_dependency("ollama").Client(**client_kwargs)
 
     @observable
     def try_run(self, prompt_stack: PromptStack) -> Message:

--- a/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
@@ -257,6 +257,25 @@ class TestOllamaPromptDriver:
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
+    def test_client_forwards_auth_kwargs(self, mocker):
+        mock_client_cls = mocker.patch("ollama.Client")
+        mocker.patch(
+            "griptape.drivers.prompt.ollama_prompt_driver.import_optional_dependency",
+            return_value=mocker.Mock(Client=mock_client_cls),
+        )
+        driver = OllamaPromptDriver(
+            model="llama3",
+            host="http://localhost:11434",
+            api_key="secret",
+            headers={"X-Proxy": "1"},
+        )
+        _ = driver.client
+        mock_client_cls.assert_called_once_with(
+            host="http://localhost:11434",
+            headers={"X-Proxy": "1"},
+            api_key="secret",
+        )
+
     def test_try_run(
         self,
         mock_client,

--- a/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_ollama_prompt_driver.py
@@ -255,8 +255,6 @@ class TestOllamaPromptDriver:
     def test_init(self):
         assert OllamaPromptDriver(model="llama")
 
-    @pytest.mark.parametrize("use_native_tools", [True, False])
-    @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
     def test_client_forwards_auth_kwargs(self, mocker):
         mock_client_cls = mocker.patch("ollama.Client")
         mocker.patch(
@@ -276,6 +274,8 @@ class TestOllamaPromptDriver:
             api_key="secret",
         )
 
+    @pytest.mark.parametrize("use_native_tools", [True, False])
+    @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])
     def test_try_run(
         self,
         mock_client,


### PR DESCRIPTION
## Summary
`OllamaPromptDriver` (and the embedding driver) only passed `host` into `ollama.Client`, so reverse-proxy auth was impossible without dropping down to the OpenAI-compatible driver (and losing native tool calling).

## Change
- Add optional `api_key` and `headers` fields on `OllamaPromptDriver` and `OllamaEmbeddingDriver`
- Forward them to `ollama.Client(**kwargs)` (ollama already maps `api_key` → `Authorization`)
- Unit test covers client construction kwargs

Closes #2238.
