### PR TITLE
ci: push only the release tag on version/publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,10 @@ version/commit: ## Commit version.
 	@git commit -m "chore: bump v$$(make version/get)"
 
 .PHONY: version/publish
-version/publish: ## Create and push git tags.
-	@git tag v$$(make version/get)
-	@git tag latest -f
-	@git push -f --tags
+version/publish: ## Create and push the release tag.
 	@git push
+	@git tag v$$(make version/get)
+	@git push origin v$$(make version/get)
 	
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

`make version/publish` force-pushed every local tag and maintained a moving `latest` tag, which overrode Read the Docs' automatic `latest`/`stable` version resolution and let a stale `stable` tag pointing at v0.27.1 get swept up to the remote. It now pushes only the new `vX.Y.Z` tag.

## Issue ticket number and link

Related https://github.com/griptape-ai/griptape/issues/2255