### PR TITLE
fix: implement upsert_vector for MarqoVectorStoreDriver

### DIFF
--- a/griptape/drivers/vector/marqo_vector_store_driver.py
+++ b/griptape/drivers/vector/marqo_vector_store_driver.py
@@ -236,13 +236,21 @@ class MarqoVectorStoreDriver(BaseVectorStoreDriver):
             meta: An optional dictionary of metadata for the vector.
             kwargs: Additional keyword arguments to pass to the Marqo client.
 
-        Raises:
-            Exception: This function is not yet implemented.
-
         Returns:
             The ID of the vector that was added.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support upserting a vector.")
+        doc: dict[str, Any] = {"_id": vector_id, "vector": {"vector": vector}}
+        if namespace:
+            doc["namespace"] = namespace
+        if meta:
+            doc["meta"] = str(meta)
+
+        response = self.client.index(self.index).add_documents(
+            [doc], mappings={"vector": {"type": "custom_vector"}}, tensor_fields=["vector"]
+        )
+        if isinstance(response, dict) and "items" in response and response["items"]:
+            return response["items"][0]["_id"]
+        raise ValueError(f"Failed to upsert vector: {response}")
 
     def delete_vector(self, vector_id: str) -> NoReturn:
         raise NotImplementedError(f"{self.__class__.__name__} does not support deletion.")

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -95,6 +95,23 @@ class TestMarqoVectorStorageDriver:
         mock_marqo.index().add_documents.assert_called()
         assert result == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
 
+    def test_upsert_vector(self, driver, mock_marqo):
+        result = driver.upsert_vector([0.1, 0.2, 0.3], vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d")
+        mock_marqo.index().add_documents.assert_called()
+        assert result == "5aed93eb-3878-4f12-bc92-0fda01c7d23d"
+
+    def test_upsert_vector_with_namespace_and_meta(self, driver, mock_marqo):
+        driver.upsert_vector(
+            [0.1, 0.2, 0.3],
+            vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d",
+            namespace="test-namespace",
+            meta={"foo": "bar"},
+        )
+        args, kwargs = mock_marqo.index().add_documents.call_args
+        doc = args[0][0]
+        assert doc["namespace"] == "test-namespace"
+        assert doc["meta"] == str({"foo": "bar"})
+
     def test_upsert_text_artifact(self, driver, mock_marqo):
         # Arrange
         text = TextArtifact(id="a44b04ff052e4109b3c6fda0f3f3e997", value="racoons")

--- a/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_marqo_vector_store_driver.py
@@ -112,6 +112,11 @@ class TestMarqoVectorStorageDriver:
         assert doc["namespace"] == "test-namespace"
         assert doc["meta"] == str({"foo": "bar"})
 
+    def test_upsert_vector_raises_on_failed_response(self, driver, mock_marqo):
+        mock_marqo.index().add_documents.return_value = {"errors": True, "items": []}
+        with pytest.raises(ValueError, match="Failed to upsert vector"):
+            driver.upsert_vector([0.1, 0.2, 0.3], vector_id="5aed93eb-3878-4f12-bc92-0fda01c7d23d")
+
     def test_upsert_text_artifact(self, driver, mock_marqo):
         # Arrange
         text = TextArtifact(id="a44b04ff052e4109b3c6fda0f3f3e997", value="racoons")


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

`MarqoVectorStoreDriver.upsert_vector` previously raised `NotImplementedError`. Marqo supports upserting arbitrary vectors through [custom vector fields](https://docs.marqo.ai/latest/reference/api/documents/add-or-replace-documents/#unstructured-index-default_1), so this implements it:

- Builds a document with a `custom_vector` mapping and upserts it via `add_documents`, mirroring the existing `upsert` method in the same driver (namespace/meta handling, response parsing, and returning the `_id`).
- Removes the now-inaccurate `Raises: ... not yet implemented` line from the docstring.
- Adds unit tests covering the basic upsert and the namespace/meta passthrough, using the existing mocked Marqo client fixture.

Note: unlike the `PineconeVectorStoreDriver`, `**kwargs` is intentionally not forwarded to `add_documents`, since Marqo's `add_documents` has a fixed signature (no `**kwargs`) — this matches the existing `upsert` method in this driver.

## Issue ticket number and link

Closes #1802 — https://github.com/griptape-ai/griptape/issues/1802

---

_AI assistance disclosure (per CONTRIBUTING.md): this change was drafted with AI assistance. The implementation follows the pattern of the existing `upsert` method and the issue author's suggested approach; I verified `custom_vector` is a valid Marqo mapping type and that `add_documents` does not accept arbitrary kwargs against the pinned `marqo` version, and confirmed the full driver test suite passes locally (`pytest`) with `ruff check`/`format` clean._