### PR TITLE
fix: resolve optional dependency types defensively so a broken install degrades to Any

### DIFF
--- a/griptape/schemas/base_schema.py
+++ b/griptape/schemas/base_schema.py
@@ -269,7 +269,7 @@ class BaseSchema(Schema):
         from griptape.tasks import BaseTask
         from griptape.tokenizers import BaseTokenizer
         from griptape.tools import BaseTool
-        from griptape.utils import import_optional_dependency, is_dependency_installed
+        from griptape.utils import optional_type
 
         if types_override is None:
             types_override = {}
@@ -332,17 +332,13 @@ class BaseSchema(Schema):
                 "StructuredOutputStrategy": StructuredOutputStrategy,
                 "RagContext": RagContext,
                 # Third party modules
-                "Client": import_optional_dependency("cohere").Client if is_dependency_installed("cohere") else Any,
-                "ClientV2": import_optional_dependency("cohere").ClientV2 if is_dependency_installed("cohere") else Any,
-                "boto3": import_optional_dependency("boto3") if is_dependency_installed("boto3") else Any,
-                "Anthropic": import_optional_dependency("anthropic").Anthropic
-                if is_dependency_installed("anthropic")
-                else Any,
-                "BedrockRuntimeClient": import_optional_dependency("mypy_boto3_bedrock_runtime").BedrockRuntimeClient
-                if is_dependency_installed("mypy_boto3_bedrock_runtime")
-                else Any,
-                "voyageai": import_optional_dependency("voyageai") if is_dependency_installed("voyageai") else Any,
-                "openai": import_optional_dependency("openai") if is_dependency_installed("openai") else Any,
+                "Client": optional_type("cohere", "Client"),
+                "ClientV2": optional_type("cohere", "ClientV2"),
+                "boto3": optional_type("boto3"),
+                "Anthropic": optional_type("anthropic", "Anthropic"),
+                "BedrockRuntimeClient": optional_type("mypy_boto3_bedrock_runtime", "BedrockRuntimeClient"),
+                "voyageai": optional_type("voyageai"),
+                "openai": optional_type("openai"),
                 "Schema": Schema,
                 "BaseModel": BaseModel,
                 **types_override,

