### PR TITLE
feat: add video URL prompt content

### DIFF
--- a/griptape/common/__init__.py
+++ b/griptape/common/__init__.py
@@ -7,6 +7,7 @@ from .prompt_stack.contents.text_delta_message_content import TextDeltaMessageCo
 from .prompt_stack.contents.audio_delta_message_content import AudioDeltaMessageContent
 from .prompt_stack.contents.text_message_content import TextMessageContent
 from .prompt_stack.contents.image_message_content import ImageMessageContent
+from .prompt_stack.contents.video_message_content import VideoMessageContent
 from .prompt_stack.contents.audio_message_content import AudioMessageContent
 from .prompt_stack.contents.action_call_delta_message_content import ActionCallDeltaMessageContent
 from .prompt_stack.contents.action_call_message_content import ActionCallMessageContent
@@ -45,5 +46,6 @@ __all__ = [
     "TextDeltaMessageContent",
     "TextMessageContent",
     "ToolAction",
+    "VideoMessageContent",
     "observable",
 ]

--- a/griptape/common/prompt_stack/contents/video_message_content.py
+++ b/griptape/common/prompt_stack/contents/video_message_content.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from attrs import define, field
+
+from griptape.common import BaseDeltaMessageContent, BaseMessageContent
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from griptape.artifacts import VideoUrlArtifact
+
+
+@define
+class VideoMessageContent(BaseMessageContent):
+    artifact: VideoUrlArtifact = field(metadata={"serializable": True})
+
+    @classmethod
+    def from_deltas(cls, deltas: Sequence[BaseDeltaMessageContent]) -> VideoMessageContent:
+        raise NotImplementedError

--- a/griptape/common/prompt_stack/prompt_stack.py
+++ b/griptape/common/prompt_stack/prompt_stack.py
@@ -15,6 +15,7 @@ from griptape.artifacts import (
     ImageUrlArtifact,
     ListArtifact,
     TextArtifact,
+    VideoUrlArtifact,
 )
 from griptape.common import (
     ActionCallMessageContent,
@@ -25,6 +26,7 @@ from griptape.common import (
     ImageMessageContent,
     Message,
     TextMessageContent,
+    VideoMessageContent,
 )
 from griptape.mixins.serializable_mixin import SerializableMixin
 from griptape.utils.json_schema_utils import build_strict_schema
@@ -87,7 +89,7 @@ class PromptStack(SerializableMixin):
 
         return prompt_stack
 
-    def __to_message_content(self, artifact: str | BaseArtifact) -> list[BaseMessageContent]:
+    def __to_message_content(self, artifact: str | BaseArtifact) -> list[BaseMessageContent]:  # noqa: C901
         if isinstance(artifact, str):
             return [TextMessageContent(TextArtifact(artifact))]
         if isinstance(artifact, TextArtifact):
@@ -98,6 +100,8 @@ class PromptStack(SerializableMixin):
             return [ImageMessageContent(artifact)]
         if isinstance(artifact, AudioArtifact):
             return [AudioMessageContent(artifact)]
+        if isinstance(artifact, VideoUrlArtifact):
+            return [VideoMessageContent(artifact)]
         if isinstance(artifact, GenericArtifact):
             return [GenericMessageContent(artifact)]
         if isinstance(artifact, ActionArtifact):

--- a/griptape/drivers/prompt/openai_chat_prompt_driver.py
+++ b/griptape/drivers/prompt/openai_chat_prompt_driver.py
@@ -25,6 +25,7 @@ from griptape.common import (
     TextDeltaMessageContent,
     TextMessageContent,
     ToolAction,
+    VideoMessageContent,
     observable,
 )
 from griptape.configs.defaults_config import Defaults
@@ -324,7 +325,7 @@ class OpenAiChatPromptDriver(BasePromptDriver):
             for activity in tool.activities()
         ]
 
-    def __to_openai_message_content(self, content: BaseMessageContent) -> str | dict:
+    def __to_openai_message_content(self, content: BaseMessageContent) -> str | dict:  # noqa: C901
         if isinstance(content, TextMessageContent):
             return {"type": "text", "text": content.artifact.to_text()}
         if isinstance(content, ImageMessageContent):
@@ -361,6 +362,11 @@ class OpenAiChatPromptDriver(BasePromptDriver):
                     "data": base64.b64encode(artifact.value).decode("utf-8"),
                     "format": artifact.format,
                 },
+            }
+        if isinstance(content, VideoMessageContent):
+            return {
+                "type": "video_url",
+                "video_url": {"url": content.artifact.value},
             }
         if isinstance(content, ActionCallMessageContent):
             action = content.artifact.value

