### PR TITLE
fix(tools-mcp): use removeprefix instead of lstrip for image/audio MIME format

### DIFF
--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -249,10 +249,12 @@ class MCPTool(BaseTool):
                 response_artifacts.append(TextArtifact(content.text))
             elif isinstance(content, types.ImageContent):
                 response_artifacts.append(
-                    ImageArtifact(value=content.data, format=content.mimeType.lstrip("image/"), width=0, height=0)
+                    ImageArtifact(value=content.data, format=content.mimeType.removeprefix("image/"), width=0, height=0)
                 )
             elif isinstance(content, types.AudioContent):
-                response_artifacts.append(AudioArtifact(value=content.data, format=content.mimeType.lstrip("audio/")))
+                response_artifacts.append(
+                    AudioArtifact(value=content.data, format=content.mimeType.removeprefix("audio/"))
+                )
             elif isinstance(content, types.EmbeddedResource):
                 if isinstance(content.resource, types.TextResourceContents):
                     response_artifacts.append(TextArtifact(content.resource.text))

--- a/tests/unit/tools/test_mcp_tool.py
+++ b/tests/unit/tools/test_mcp_tool.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from mcp import types as mcp_types
 
-from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import AudioArtifact, ErrorArtifact, ImageArtifact, ListArtifact, TextArtifact
 from griptape.tools.mcp.tool import MCPTool
 
 
@@ -96,3 +96,38 @@ class TestMCPTool:
 
         assert isinstance(artifact, ListArtifact)
         assert artifact.value == []
+
+    @pytest.mark.parametrize(
+        ("mime_type", "expected_format"),
+        [
+            ("image/png", "png"),
+            ("image/gif", "gif"),
+            ("image/apng", "apng"),
+        ],
+    )
+    def test_image_content_format_strips_only_mime_prefix(self, tool, mime_type, expected_format):
+        """Format must be derived via literal prefix removal, not lstrip's character-set stripping."""
+        result = call_tool_result(content=[{"type": "image", "data": "aGk=", "mimeType": mime_type}])
+        artifact = tool._convert_call_tool_result_to_artifact(result)
+
+        assert isinstance(artifact, ListArtifact)
+        assert len(artifact.value) == 1
+        assert isinstance(artifact.value[0], ImageArtifact)
+        assert artifact.value[0].format == expected_format
+
+    @pytest.mark.parametrize(
+        ("mime_type", "expected_format"),
+        [
+            ("audio/wav", "wav"),
+            ("audio/aac", "aac"),
+        ],
+    )
+    def test_audio_content_format_strips_only_mime_prefix(self, tool, mime_type, expected_format):
+        """Format must be derived via literal prefix removal, not lstrip's character-set stripping."""
+        result = call_tool_result(content=[{"type": "audio", "data": "aGk=", "mimeType": mime_type}])
+        artifact = tool._convert_call_tool_result_to_artifact(result)
+
+        assert isinstance(artifact, ListArtifact)
+        assert len(artifact.value) == 1
+        assert isinstance(artifact.value[0], AudioArtifact)
+        assert artifact.value[0].format == expected_format


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

`MCPTool._convert_call_tool_result_to_artifact` derived `ImageArtifact`/`AudioArtifact` `format` from the MCP result's `mimeType` using `str.lstrip("image/")` / `str.lstrip("audio/")`. `lstrip` strips any leading *characters* in the given set, not a literal prefix, so it silently corrupts any format whose subtype starts with a letter already in `{i,m,a,g,e,/}` (image) or `{a,u,d,i,o,/}` (audio):

- `"image/gif".lstrip("image/")` -> `"f"` (should be `"gif"`)
- `"image/apng".lstrip("image/")` -> `"png"` (should be `"apng"`)
- `"audio/aac".lstrip("audio/")` -> `"c"` (should be `"aac"`)

This corrupted `format` then flows into the `mime_type` sent back to LLM providers and into the file extension used when saving the artifact. It happened to go unnoticed because the existing test only covered `image/png`, which coincidentally survives `lstrip` unscathed.

Fix: use `str.removeprefix`, which already the established pattern elsewhere in this codebase (e.g. `griptape_cloud_assistant_driver.py`, `griptape_cloud_prompt_driver.py`) for exact-prefix stripping.

Added parametrized regression tests covering `image/gif`, `image/apng`, `audio/wav`, and `audio/aac`; confirmed they fail against the old `lstrip` implementation and pass with `removeprefix`. `ruff check` and `ruff format` are clean on both changed files.

## Issue ticket number and link

Fixes #2286