### PR TITLE
fix(drivers-prompt): treat streamed usage deltas as running totals, not increments

### DIFF
--- a/griptape/drivers/prompt/base_prompt_driver.py
+++ b/griptape/drivers/prompt/base_prompt_driver.py
@@ -171,7 +171,15 @@ class BasePromptDriver(SerializableMixin, ExponentialBackoffMixin, ABC):
         # Aggregate all content deltas from the stream
         message_deltas = self.try_stream(prompt_stack)
         for message_delta in message_deltas:
-            usage += message_delta.usage
+            # Providers report usage as running totals over the stream -- e.g. Anthropic's
+            # cumulative output tokens on every `message_delta`, Gemini's per-chunk
+            # `usage_metadata` -- rather than as per-delta increments. Keep the latest
+            # reported value per field: summing would inflate those providers' totals,
+            # while being equivalent for providers that emit a single final usage delta.
+            if message_delta.usage.input_tokens is not None:
+                usage.input_tokens = message_delta.usage.input_tokens
+            if message_delta.usage.output_tokens is not None:
+                usage.output_tokens = message_delta.usage.output_tokens
             content = message_delta.content
 
             if content is not None:

--- a/tests/mocks/mock_stream_usage_prompt_driver.py
+++ b/tests/mocks/mock_stream_usage_prompt_driver.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from attrs import define, field
+
+from griptape.common import DeltaMessage, PromptStack
+from tests.mocks.mock_prompt_driver import MockPromptDriver
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@define
+class MockStreamUsagePromptDriver(MockPromptDriver):
+    """Emits a fixed sequence of usage-only deltas from try_stream.
+
+    Mimics providers that report usage as running totals over the stream rather than
+    per-delta increments (Anthropic's cumulative ``message_delta`` usage, Gemini's
+    per-chunk ``usage_metadata``).
+    """
+
+    stream_usage_deltas: list[DeltaMessage.Usage] = field(factory=list, kw_only=True)
+
+    def try_stream(self, prompt_stack: PromptStack) -> Iterator[DeltaMessage]:
+        for usage in self.stream_usage_deltas:
+            yield DeltaMessage(usage=usage)

--- a/tests/unit/drivers/prompt/test_base_prompt_driver.py
+++ b/tests/unit/drivers/prompt/test_base_prompt_driver.py
@@ -4,7 +4,7 @@ import warnings
 import pytest
 
 from griptape.artifacts import ActionArtifact, ErrorArtifact, TextArtifact
-from griptape.common import AudioMessageContent, Message, PromptStack, TextMessageContent
+from griptape.common import AudioMessageContent, DeltaMessage, Message, PromptStack, TextMessageContent
 from griptape.events import FinishPromptEvent, StartPromptEvent
 from griptape.events.event_bus import _EventBus
 from griptape.structures import Pipeline
@@ -12,6 +12,7 @@ from griptape.tasks import PromptTask
 from griptape.tools.structured_output.tool import StructuredOutputTool
 from tests.mocks.mock_failing_prompt_driver import MockFailingPromptDriver
 from tests.mocks.mock_prompt_driver import MockPromptDriver
+from tests.mocks.mock_stream_usage_prompt_driver import MockStreamUsagePromptDriver
 from tests.mocks.mock_tool.tool import MockTool
 
 
@@ -145,3 +146,32 @@ class TestBasePromptDriver:
             from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 
             assert BasePromptDriver
+
+    def test_stream_usage_keeps_latest_running_total(self):
+        # Providers like Anthropic (cumulative `message_delta` usage) and Gemini
+        # (per-chunk `usage_metadata`) report running totals, not increments.
+        driver = MockStreamUsagePromptDriver(
+            stream=True,
+            stream_usage_deltas=[
+                DeltaMessage.Usage(input_tokens=100),
+                DeltaMessage.Usage(output_tokens=1),
+                DeltaMessage.Usage(output_tokens=2),
+            ],
+        )
+
+        message = driver.run(PromptStack())
+
+        assert message.usage.input_tokens == 100
+        assert message.usage.output_tokens == 2
+
+    def test_stream_usage_single_final_report(self):
+        # Providers like OpenAI and Bedrock report a single final usage delta.
+        driver = MockStreamUsagePromptDriver(
+            stream=True,
+            stream_usage_deltas=[DeltaMessage.Usage(input_tokens=7, output_tokens=9)],
+        )
+
+        message = driver.run(PromptStack())
+
+        assert message.usage.input_tokens == 7
+        assert message.usage.output_tokens == 9


### PR DESCRIPTION
## Root cause

`BasePromptDriver.__process_stream` aggregated streamed usage with `usage += message_delta.usage`. `BaseMessage.Usage.__add__` sums each field (treating `None` as `0`), which assumes every delta carries a *per-delta increment* — but Anthropic (`message_delta` usage) and Gemini (per-chunk `usage_metadata`) report **running totals**. A 100-chunk Anthropic response emitting cumulative totals `1..100` was reported as `5050` output tokens instead of `100`; unknown fields were also silently coerced to `0`.

Details and repro in #2275.

## Fix

Aggregate field-wise with last-reported-wins in `__process_stream`, keeping the public `Usage.__add__` untouched:

```python
if message_delta.usage.input_tokens is not None:
    usage.input_tokens = message_delta.usage.input_tokens
if message_delta.usage.output_tokens is not None:
    usage.output_tokens = message_delta.usage.output_tokens
```

Equivalent for providers that emit one final usage delta (OpenAI, Bedrock, Cohere, HuggingFace), correct for running-total providers (Anthropic, Gemini). Unknown fields now stay honestly `None` when never reported.

## Test

- [x] Regression test: running-total sequence `[Usage(input=100), Usage(output=1), Usage(output=2)]` → final `Usage(input=100, output=2)` — **fails on main** (reports `output=3`)
- [x] Contract test: single final delta `[Usage(7, 9)]` → `(7, 9)` unchanged
- [x] New mock `tests/mocks/mock_stream_usage_prompt_driver.py` emits configurable usage-only deltas
- [x] `pytest tests/unit/drivers/prompt tests/unit/structures tests/unit/common` → 1045 passed; failures identical to clean-main baseline under the same environment (missing optional ollama deps), no new failures
- [x] `ruff check` + `ruff format --check` clean on changed files

## Diff scope

3 files: driver aggregation loop (+9/-1), one new mock (+27), two regression tests in `test_base_prompt_driver.py` (+31/-0).

Fixes #2275