--- a/tests/unit/common/contents/test_video_message_content.py
+++ b/tests/unit/common/contents/test_video_message_content.py
@@ -1,0 +1,15 @@
+import pytest
+
+from griptape.artifacts import VideoUrlArtifact
+from griptape.common import VideoMessageContent
+
+
+class TestVideoMessageContent:
+    def test_init(self):
+        assert VideoMessageContent(VideoUrlArtifact("https://example.com/input.mp4")).artifact.value == (
+            "https://example.com/input.mp4"
+        )
+
+    def test_from_deltas(self):
+        with pytest.raises(NotImplementedError):
+            VideoMessageContent.from_deltas([])

--- a/tests/unit/common/test_prompt_stack.py
+++ b/tests/unit/common/test_prompt_stack.py
@@ -4,7 +4,14 @@ import pytest
 from pydantic import create_model
 from schema import Schema
 
-from griptape.artifacts import ActionArtifact, GenericArtifact, ImageArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import (
+    ActionArtifact,
+    GenericArtifact,
+    ImageArtifact,
+    ListArtifact,
+    TextArtifact,
+    VideoUrlArtifact,
+)
 from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.common import (
     ActionCallMessageContent,
@@ -14,6 +21,7 @@ from griptape.common import (
     PromptStack,
     TextMessageContent,
     ToolAction,
+    VideoMessageContent,
 )
 
 
@@ -100,6 +108,12 @@ class TestPromptStack:
 
         assert prompt_stack.messages[0].role == "system"
         assert prompt_stack.messages[0].content[0].artifact.value == "foo"
+
+    def test_add_video_url_message(self, prompt_stack):
+        prompt_stack.add_user_message(VideoUrlArtifact("https://example.com/input.mp4"))
+
+        assert isinstance(prompt_stack.messages[0].content[0], VideoMessageContent)
+        assert prompt_stack.messages[0].content[0].artifact.value == "https://example.com/input.mp4"
 
     def test_add_user_message(self, prompt_stack):
         prompt_stack.add_user_message("foo")

--- a/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py
@@ -9,6 +9,7 @@ from griptape.artifacts import ActionArtifact, ImageArtifact, ListArtifact, Text
 from griptape.artifacts.audio_artifact import AudioArtifact
 from griptape.artifacts.generic_artifact import GenericArtifact
 from griptape.artifacts.image_url_artifact import ImageUrlArtifact
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape.common import ActionCallDeltaMessageContent, PromptStack, TextDeltaMessageContent, ToolAction
 from griptape.common.prompt_stack.contents.audio_delta_message_content import AudioDeltaMessageContent
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
@@ -532,6 +533,25 @@ class TestOpenAiChatPromptDriver(TestOpenAiChatPromptDriverFixtureMixin):
         # Test reasoning effort inclusion
         has_reasoning_effort = "reasoning_effort" in params
         assert has_reasoning_effort == expected_reasoning
+
+    def test_video_url_message_content(self):
+        driver = OpenAiChatPromptDriver(model="MiniMax-M3")
+        prompt_stack = PromptStack()
+        prompt_stack.add_user_message(VideoUrlArtifact("https://example.com/input.mp4"))
+
+        params = driver._base_params(prompt_stack)
+
+        assert params["messages"] == [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/input.mp4"},
+                    }
+                ],
+            }
+        ]
 
     @pytest.mark.parametrize("use_native_tools", [True, False])
     @pytest.mark.parametrize("structured_output_strategy", ["native", "tool", "rule", "foo"])


### PR DESCRIPTION
Reason: MiniMax-M3 accepts video input, but Griptape could not represent or convert video prompt content.

## Summary

- Add URL-backed video message content to prompt stacks.
- Convert video prompts to the OpenAI-compatible `video_url` request shape.
- Cover content creation, prompt-stack conversion, and driver request conversion.

## Testing

- `uv run --python 3.13 --offline pytest -q tests/unit/common/contents/test_video_message_content.py tests/unit/common/test_prompt_stack.py tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py` (457 passed)
- `uv run --python 3.13 --offline ruff format --check griptape/common/__init__.py griptape/common/prompt_stack/contents/video_message_content.py griptape/common/prompt_stack/prompt_stack.py griptape/drivers/prompt/openai_chat_prompt_driver.py tests/unit/common/contents/test_video_message_content.py tests/unit/common/test_prompt_stack.py tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py`
- `uv run --python 3.13 --offline ruff check griptape/common/__init__.py griptape/common/prompt_stack/contents/video_message_content.py griptape/common/prompt_stack/prompt_stack.py griptape/drivers/prompt/openai_chat_prompt_driver.py tests/unit/common/contents/test_video_message_content.py tests/unit/common/test_prompt_stack.py tests/unit/drivers/prompt/test_openai_chat_prompt_driver.py`
- `uv run --python 3.13 --offline pyright griptape/common/prompt_stack/contents/video_message_content.py griptape/common/prompt_stack/prompt_stack.py griptape/drivers/prompt/openai_chat_prompt_driver.py`