--- a/griptape/utils/__init__.py
+++ b/griptape/utils/__init__.py
@@ -16,6 +16,7 @@ from .dict_utils import (
 from .hash import str_to_hash
 from .import_utils import import_optional_dependency
 from .import_utils import is_dependency_installed
+from .import_utils import optional_type
 from .stream import Stream
 from .load_artifact_from_memory import load_artifact_from_memory
 from .deprecation import deprecation_warn
@@ -54,6 +55,7 @@ __all__ = [
     "is_dependency_installed",
     "load_artifact_from_memory",
     "minify_json",
+    "optional_type",
     "references_from_artifacts",
     "remove_key_in_dict_recursively",
     "remove_null_values_in_dict_recursively",

--- a/griptape/utils/import_utils.py
+++ b/griptape/utils/import_utils.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import logging
+from functools import cache
 from importlib import import_module
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from types import ModuleType
+
+# Child of the "griptape" logger. Naming it via `Defaults` would cycle: configs imports utils.
+logger = logging.getLogger(__name__)
 
 INSTALL_MAPPING = {
     "huggingface_hub": "huggingface-hub",
@@ -56,3 +61,69 @@ def is_dependency_installed(name: str) -> bool:
         return False
 
     return True
+
+
+@cache
+def optional_type(name: str, attr: str | None = None) -> Any:
+    """Resolve an optional dependency's module or attribute for an annotation, or `Any`.
+
+    An unimportable dependency must not raise, or it fails serialization of objects that never
+    touch it, so it degrades to `Any` -- silently when merely absent, with a warning when
+    installed and broken. A missing attribute on a real module still raises `AttributeError`,
+    since a wrong name or upstream rename is a bug and `Any` would hide it. Cached per name, so a
+    broken dependency is reported once rather than on every `to_dict()`.
+
+    `Any` only satisfies a name used BARE in an annotation. `boto3` and `openai` are annotated
+    dotted (`boto3.Session`), so those entries degrade to `Any.Session` and fail; fixing that
+    needs a shim, not a fallback value.
+
+    Args:
+        name: The module name.
+        attr: An attribute to resolve on the module. None returns the module itself.
+
+    Returns:
+        The module or attribute, or `Any` when the dependency is absent or unimportable.
+    """
+    try:
+        module = import_module(name)
+    except ImportError as exc:
+        if _is_absent(name, exc):
+            return Any
+        return _warn_unimportable(name, attr, exc)
+
+    if attr is None:
+        return module
+
+    try:
+        return getattr(module, attr)
+    except ImportError as exc:
+        return _warn_unimportable(name, attr, exc)
+    except AttributeError as exc:
+        # An empty directory on sys.path imports as a namespace package: a package (`__path__`)
+        # with no module of its own (`__file__`), so every attribute is missing. That is a broken
+        # environment, not a wrong name.
+        if hasattr(module, "__path__") and getattr(module, "__file__", None) is None:
+            return _warn_unimportable(name, attr, exc)
+        raise
+
+
+def _warn_unimportable(name: str, attr: str | None, exc: Exception) -> Any:
+    """Report an installed-but-unusable dependency and fall back to `Any`."""
+    logger.warning(
+        "Optional dependency '%s' is installed but could not be imported, so it is treated as "
+        "`Any`. This usually means a broken install, or a conflicting version of one of its own "
+        "dependencies. Underlying error: %s",
+        name if attr is None else f"{name}.{attr}",
+        exc,
+    )
+    return Any
+
+
+def _is_absent(name: str, exc: ImportError) -> bool:
+    """Whether the dependency is not installed, as opposed to installed and broken.
+
+    Both raise from the same hierarchy, so the requested module is compared against the missing one.
+    """
+    if not isinstance(exc, ModuleNotFoundError) or exc.name is None:
+        return False
+    return name == exc.name or name.startswith(f"{exc.name}.")

--- a/tests/unit/schemas/test_base_schema.py
+++ b/tests/unit/schemas/test_base_schema.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime
 from enum import Enum
+from types import ModuleType
 from typing import Literal, Union
 
 import pytest
@@ -14,6 +16,7 @@ from griptape.schemas.base_schema import BaseSchema
 from griptape.schemas.bytes_field import Bytes
 from griptape.schemas.pydantic_model_field import PydanticModel
 from griptape.schemas.union_field import Union as UnionField
+from griptape.utils import optional_type
 from tests.mocks.mock_serializable import MockSerializable
 
 
@@ -174,3 +177,24 @@ class TestBaseSchema:
 
     def test_types_override(self):
         assert MockSerializable().to_dict(types_overrides={"foo": int})
+
+    def test_to_dict_survives_a_broken_optional_dependency(self, monkeypatch: pytest.MonkeyPatch):
+        """`_resolve_types` resolves cohere on every call, so its broken imports reach every caller.
+
+        A package with a lazy `__getattr__` passes an is-it-installed check and raises only on
+        attribute access, which used to abort serialization of objects unrelated to it.
+        """
+        broken = ModuleType("cohere")
+
+        def lazy_getattr(name: str) -> object:
+            msg = f"cannot import name 'parse_schema' from 'fastavro' (unknown location), for {name}"
+            raise ImportError(msg)
+
+        broken.__getattr__ = lazy_getattr  # type: ignore[method-assign]
+        monkeypatch.setitem(sys.modules, "cohere", broken)
+        optional_type.cache_clear()
+
+        try:
+            assert MockSerializable().to_dict()
+        finally:
+            optional_type.cache_clear()

--- a/tests/unit/utils/test_import_utils.py
+++ b/tests/unit/utils/test_import_utils.py
@@ -1,6 +1,28 @@
+import logging
+import os
+import sys
+from types import ModuleType
+from typing import Any
+
 import pytest
 
-from griptape.utils import import_optional_dependency, is_dependency_installed
+from griptape.utils import import_optional_dependency, is_dependency_installed, optional_type
+
+
+@pytest.fixture(autouse=True)
+def _isolate_optional_type(monkeypatch: pytest.MonkeyPatch):
+    """Caches per process, so injected modules must not outlive their test.
+
+    `LoggingConfig`, once any test has built one, sets `propagate = False` and level INFO on the
+    "griptape" logger. Both would drop these records before `caplog` sees them, and whether it has
+    run yet depends on test order.
+    """
+    griptape_logger = logging.getLogger("griptape")
+    monkeypatch.setattr(griptape_logger, "propagate", True)
+    monkeypatch.setattr(griptape_logger, "level", logging.NOTSET)
+    optional_type.cache_clear()
+    yield
+    optional_type.cache_clear()
 
 
 class TestImportUtils:
@@ -16,3 +38,111 @@ class TestImportUtils:
         assert is_dependency_installed("boto3") is True
 
         assert is_dependency_installed("foobar") is False
+
+    def test_optional_type(self):
+        assert optional_type("boto3") is import_optional_dependency("boto3")
+        assert optional_type("os", "getcwd") is os.getcwd
+
+    def test_optional_type_returns_any_for_a_missing_dependency(self, caplog: pytest.LogCaptureFixture):
+        """Silently: a plain install without the extras has nothing to report."""
+        with caplog.at_level(logging.DEBUG):
+            assert optional_type("foobar") is Any
+            assert optional_type("foobar", "Client") is Any
+
+        assert caplog.records == []
+
+    def test_optional_type_returns_any_when_the_top_level_import_is_broken(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """An eager package whose own dependency is broken fails at `import`, not at `getattr`.
+
+        Distinct from absence, and worth reporting: the environment is broken, not unconfigured.
+        """
+
+        def raise_broken_transitive(name: str, *_args: object, **_kwargs: object) -> ModuleType:
+            if name == "eagerly_broken":
+                msg = "cannot import name 'parse_schema' from 'someavro' (unknown location)"
+                raise ImportError(msg)
+            raise AssertionError(name)
+
+        monkeypatch.setattr("griptape.utils.import_utils.import_module", raise_broken_transitive)
+
+        with caplog.at_level(logging.WARNING):
+            assert optional_type("eagerly_broken", "Client") is Any
+
+        assert "eagerly_broken.Client" in caplog.text
+
+    def test_optional_type_returns_any_when_the_attribute_import_fails(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """A lazy package imports cleanly and only raises on attribute access.
+
+        The failing import is often a broken transitive dependency rather than this package.
+        """
+        module = ModuleType("lazily_broken")
+
+        def lazy_getattr(name: str) -> Any:
+            msg = f"cannot import name 'parse_schema' from 'someavro' (unknown location), wanted for {name}"
+            raise ImportError(msg)
+
+        module.__getattr__ = lazy_getattr  # type: ignore[method-assign]
+        monkeypatch.setitem(sys.modules, "lazily_broken", module)
+
+        assert optional_type("lazily_broken") is module
+
+        with caplog.at_level(logging.WARNING):
+            assert optional_type("lazily_broken", "Client") is Any
+
+        assert "lazily_broken.Client" in caplog.text
+
+    def test_optional_type_returns_any_when_a_transitive_dependency_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """An eager package missing one of its OWN dependencies is broken, not absent.
+
+        The most common real shape, and the one `_is_absent` has to tell apart from the package
+        itself being uninstalled.
+        """
+
+        def raise_missing_transitive(name: str, *_args: object, **_kwargs: object) -> ModuleType:
+            raise ModuleNotFoundError(f"No module named 'fastavro' (imported by {name})", name="fastavro")
+
+        monkeypatch.setattr("griptape.utils.import_utils.import_module", raise_missing_transitive)
+
+        with caplog.at_level(logging.WARNING):
+            assert optional_type("eager_pkg", "Client") is Any
+
+        assert "eager_pkg.Client" in caplog.text
+
+    def test_optional_type_returns_any_for_an_empty_directory_on_sys_path(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """A directory with no `__init__.py` imports as a namespace package with no attributes.
+
+        Indistinguishable from a wrong attribute name except by `__file__`, and it is the shape a
+        half-removed install leaves behind.
+        """
+        husk = ModuleType("husk_pkg")
+        husk.__file__ = None
+        husk.__path__ = []  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "husk_pkg", husk)
+
+        with caplog.at_level(logging.WARNING):
+            assert optional_type("husk_pkg", "Client") is Any
+
+        assert "husk_pkg.Client" in caplog.text
+
+    def test_optional_type_does_not_swallow_a_wrong_attribute_name(self, monkeypatch: pytest.MonkeyPatch):
+        """A missing attribute is a caller bug or an upstream rename, not an environment problem.
+
+        Degrading it to `Any` would hide it permanently, since the annotation still resolves. Shaped
+        like a real installed package -- both `__file__` and `__path__` -- so that the namespace
+        check cannot pass by accident.
+        """
+        module = ModuleType("present_module")
+        module.__file__ = "/somewhere/present_module/__init__.py"
+        module.__path__ = ["/somewhere/present_module"]  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "present_module", module)
+
+        with pytest.raises(AttributeError):
+            optional_type("present_module", "NoSuchAttribute")


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

`BaseSchema._resolve_types` guarded its third-party entries like this:

```python
"Client": import_optional_dependency("cohere").Client if is_dependency_installed("cohere") else Any,
```

`is_dependency_installed` imports only the **top-level** module. A package that defers work to `__getattr__` therefore passes the gate and raises on the *attribute* access, which happens outside the guard. The `ImportError` escapes into whatever called `to_dict()`, so serializing an object that has nothing to do with cohere fails:

```
ImportError: Failed to import Client from .client: cannot import name 'parse_schema' from 'fastavro' (unknown location)
```

`optional_type(name, attr=None)` replaces all seven entries and degrades to `Any` instead of raising, since an unimportable dependency must not fail serialization of objects that never touch it. It distinguishes three cases:

| Situation | Result |
|---|---|
| Dependency absent | `Any`, silently — what the old expression did, and what a plain install without the extras should see |
| Installed but unimportable | `Any` + logged warning |
| Attribute missing from a real module | still raises `AttributeError` |

The middle case covers more than the lazy `__getattr__` shape: a transitive dependency that is missing or broken, and an empty directory on `sys.path`, which imports as a namespace package whose every attribute is missing. That last one is the shape a half-removed install leaves behind, and it is detected by `__path__` present with `__file__` None. The third case is deliberate — a wrong name or an upstream rename is a bug to fix, and `Any` would hide it permanently while the annotation still resolved.

Two implementation notes:

- **Logged, not `warnings.warn`.** A downstream `filterwarnings = error` would otherwise turn `to_dict()` into a hard failure, which is the same class of breakage this change exists to prevent. It logs to `griptape.utils.import_utils`, a child of the framework's `griptape` logger, so records reach the same handler; naming that logger via `Defaults.logging_config` would cycle, since `griptape.configs` imports `griptape.utils`.
- **`functools.cache`d**, so a broken dependency is reported once rather than on every `to_dict()`. `_resolve_types` rebuilds its `localns` literal on every call and is not otherwise cached, so this also removes a large number of redundant `import_module` calls per serialization.

`import_module` is called directly rather than through `import_optional_dependency` because that wrapper re-raises a generic `ImportError` and discards `exc.name`, which is what distinguishes "absent" from "installed and broken".

### Known limitation

`Any` only satisfies a name used **bare** in an annotation. `boto3` and `openai` are annotated dotted (`boto3.Session`, `openai.OpenAI`), so for those two entries the fallback yields `AttributeError: type object 'Any' has no attribute 'Session'`. That behavior predates this change — it is what the absent path already did on `main` — and fixing it properly needs a shim rather than a fallback value, so it is documented in the docstring and left out of scope.

## Issue ticket number and link

None; found while debugging a downstream serialization failure.

## Tests

`tests/unit/utils/test_import_utils.py` covers the module and attribute forms, silent absence, a missing transitive dependency, a broken top-level import, a lazy `__getattr__`, an empty namespace-package directory, and a wrong attribute name still raising. `tests/unit/schemas/test_base_schema.py` adds a regression test at the layer the bug actually occurs: `to_dict()` succeeds with a lazily-broken `cohere` injected, which fails on `main`.

Both guards were mutation-tested — collapsing either the namespace-package check or the absent/broken discrimination to its naive form breaks a test.

Full unit suite: 3626 passed. `make check` format and lint clean; the 3 remaining `pyright` errors and 2 test errors in my environment are `ModuleNotFoundError: No module named 'ddgs'`, an extra I do not have installed locally.
