### PR TITLE
feat(drivers-rerank-voyageai): add VoyageAiRerankDriver

### DIFF
--- a/docs/griptape-framework/drivers/rerank-drivers.md
+++ b/docs/griptape-framework/drivers/rerank-drivers.md
@@ -68,3 +68,17 @@ The [NvidiaNimRerankDriver](../../reference/griptape/drivers/rerank/nvidia_nim_r
     ```python
     --8<-- "docs/griptape-framework/drivers/src/nvidia_nim_rerank_driver.py"
     ```
+
+### Voyage AI
+
+!!! info
+
+    This driver requires the `drivers-rerank-voyageai` [extra](../index.md#extras).
+
+The [VoyageAiRerankDriver](../../reference/griptape/drivers/rerank/voyageai_rerank_driver.md) uses [Voyage AI's Rerank](https://docs.voyageai.com/docs/reranker) API.
+
+=== "Code"
+
+    ```python
+    --8<-- "docs/griptape-framework/drivers/src/voyageai_rerank_driver.py"
+    ```

--- a/docs/griptape-framework/drivers/src/voyageai_rerank_driver.py
+++ b/docs/griptape-framework/drivers/src/voyageai_rerank_driver.py
@@ -1,0 +1,20 @@
+import os
+
+from griptape.artifacts import TextArtifact
+from griptape.drivers.rerank.voyageai import VoyageAiRerankDriver
+
+rerank_driver = VoyageAiRerankDriver(
+    api_key=os.environ["VOYAGE_API_KEY"],
+)
+
+artifacts = rerank_driver.run(
+    "Where is NYC located?",
+    [
+        TextArtifact("NYC Media"),
+        TextArtifact("New York City Police Department"),
+        TextArtifact("New York City"),
+        TextArtifact("New York City Subway"),
+    ],
+)
+for artifact in artifacts:
+    print(artifact.value)

--- a/griptape/drivers/__init__.py
+++ b/griptape/drivers/__init__.py
@@ -104,6 +104,7 @@ from .rerank import BaseRerankDriver
 from .rerank.cohere import CohereRerankDriver
 from .rerank.local import LocalRerankDriver
 from .rerank.amazon_bedrock import AmazonBedrockRerankDriver
+from .rerank.voyageai import VoyageAiRerankDriver
 
 from .ruleset import BaseRulesetDriver
 from .ruleset.local import LocalRulesetDriver
@@ -263,6 +264,7 @@ __all__ = [
     "TavilyWebSearchDriver",
     "TrafilaturaWebScraperDriver",
     "VoyageAiEmbeddingDriver",
+    "VoyageAiRerankDriver",
     "WebhookEventListenerDriver",
 ]
 

--- a/griptape/drivers/rerank/voyageai/__init__.py
+++ b/griptape/drivers/rerank/voyageai/__init__.py
@@ -1,0 +1,3 @@
+from griptape.drivers.rerank.voyageai_rerank_driver import VoyageAiRerankDriver
+
+__all__ = ["VoyageAiRerankDriver"]

--- a/griptape/drivers/rerank/voyageai_rerank_driver.py
+++ b/griptape/drivers/rerank/voyageai_rerank_driver.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from attrs import define, field
+
+from griptape.drivers.rerank import BaseRerankDriver
+from griptape.utils import import_optional_dependency
+from griptape.utils.decorators import lazy_property
+
+if TYPE_CHECKING:
+    from voyageai.client import Client
+
+    from griptape.artifacts import TextArtifact
+
+
+@define(kw_only=True)
+class VoyageAiRerankDriver(BaseRerankDriver):
+    """Voyage AI Rerank Driver.
+
+    Attributes:
+        model: Voyage AI rerank model name.
+        api_key: API key to pass directly. Defaults to `VOYAGE_API_KEY` environment variable.
+        top_k: Optional maximum number of results to return.
+    """
+
+    model: str = field(default="rerank-2.5", metadata={"serializable": True})
+    api_key: str | None = field(default=None, metadata={"serializable": False})
+    top_k: int | None = field(default=None, metadata={"serializable": True})
+    _client: Client | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
+
+    @lazy_property()
+    def client(self) -> Any:
+        return import_optional_dependency("voyageai").Client(api_key=self.api_key)
+
+    def run(self, query: str, artifacts: list[TextArtifact]) -> list[TextArtifact]:
+        truthy_artifacts = [artifact for artifact in artifacts if artifact]
+
+        if not truthy_artifacts:
+            return []
+
+        response = self.client.rerank(
+            query=query,
+            documents=[artifact.to_text() for artifact in truthy_artifacts],
+            model=self.model,
+            top_k=self.top_k,
+        )
+
+        return [truthy_artifacts[result.index] for result in response.results]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ drivers-event-listener-pusher = ["pusher>=3.3.2"]
 drivers-text-to-speech-elevenlabs = ["elevenlabs>=1.1.2"]
 drivers-rerank-cohere = ["cohere>=5.11.2"]
 drivers-rerank-amazon-bedrock = ["boto3>=1.34.119"]
+drivers-rerank-voyageai = ["voyageai>=0.2.1"]
 drivers-observability-opentelemetry = [
   "opentelemetry-sdk>=1.25.0",
   "opentelemetry-api>=1.25.0",

--- a/tests/unit/drivers/rerank/test_voyageai_rerank_driver.py
+++ b/tests/unit/drivers/rerank/test_voyageai_rerank_driver.py
@@ -1,0 +1,160 @@
+from unittest.mock import Mock
+
+import pytest
+
+from griptape.artifacts import TextArtifact
+from griptape.drivers.rerank.voyageai import VoyageAiRerankDriver
+
+
+class TestVoyageAiRerankDriver:
+    # ---------------------------------------------------------------------------
+    # Fixtures
+    # ---------------------------------------------------------------------------
+
+    @pytest.fixture()
+    def mock_client(self, mocker):
+        mock_client = mocker.patch("voyageai.Client").return_value
+        mock_client.rerank.return_value = Mock(
+            results=[
+                Mock(index=1, document="bar", relevance_score=1.0),
+                Mock(index=0, document="foo", relevance_score=0.5),
+            ]
+        )
+
+        return mock_client
+
+    @pytest.fixture()
+    def mock_empty_client(self, mocker):
+        mock_client = mocker.patch("voyageai.Client").return_value
+        mock_client.rerank.side_effect = Exception("Client should not be called")
+
+        return mock_client
+
+    # ---------------------------------------------------------------------------
+    # Defaults / instantiation
+    # ---------------------------------------------------------------------------
+
+    def test_init(self):
+        assert VoyageAiRerankDriver()
+
+    def test_default_model(self):
+        assert VoyageAiRerankDriver().model == "rerank-2.5"
+
+    def test_default_api_key_is_none(self):
+        assert VoyageAiRerankDriver().api_key is None
+
+    def test_default_top_k_is_none(self):
+        assert VoyageAiRerankDriver().top_k is None
+
+    def test_client_is_constructed_with_api_key(self, mocker):
+        mock_client_cls = mocker.patch("voyageai.Client")
+
+        driver = VoyageAiRerankDriver(api_key="my-secret-key")
+        _ = driver.client
+
+        mock_client_cls.assert_called_once_with(api_key="my-secret-key")
+
+    def test_client_override(self, mocker):
+        mock_client_cls = mocker.patch("voyageai.Client")
+        custom_client = mocker.MagicMock()
+
+        driver = VoyageAiRerankDriver(client=custom_client)
+
+        assert driver.client is custom_client
+        mock_client_cls.assert_not_called()
+
+    # ---------------------------------------------------------------------------
+    # run() — empty / falsy inputs
+    # ---------------------------------------------------------------------------
+
+    def test_run_empty_artifacts_returns_empty(self, mock_empty_client):
+        driver = VoyageAiRerankDriver(api_key="api-key")
+
+        result = driver.run("hello", artifacts=[])
+
+        assert result == []
+        mock_empty_client.rerank.assert_not_called()
+
+    def test_run_all_falsy_artifacts_returns_empty(self, mock_empty_client):
+        driver = VoyageAiRerankDriver(api_key="api-key")
+
+        result = driver.run("hello", artifacts=[TextArtifact(""), TextArtifact("  ")])
+
+        assert result == []
+        mock_empty_client.rerank.assert_not_called()
+
+    def test_run_with_mixed_falsy_and_truthy_artifacts(self, mocker):
+        mock_client = mocker.patch("voyageai.Client").return_value
+        # "first" and "third" survive filtering and are sent to the API at index 0 and 1 respectively.
+        mock_client.rerank.return_value = Mock(
+            results=[
+                Mock(index=1, document="third", relevance_score=0.95),
+                Mock(index=0, document="first", relevance_score=0.60),
+            ]
+        )
+
+        artifacts = [TextArtifact("first"), TextArtifact("   "), TextArtifact("third")]
+        driver = VoyageAiRerankDriver(api_key="api-key")
+
+        result = driver.run("query", artifacts=artifacts)
+
+        mock_client.rerank.assert_called_once_with(
+            query="query", documents=["first", "third"], model="rerank-2.5", top_k=None
+        )
+        assert len(result) == 2
+        assert result[0].value == "third"
+        assert result[1].value == "first"
+
+    # ---------------------------------------------------------------------------
+    # run() — happy path
+    # ---------------------------------------------------------------------------
+
+    def test_run_returns_artifacts_in_relevance_order(self, mock_client):
+        driver = VoyageAiRerankDriver(api_key="api-key")
+
+        result = driver.run("hello", artifacts=[TextArtifact("foo"), TextArtifact("bar")])
+
+        assert len(result) == 2
+        assert result[0].value == "bar"
+        assert result[1].value == "foo"
+
+    def test_run_single_artifact(self, mocker):
+        mock_client = mocker.patch("voyageai.Client").return_value
+        mock_client.rerank.return_value = Mock(results=[Mock(index=0, document="only one", relevance_score=0.99)])
+
+        driver = VoyageAiRerankDriver(api_key="api-key")
+        result = driver.run("query", artifacts=[TextArtifact("only one")])
+
+        assert len(result) == 1
+        assert result[0].value == "only one"
+
+    def test_run_empty_results_returns_empty(self, mocker):
+        mock_client = mocker.patch("voyageai.Client").return_value
+        mock_client.rerank.return_value = Mock(results=[])
+
+        driver = VoyageAiRerankDriver(api_key="api-key")
+        result = driver.run("query", artifacts=[TextArtifact("only one")])
+
+        assert result == []
+
+    # ---------------------------------------------------------------------------
+    # run() — request parameters
+    # ---------------------------------------------------------------------------
+
+    def test_run_passes_model_and_top_k(self, mock_client):
+        driver = VoyageAiRerankDriver(api_key="api-key", model="rerank-2.5-lite", top_k=1)
+
+        driver.run("hello", artifacts=[TextArtifact("foo"), TextArtifact("bar")])
+
+        mock_client.rerank.assert_called_once_with(
+            query="hello", documents=["foo", "bar"], model="rerank-2.5-lite", top_k=1
+        )
+
+    def test_run_passes_top_k_none_when_unset(self, mock_client):
+        driver = VoyageAiRerankDriver(api_key="api-key")
+
+        driver.run("hello", artifacts=[TextArtifact("foo"), TextArtifact("bar")])
+
+        mock_client.rerank.assert_called_once_with(
+            query="hello", documents=["foo", "bar"], model="rerank-2.5", top_k=None
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1544,6 +1544,9 @@ drivers-rerank-amazon-bedrock = [
 drivers-rerank-cohere = [
     { name = "cohere" },
 ]
+drivers-rerank-voyageai = [
+    { name = "voyageai" },
+]
 drivers-sql = [
     { name = "sqlalchemy" },
 ]
@@ -1791,9 +1794,10 @@ requires-dist = [
     { name = "urllib3", specifier = ">=1.25.4,!=2.2.0,<3" },
     { name = "voyageai", marker = "extra == 'all'", specifier = ">=0.2.1" },
     { name = "voyageai", marker = "extra == 'drivers-embedding-voyageai'", specifier = ">=0.2.1" },
+    { name = "voyageai", marker = "extra == 'drivers-rerank-voyageai'", specifier = ">=0.2.1" },
     { name = "wrapt", specifier = ">=1.16.0" },
 ]
-provides-extras = ["drivers-prompt-cohere", "drivers-prompt-anthropic", "drivers-prompt-huggingface-hub", "drivers-prompt-huggingface-pipeline", "drivers-prompt-amazon-bedrock", "drivers-prompt-amazon-sagemaker", "drivers-prompt-google", "drivers-prompt-ollama", "drivers-sql", "drivers-sql-amazon-redshift", "drivers-sql-snowflake", "drivers-memory-conversation-amazon-dynamodb", "drivers-memory-conversation-redis", "drivers-vector-marqo", "drivers-vector-pinecone", "drivers-vector-mongodb", "drivers-vector-redis", "drivers-vector-opensearch", "drivers-vector-amazon-opensearch", "drivers-vector-pgvector", "drivers-vector-qdrant", "drivers-vector-astra-db", "drivers-vector-pgai", "drivers-embedding-amazon-bedrock", "drivers-embedding-amazon-sagemaker", "drivers-embedding-huggingface", "drivers-embedding-voyageai", "drivers-embedding-google", "drivers-embedding-cohere", "drivers-embedding-ollama", "drivers-web-scraper-trafilatura", "drivers-web-scraper-markdownify", "drivers-web-search-duckduckgo", "drivers-web-search-tavily", "drivers-web-search-exa", "drivers-event-listener-amazon-sqs", "drivers-event-listener-amazon-iot", "drivers-event-listener-pusher", "drivers-text-to-speech-elevenlabs", "drivers-rerank-cohere", "drivers-rerank-amazon-bedrock", "drivers-observability-opentelemetry", "drivers-observability-griptape-cloud", "drivers-observability-datadog", "drivers-image-generation-huggingface", "drivers-file-manager-amazon-s3", "loaders-pdf", "loaders-image", "loaders-email", "loaders-sql", "all"]
+provides-extras = ["drivers-prompt-cohere", "drivers-prompt-anthropic", "drivers-prompt-huggingface-hub", "drivers-prompt-huggingface-pipeline", "drivers-prompt-amazon-bedrock", "drivers-prompt-amazon-sagemaker", "drivers-prompt-google", "drivers-prompt-ollama", "drivers-sql", "drivers-sql-amazon-redshift", "drivers-sql-snowflake", "drivers-memory-conversation-amazon-dynamodb", "drivers-memory-conversation-redis", "drivers-vector-marqo", "drivers-vector-pinecone", "drivers-vector-mongodb", "drivers-vector-redis", "drivers-vector-opensearch", "drivers-vector-amazon-opensearch", "drivers-vector-pgvector", "drivers-vector-qdrant", "drivers-vector-astra-db", "drivers-vector-pgai", "drivers-embedding-amazon-bedrock", "drivers-embedding-amazon-sagemaker", "drivers-embedding-huggingface", "drivers-embedding-voyageai", "drivers-embedding-google", "drivers-embedding-cohere", "drivers-embedding-ollama", "drivers-web-scraper-trafilatura", "drivers-web-scraper-markdownify", "drivers-web-search-duckduckgo", "drivers-web-search-tavily", "drivers-web-search-exa", "drivers-event-listener-amazon-sqs", "drivers-event-listener-amazon-iot", "drivers-event-listener-pusher", "drivers-text-to-speech-elevenlabs", "drivers-rerank-cohere", "drivers-rerank-amazon-bedrock", "drivers-rerank-voyageai", "drivers-observability-opentelemetry", "drivers-observability-griptape-cloud", "drivers-observability-datadog", "drivers-image-generation-huggingface", "drivers-file-manager-amazon-s3", "loaders-pdf", "loaders-image", "loaders-email", "loaders-sql", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes
Adds a VoyageAiRerankDriver for reranking search results using Voyage AI's Rerank API (rerank-2.5 by default). Same pattern as the existing Cohere/Bedrock rerank drivers and the existing VoyageAiEmbeddingDriver — lazy client, optional dependency, filters out empty artifacts before calling the API.

Includes unit tests, a doc example, and the new drivers-rerank-voyageai extra.

## Issue ticket number and link
Closes #1771 


<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2263.org.readthedocs.build//2263/

<!-- readthedocs-preview griptape end -->