### PR TITLE
feat(tools-mcp)!: migrate MCPTool to MCP Python SDK 2.x

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,56 @@ This document provides instructions for migrating your codebase to accommodate b
 
 ## Next Version (Security Hardening)
 
+### `MCPTool` requires MCP Python SDK 2.x.
+
+`MCPTool` now uses [MCP Python SDK 2.x](https://github.com/modelcontextprotocol/python-sdk). Reinstall the tool's requirements (`griptape/tools/mcp/requirements.txt`) to pick up `mcp>=2,<3`.
+
+### Removed `websocket` transport from `MCPTool`.
+
+MCP 2.x dropped the WebSocket transport, so `WebsocketConnection` is gone. Use `streamable_http` instead.
+
+#### Before
+
+```python
+connection: WebsocketConnection = {
+    "transport": "websocket",
+    "url": "ws://localhost:8000/ws",
+}
+```
+
+#### After
+
+```python
+connection: StreamableHttpConnection = {
+    "transport": "streamable_http",
+    "url": "http://localhost:8000/mcp",
+}
+```
+
+### `MCPTool` connection timeouts are seconds, not `timedelta`.
+
+`StreamableHttpConnection`'s `timeout` and `sse_read_timeout` are now floats, matching `SSEConnection`. `timedelta` values are still accepted and converted.
+
+#### Before
+
+```python
+connection: StreamableHttpConnection = {
+    "transport": "streamable_http",
+    "url": "http://localhost:8000/mcp",
+    "timeout": timedelta(seconds=30),
+}
+```
+
+#### After
+
+```python
+connection: StreamableHttpConnection = {
+    "transport": "streamable_http",
+    "url": "http://localhost:8000/mcp",
+    "timeout": 30,
+}
+```
+
 ### `CommandRunner` now executes commands directly (`shell=False`).
 
 To prevent shell injection, `CommandRunner` no longer uses a system shell to execute commands. This means shell metacharacters such as pipes (`|`), redirects (`>`, `>>`), and logical operators (`&&`, `||`) are no longer supported.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -30,6 +30,10 @@ connection: StreamableHttpConnection = {
 }
 ```
 
+### `MCPTool` honors `sse_read_timeout` and `terminate_on_close`.
+
+`SSEConnection`'s `sse_read_timeout` was ignored in favor of `timeout`, so an SSE connection gave up on a quiet stream after `timeout` seconds (5 by default). It is now read, raising the default read timeout to 300 seconds. `StreamableHttpConnection`'s `terminate_on_close` was ignored too, always terminating the session on close; set it to `False` to keep the session alive.
+
 ### `MCPTool`'s `httpx_client_factory` must return an `httpx2` client.
 
 MCP 2.x replaced `httpx` with [`httpx2`](https://pypi.org/project/httpx2/). A factory supplied on an `SSEConnection` or `StreamableHttpConnection` must return an `httpx2.AsyncClient`; an `httpx.AsyncClient` fails once the connection is used.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,7 +32,7 @@ connection: StreamableHttpConnection = {
 
 ### `MCPTool` connection timeouts are seconds, not `timedelta`.
 
-`StreamableHttpConnection`'s `timeout` and `sse_read_timeout` are now floats, matching `SSEConnection`. `timedelta` values are still accepted and converted.
+`StreamableHttpConnection`'s `timeout` and `sse_read_timeout` are seconds, matching `SSEConnection`. `timedelta` values are still accepted and converted.
 
 #### Before
 
@@ -52,6 +52,30 @@ connection: StreamableHttpConnection = {
     "url": "http://localhost:8000/mcp",
     "timeout": 30,
 }
+```
+
+### `MCPTool`'s `httpx_client_factory` must return an `httpx2` client.
+
+MCP 2.x replaced `httpx` with [`httpx2`](https://pypi.org/project/httpx2/). A factory supplied on an `SSEConnection` or `StreamableHttpConnection` must return an `httpx2.AsyncClient`; an `httpx.AsyncClient` fails once the connection is used.
+
+#### Before
+
+```python
+import httpx
+
+
+def factory(headers=None, timeout=None, auth=None) -> httpx.AsyncClient:
+    return httpx.AsyncClient(headers=headers, timeout=timeout, auth=auth)
+```
+
+#### After
+
+```python
+import httpx2
+
+
+def factory(headers=None, timeout=None, auth=None) -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(headers=headers, timeout=timeout, auth=auth)
 ```
 
 ### `CommandRunner` now executes commands directly (`shell=False`).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -30,30 +30,6 @@ connection: StreamableHttpConnection = {
 }
 ```
 
-### `MCPTool` connection timeouts are seconds, not `timedelta`.
-
-`StreamableHttpConnection`'s `timeout` and `sse_read_timeout` are seconds, matching `SSEConnection`. `timedelta` values are still accepted and converted.
-
-#### Before
-
-```python
-connection: StreamableHttpConnection = {
-    "transport": "streamable_http",
-    "url": "http://localhost:8000/mcp",
-    "timeout": timedelta(seconds=30),
-}
-```
-
-#### After
-
-```python
-connection: StreamableHttpConnection = {
-    "transport": "streamable_http",
-    "url": "http://localhost:8000/mcp",
-    "timeout": 30,
-}
-```
-
 ### `MCPTool`'s `httpx_client_factory` must return an `httpx2` client.
 
 MCP 2.x replaced `httpx` with [`httpx2`](https://pypi.org/project/httpx2/). A factory supplied on an `SSEConnection` or `StreamableHttpConnection` must return an `httpx2.AsyncClient`; an `httpx.AsyncClient` fails once the connection is used.

--- a/docs/griptape-framework/tools/official-tools/index.md
+++ b/docs/griptape-framework/tools/official-tools/index.md
@@ -165,7 +165,7 @@ This tool allows LLMs to generate images using inpainting, where an input image 
 
 ### MCP
 
-This tool allows LLMs to call MCP Tools. It requires [MCP](https://github.com/modelcontextprotocol/python-sdk) and Python 3.10 or greater.
+This tool allows LLMs to call MCP Tools. It requires [MCP](https://github.com/modelcontextprotocol/python-sdk) 2.x and Python 3.10 or greater.
 
 === "Code"
 

--- a/griptape/tools/mcp/requirements.txt
+++ b/griptape/tools/mcp/requirements.txt
@@ -1,2 +1,2 @@
-mcp[ws]>=1.10.0,<2
+mcp>=2,<3
 exceptiongroup>=1.2.2

--- a/griptape/tools/mcp/requirements.txt
+++ b/griptape/tools/mcp/requirements.txt
@@ -1,2 +1,3 @@
 mcp>=2,<3
+httpx2>=2.5.0
 exceptiongroup>=1.2.2

--- a/griptape/tools/mcp/sessions.py
+++ b/griptape/tools/mcp/sessions.py
@@ -72,10 +72,10 @@ class SSEConnection(TypedDict):
     headers: dict[str, Any] | None
     """HTTP headers to send to the SSE endpoint."""
 
-    timeout: float
+    timeout: float | timedelta
     """HTTP timeout, in seconds."""
 
-    sse_read_timeout: float
+    sse_read_timeout: float | timedelta
     """SSE read timeout, in seconds."""
 
     session_kwargs: dict[str, Any] | None
@@ -94,10 +94,10 @@ class StreamableHttpConnection(TypedDict):
     headers: dict[str, Any] | None
     """HTTP headers to send to the endpoint."""
 
-    timeout: float
+    timeout: float | timedelta
     """HTTP timeout, in seconds."""
 
-    sse_read_timeout: float
+    sse_read_timeout: float | timedelta
     """How long (in seconds) the client will wait for a new event before disconnecting.
     All other HTTP operations are controlled by `timeout`."""
 

--- a/griptape/tools/mcp/sessions.py
+++ b/griptape/tools/mcp/sessions.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
 
-    import httpx
+    import httpx2
     from mcp import ClientSession  # type: ignore[reportAttributeAccessIssue]
 
 EncodingErrorHandler = Literal["strict", "ignore", "replace"]
@@ -17,20 +17,20 @@ EncodingErrorHandler = Literal["strict", "ignore", "replace"]
 DEFAULT_ENCODING = "utf-8"
 DEFAULT_ENCODING_ERROR_HANDLER: EncodingErrorHandler = "strict"
 
-DEFAULT_HTTP_TIMEOUT = 5
-DEFAULT_SSE_READ_TIMEOUT = 60 * 5
+DEFAULT_HTTP_TIMEOUT = 5.0
+DEFAULT_SSE_READ_TIMEOUT = 60.0 * 5
 
-DEFAULT_STREAMABLE_HTTP_TIMEOUT = timedelta(seconds=30)
-DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT = timedelta(seconds=60 * 5)
+DEFAULT_STREAMABLE_HTTP_TIMEOUT = 30.0
+DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT = 60.0 * 5
 
 
 class McpHttpClientFactory(Protocol):
     def __call__(
         self,
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient: ...
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient: ...
 
 
 class StdioConnection(TypedDict):
@@ -73,16 +73,16 @@ class SSEConnection(TypedDict):
     """HTTP headers to send to the SSE endpoint."""
 
     timeout: float
-    """HTTP timeout."""
+    """HTTP timeout, in seconds."""
 
     sse_read_timeout: float
-    """SSE read timeout."""
+    """SSE read timeout, in seconds."""
 
     session_kwargs: dict[str, Any] | None
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: McpHttpClientFactory | None
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
 
 class StreamableHttpConnection(TypedDict):
@@ -94,10 +94,10 @@ class StreamableHttpConnection(TypedDict):
     headers: dict[str, Any] | None
     """HTTP headers to send to the endpoint."""
 
-    timeout: timedelta
-    """HTTP timeout."""
+    timeout: float
+    """HTTP timeout, in seconds."""
 
-    sse_read_timeout: timedelta
+    sse_read_timeout: float
     """How long (in seconds) the client will wait for a new event before disconnecting.
     All other HTTP operations are controlled by `timeout`."""
 
@@ -108,20 +108,26 @@ class StreamableHttpConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: McpHttpClientFactory | None
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
 
-class WebsocketConnection(TypedDict):
-    transport: Literal["websocket"]
-
-    url: str
-    """The URL of the Websocket endpoint to connect to."""
-
-    session_kwargs: dict[str, Any] | None
-    """Additional keyword arguments to pass to the ClientSession"""
+Connection = StdioConnection | SSEConnection | StreamableHttpConnection
 
 
-Connection = StdioConnection | SSEConnection | StreamableHttpConnection | WebsocketConnection
+def _to_seconds(value: float | timedelta) -> float:
+    """Normalizes a timeout to seconds, since MCP takes floats rather than `timedelta`s."""
+    return value.total_seconds() if isinstance(value, timedelta) else float(value)
+
+
+def _create_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx2.Timeout | None = None,
+    auth: httpx2.Auth | None = None,
+) -> httpx2.AsyncClient:
+    """Builds the httpx2 client MCP transports use when no factory is supplied."""
+    import httpx2  # type: ignore[reportMissingImports]
+
+    return httpx2.AsyncClient(follow_redirects=True, headers=headers, timeout=timeout, auth=auth)
 
 
 @asynccontextmanager
@@ -186,10 +192,10 @@ async def _create_sse_session(
     Args:
         url: URL of the SSE server
         headers: HTTP headers to send to the SSE endpoint
-        timeout: HTTP timeout
-        sse_read_timeout: SSE read timeout
+        timeout: HTTP timeout, in seconds
+        sse_read_timeout: SSE read timeout, in seconds
         session_kwargs: Additional keyword arguments to pass to the ClientSession
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional)
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional)
     """
     from mcp import ClientSession  # type: ignore[reportAttributeAccessIssue]
     from mcp.client.sse import sse_client  # type: ignore[reportMissingImports]
@@ -209,8 +215,8 @@ async def _create_streamable_http_session(
     *,
     url: str,
     headers: dict[str, Any] | None = None,
-    timeout: timedelta = DEFAULT_STREAMABLE_HTTP_TIMEOUT,
-    sse_read_timeout: timedelta = DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT,
+    timeout: float = DEFAULT_STREAMABLE_HTTP_TIMEOUT,
+    sse_read_timeout: float = DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT,
     terminate_on_close: bool = True,
     session_kwargs: dict[str, Any] | None = None,
     httpx_client_factory: McpHttpClientFactory | None = None,
@@ -220,51 +226,32 @@ async def _create_streamable_http_session(
     Args:
         url: URL of the endpoint to connect to
         headers: HTTP headers to send to the endpoint
-        timeout: HTTP timeout
+        timeout: HTTP timeout, in seconds
         sse_read_timeout: How long (in seconds) the client will wait for a new event before disconnecting
         terminate_on_close: Whether to terminate the session on close
         session_kwargs: Additional keyword arguments to pass to the ClientSession
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional)
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional)
     """
+    import httpx2  # type: ignore[reportMissingImports]
     from mcp import ClientSession  # type: ignore[reportAttributeAccessIssue]
-    from mcp.client.streamable_http import streamablehttp_client  # type: ignore[reportMissingImports]
+    from mcp.client.streamable_http import streamable_http_client  # type: ignore[reportMissingImports]
 
-    # Create and store the connection
-    kwargs = {}
-    if httpx_client_factory is not None:
-        kwargs["httpx_client_factory"] = httpx_client_factory
+    # Streamable HTTP takes its HTTP configuration from the client it is handed, so the
+    # timeouts and headers are baked into the client here.
+    create_client = httpx_client_factory or _create_http_client
+    http_client = create_client(headers=headers, timeout=httpx2.Timeout(timeout, read=sse_read_timeout))
 
-    async with streamablehttp_client(url, headers, timeout, sse_read_timeout, terminate_on_close, **kwargs) as (  # noqa: SIM117
-        read,
-        write,
-        _,
+    # A caller-provided client is not closed by the transport, so its lifecycle is managed here.
+    async with (
+        http_client,
+        streamable_http_client(url, http_client=http_client, terminate_on_close=terminate_on_close) as (read, write),
+        ClientSession(read, write, **(session_kwargs or {})) as session,
     ):
-        async with ClientSession(read, write, **(session_kwargs or {})) as session:
-            yield session
+        yield session
 
 
 @asynccontextmanager
-async def _create_websocket_session(
-    *,
-    url: str,
-    session_kwargs: dict[str, Any] | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using Websockets.
-
-    Args:
-        url: URL of the Websocket endpoint
-        session_kwargs: Additional keyword arguments to pass to the ClientSession
-    """
-    from mcp import ClientSession  # type: ignore[reportAttributeAccessIssue]
-    from mcp.client.websocket import websocket_client  # type: ignore[reportMissingImports]
-
-    async with websocket_client(url) as (read, write):  # noqa: SIM117
-        async with ClientSession(read, write, **(session_kwargs or {})) as session:
-            yield session
-
-
-@asynccontextmanager
-async def create_session(  # noqa: C901
+async def create_session(
     connection: Connection,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server.
@@ -283,17 +270,11 @@ async def create_session(  # noqa: C901
     if transport == "sse":
         if "url" not in connection:
             raise ValueError("'url' parameter is required for SSE connection")
-        timeout_val = connection.get("timeout", DEFAULT_HTTP_TIMEOUT)
-        if isinstance(timeout_val, timedelta):
-            timeout_val = timeout_val.total_seconds()
-        sse_read_timeout_val = connection.get("timeout", DEFAULT_HTTP_TIMEOUT)
-        if isinstance(sse_read_timeout_val, timedelta):
-            sse_read_timeout_val = sse_read_timeout_val.total_seconds()
         async with _create_sse_session(
             url=connection["url"],
             headers=connection.get("headers"),
-            timeout=timeout_val,
-            sse_read_timeout=sse_read_timeout_val,
+            timeout=_to_seconds(connection.get("timeout", DEFAULT_HTTP_TIMEOUT)),
+            sse_read_timeout=_to_seconds(connection.get("sse_read_timeout", DEFAULT_SSE_READ_TIMEOUT)),
             session_kwargs=connection.get("session_kwargs"),
             httpx_client_factory=connection.get("httpx_client_factory"),
         ) as session:
@@ -301,17 +282,12 @@ async def create_session(  # noqa: C901
     elif transport == "streamable_http":
         if "url" not in connection:
             raise ValueError("'url' parameter is required for Streamable HTTP connection")
-        timeout_val = connection.get("timeout", DEFAULT_STREAMABLE_HTTP_TIMEOUT)
-        if isinstance(timeout_val, (int, float)):
-            timeout_val = timedelta(seconds=timeout_val)
-        sse_read_timeout_val = connection.get("sse_read_timeout", DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT)
-        if isinstance(sse_read_timeout_val, (int, float)):
-            sse_read_timeout_val = timedelta(seconds=sse_read_timeout_val)
         async with _create_streamable_http_session(
             url=connection["url"],
             headers=connection.get("headers"),
-            timeout=timeout_val,
-            sse_read_timeout=sse_read_timeout_val,
+            timeout=_to_seconds(connection.get("timeout", DEFAULT_STREAMABLE_HTTP_TIMEOUT)),
+            sse_read_timeout=_to_seconds(connection.get("sse_read_timeout", DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT)),
+            terminate_on_close=connection.get("terminate_on_close", True),
             session_kwargs=connection.get("session_kwargs"),
             httpx_client_factory=connection.get("httpx_client_factory"),
         ) as session:
@@ -329,15 +305,5 @@ async def create_session(  # noqa: C901
             session_kwargs=connection.get("session_kwargs"),
         ) as session:
             yield session
-    elif transport == "websocket":
-        if "url" not in connection:
-            raise ValueError("'url' parameter is required for Websocket connection")
-        async with _create_websocket_session(
-            url=connection["url"],
-            session_kwargs=connection.get("session_kwargs"),
-        ) as session:
-            yield session
     else:
-        raise ValueError(
-            f"Unsupported transport: {transport}. Must be one of: 'stdio', 'sse', 'websocket', 'streamable_http'"
-        )
+        raise ValueError(f"Unsupported transport: {transport}. Must be one of: 'stdio', 'sse', 'streamable_http'")

--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -187,7 +187,7 @@ class MCPTool(BaseTool):
             config={
                 "name": activity_name,
                 "description": tool.description or tool.title or tool.name,
-                "schema": create_model(tool.inputSchema, allow_undefined_array_items=True, allow_undefined_type=True),
+                "schema": create_model(tool.input_schema, allow_undefined_array_items=True, allow_undefined_type=True),
             }
         )
         def activity_handler(self: MCPTool, values: dict) -> Any:
@@ -230,8 +230,8 @@ class MCPTool(BaseTool):
         error_text = next(
             (content.text for content in call_tool_result.content if isinstance(content, types.TextContent)), None
         )
-        if error_text is None and call_tool_result.structuredContent is not None:
-            error_text = json.dumps(call_tool_result.structuredContent)
+        if error_text is None and call_tool_result.structured_content is not None:
+            error_text = json.dumps(call_tool_result.structured_content)
 
         return ErrorArtifact(error_text or "An unknown error occurred.")
 
@@ -240,7 +240,7 @@ class MCPTool(BaseTool):
     ) -> ListArtifact | ErrorArtifact:
         from mcp import types  # pyright: ignore[reportAttributeAccessIssue]
 
-        if call_tool_result.isError:
+        if call_tool_result.is_error:
             return self._convert_error_result_to_artifact(call_tool_result)
 
         response_artifacts: list[BaseArtifact] = []
@@ -249,17 +249,17 @@ class MCPTool(BaseTool):
                 response_artifacts.append(TextArtifact(content.text))
             elif isinstance(content, types.ImageContent):
                 response_artifacts.append(
-                    ImageArtifact(value=content.data, format=content.mimeType.lstrip("image/"), width=0, height=0)
+                    ImageArtifact(value=content.data, format=content.mime_type.lstrip("image/"), width=0, height=0)
                 )
             elif isinstance(content, types.AudioContent):
-                response_artifacts.append(AudioArtifact(value=content.data, format=content.mimeType.lstrip("audio/")))
+                response_artifacts.append(AudioArtifact(value=content.data, format=content.mime_type.lstrip("audio/")))
             elif isinstance(content, types.EmbeddedResource):
                 if isinstance(content.resource, types.TextResourceContents):
                     response_artifacts.append(TextArtifact(content.resource.text))
                 elif isinstance(content.resource, types.BlobResourceContents):
                     response_artifacts.append(BlobArtifact(value=content.resource.blob))
 
-        if not response_artifacts and call_tool_result.structuredContent is not None:
-            response_artifacts.append(TextArtifact(json.dumps(call_tool_result.structuredContent)))
+        if not response_artifacts and call_tool_result.structured_content is not None:
+            response_artifacts.append(TextArtifact(json.dumps(call_tool_result.structured_content)))
 
         return ListArtifact(response_artifacts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ test = [
   # MCPTool installs these from griptape/tools/mcp/requirements.txt at runtime.
   # Tests need them at collection time, so keep the constraints in sync with that file.
   "mcp>=2,<3",
+  "httpx2>=2.5.0",
   "exceptiongroup>=1.2.2",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ test = [
   "torch>=2.4.1",
   # MCPTool installs these from griptape/tools/mcp/requirements.txt at runtime.
   # Tests need them at collection time, so keep the constraints in sync with that file.
-  "mcp[ws]>=1.10.0,<2",
+  "mcp>=2,<3",
   "exceptiongroup>=1.2.2",
 ]
 dev = [

--- a/tests/unit/tasks/test_output_schema_validation_subtask.py
+++ b/tests/unit/tasks/test_output_schema_validation_subtask.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import schema
 from pydantic import create_model
+from pydantic.version import version_short
 
 from griptape.artifacts.json_artifact import JsonArtifact
 from griptape.artifacts.model_artifact import ModelArtifact
@@ -34,7 +35,7 @@ class TestOutputSchemaValidationSubtask:
                 {"key": 123},
                 create_model("OutputSchema", key=(str, ...)),
                 None,
-                "[{'type': 'string_type', 'loc': ('key',), 'msg': 'Input should be a valid string', 'input': 123, 'url': 'https://errors.pydantic.dev/2.11/v/string_type'}]",
+                f"[{{'type': 'string_type', 'loc': ('key',), 'msg': 'Input should be a valid string', 'input': 123, 'url': 'https://errors.pydantic.dev/{version_short()}/v/string_type'}}]",
             ),
             (
                 {"key": "value"},

--- a/tests/unit/tools/test_mcp_tool.py
+++ b/tests/unit/tools/test_mcp_tool.py
@@ -1,20 +1,25 @@
+import asyncio
 import json
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from functools import partial
 from typing import TYPE_CHECKING
 
 import anyio
+import httpx2
 import pytest
 from mcp import ClientSession
 from mcp import types as mcp_types
 from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.shared.memory import create_client_server_memory_streams
 
 from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
+from griptape.tools.mcp.sessions import create_session
 from griptape.tools.mcp.tool import MCPTool
 
 if TYPE_CHECKING:
-    from griptape.tools.mcp.sessions import StdioConnection
+    from griptape.tools.mcp.sessions import StdioConnection, StreamableHttpConnection
 
 
 def call_tool_result(**payload) -> mcp_types.CallToolResult:
@@ -195,3 +200,69 @@ class TestMCPToolSession:
 
         assert isinstance(artifact, ErrorArtifact)
         assert artifact.value == "boom"
+
+
+async def call_over_streamable_http(*, terminate_on_close: bool = True) -> dict:
+    """Drives `create_session` against an in-process streamable HTTP server.
+
+    The server is mounted as the ASGI app of the httpx2 client the connection
+    builds, so the transport wiring runs without binding a port.
+    """
+    server = Server("test-server", on_list_tools=list_tools, on_call_tool=call_tool)
+    manager = StreamableHTTPSessionManager(app=server)
+    observed: dict = {"methods": []}
+
+    async def asgi_app(scope, receive, send) -> None:
+        await manager.handle_request(scope, receive, send)
+
+    async def record_request(request: httpx2.Request) -> None:
+        observed["methods"].append(request.method)
+
+    def httpx_client_factory(headers=None, timeout=None, auth=None) -> httpx2.AsyncClient:
+        observed["headers"] = headers
+        observed["timeout"] = timeout
+        return httpx2.AsyncClient(
+            transport=httpx2.ASGITransport(app=asgi_app),
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
+            event_hooks={"request": [record_request]},
+        )
+
+    connection: StreamableHttpConnection = {  # pyright: ignore[reportAssignmentType]
+        "transport": "streamable_http",
+        "url": "http://testserver/mcp",
+        "headers": {"X-Test": "1"},
+        "timeout": 5,
+        "sse_read_timeout": timedelta(seconds=10),
+        "terminate_on_close": terminate_on_close,
+        "httpx_client_factory": httpx_client_factory,
+    }
+
+    async with manager.run(), create_session(connection) as session:
+        await session.initialize()
+        observed["tools"] = [tool.name for tool in (await session.list_tools()).tools]
+        content = (await session.call_tool("add-numbers", {"a": 17, "b": 25})).content[0]
+        assert isinstance(content, mcp_types.TextContent)
+        observed["result"] = content.text
+
+    return observed
+
+
+class TestStreamableHttpSession:
+    def test_session_calls_tools_over_streamable_http(self):
+        observed = asyncio.run(call_over_streamable_http())
+
+        assert observed["tools"] == ["add-numbers", "explode"]
+        assert observed["result"] == "42"
+
+    def test_connection_configures_the_http_client(self):
+        observed = asyncio.run(call_over_streamable_http())
+
+        assert observed["headers"] == {"X-Test": "1"}
+        # `sse_read_timeout` becomes the read timeout, whether given as seconds or a timedelta.
+        assert observed["timeout"] == httpx2.Timeout(5.0, read=10.0)
+
+    def test_terminate_on_close_deletes_the_session(self):
+        assert "DELETE" in asyncio.run(call_over_streamable_http())["methods"]
+        assert "DELETE" not in asyncio.run(call_over_streamable_http(terminate_on_close=False))["methods"]

--- a/tests/unit/tools/test_mcp_tool.py
+++ b/tests/unit/tools/test_mcp_tool.py
@@ -1,18 +1,28 @@
 import json
+from contextlib import asynccontextmanager
+from functools import partial
+from typing import TYPE_CHECKING
 
+import anyio
 import pytest
+from mcp import ClientSession
 from mcp import types as mcp_types
+from mcp.server.lowlevel import Server
+from mcp.shared.memory import create_client_server_memory_streams
 
 from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
 from griptape.tools.mcp.tool import MCPTool
+
+if TYPE_CHECKING:
+    from griptape.tools.mcp.sessions import StdioConnection
 
 
 def call_tool_result(**payload) -> mcp_types.CallToolResult:
     """Build a CallToolResult from a wire payload.
 
-    Deserializing the JSON an MCP server actually sends, rather than passing
-    Python kwargs, keeps the test honest: `CallToolResult` allows extra fields,
-    so a misspelled kwarg would be silently accepted as a new attribute.
+    Deserializing the camelCase JSON an MCP server actually sends, rather than
+    passing Python kwargs, keeps the test honest about the wire format, which is
+    unchanged even though the model attributes are snake_case.
     """
     return mcp_types.CallToolResult.model_validate({"content": [], **payload})
 
@@ -96,3 +106,92 @@ class TestMCPTool:
 
         assert isinstance(artifact, ListArtifact)
         assert artifact.value == []
+
+
+SERVER_TOOLS = [
+    mcp_types.Tool(
+        name="add-numbers",
+        description="Adds two numbers.",
+        input_schema={
+            "type": "object",
+            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        },
+    ),
+    mcp_types.Tool(
+        name="explode",
+        description="Always fails.",
+        input_schema={"type": "object", "properties": {}},
+    ),
+]
+
+
+async def list_tools(_ctx, _params) -> mcp_types.ListToolsResult:
+    return mcp_types.ListToolsResult(tools=SERVER_TOOLS)
+
+
+async def call_tool(_ctx, params: mcp_types.CallToolRequestParams) -> mcp_types.CallToolResult:
+    if params.name == "explode":
+        return mcp_types.CallToolResult(content=[mcp_types.TextContent(text="boom")], is_error=True)
+    arguments = params.arguments or {}
+    total = arguments["a"] + arguments["b"]
+    return mcp_types.CallToolResult(content=[mcp_types.TextContent(text=str(total))])
+
+
+@asynccontextmanager
+async def memory_session():
+    """Connects a ClientSession to an in-process MCP server over memory streams."""
+    server = Server("test-server", on_list_tools=list_tools, on_call_tool=call_tool)
+
+    async with (
+        create_client_server_memory_streams() as (
+            (client_read, client_write),
+            (server_read, server_write),
+        ),
+        anyio.create_task_group() as task_group,
+    ):
+        task_group.start_soon(partial(server.run, server_read, server_write, server.create_initialization_options()))
+        async with ClientSession(client_read, client_write) as session:
+            yield session
+        task_group.cancel_scope.cancel()
+
+
+class InMemoryMCPTool(MCPTool):
+    def _get_session(self):
+        return memory_session()
+
+
+class TestMCPToolSession:
+    @pytest.fixture()
+    def tool(self):
+        # `connection` is unused because `_get_session` is overridden.
+        connection: StdioConnection = {  # pyright: ignore[reportAssignmentType]
+            "transport": "stdio",
+            "command": "unused",
+            "args": [],
+        }
+        return InMemoryMCPTool(connection=connection)
+
+    def test_activities_mirror_server_tools(self, tool):
+        activities = {activity.config["name"]: activity.config["description"] for activity in tool.activities()}
+
+        assert activities == {"add_numbers": "Adds two numbers.", "explode": "Always fails."}
+
+    def test_activity_schema_from_tool_input_schema(self, tool):
+        schema = tool.to_activity_json_schema(tool.add_numbers, "Schema")
+
+        properties = schema["properties"]
+        assert properties["a"]["type"] == "integer"
+        assert properties["b"]["type"] == "integer"
+
+    def test_call_tool_returns_artifact(self, tool):
+        artifact = tool.add_numbers({"values": {"a": 17, "b": 25}})
+
+        assert isinstance(artifact, ListArtifact)
+        assert artifact.value[0].value == "42"
+
+    def test_error_result_returns_error_artifact(self, tool):
+        artifact = tool.explode({"values": {}})
+
+        assert isinstance(artifact, ErrorArtifact)
+        assert artifact.value == "boom"

--- a/uv.lock
+++ b/uv.lock
@@ -1651,6 +1651,7 @@ docs = [
 test = [
     { name = "exceptiongroup" },
     { name = "fuzzywuzzy" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "mongomock" },
     { name = "moto", extra = ["dynamodb"] },
@@ -1828,6 +1829,7 @@ docs = [
 test = [
     { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "mcp", specifier = ">=2,<3" },
     { name = "mongomock", specifier = ">=4.1.2" },
     { name = "moto", extras = ["dynamodb", "iotdata", "sqs"], specifier = ">=5.0.16" },

--- a/uv.lock
+++ b/uv.lock
@@ -174,13 +174,11 @@ name = "anthropic"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "distro" },
     { name = "httpx" },
     { name = "jiter" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
@@ -191,34 +189,12 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.8.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "idna", version = "3.10", source = { registry = "https://pypi.org/simple" } },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126, upload-time = "2025-01-05T13:13:11.095Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041, upload-time = "2025-01-05T13:13:07.985Z" },
-]
-
-[[package]]
-name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
-    { name = "idna", version = "3.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -663,10 +639,8 @@ dependencies = [
     { name = "fastavro" },
     { name = "httpx" },
     { name = "httpx-sse" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
     { name = "requests" },
     { name = "tokenizers" },
     { name = "types-requests" },
@@ -1079,10 +1053,8 @@ version = "1.59.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
     { name = "requests" },
     { name = "typing-extensions" },
     { name = "websockets" },
@@ -1107,8 +1079,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "openai" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "pytest-mock" },
     { name = "requests" },
     { name = "typing-extensions" },
@@ -1317,13 +1288,11 @@ name = "google-genai"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "distro" },
     { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "sniffio" },
     { name = "tenacity" },
@@ -1424,8 +1393,7 @@ dependencies = [
     { name = "numpy" },
     { name = "openai" },
     { name = "pip" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -1683,7 +1651,7 @@ docs = [
 test = [
     { name = "exceptiongroup" },
     { name = "fuzzywuzzy" },
-    { name = "mcp", extra = ["ws"] },
+    { name = "mcp" },
     { name = "mongomock" },
     { name = "moto", extra = ["dynamodb"] },
     { name = "pytest" },
@@ -1860,7 +1828,7 @@ docs = [
 test = [
     { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "fuzzywuzzy", specifier = ">=0.18.0" },
-    { name = "mcp", extras = ["ws"], specifier = ">=1.10.0,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "mongomock", specifier = ">=4.1.2" },
     { name = "moto", extras = ["dynamodb", "iotdata", "sqs"], specifier = ">=5.0.16" },
     { name = "pytest", specifier = ">=8.3.1" },
@@ -1982,16 +1950,27 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
-    { name = "idna", version = "3.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", version = "3.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -2017,6 +1996,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -2069,26 +2074,8 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "idna"
 version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
@@ -2254,8 +2241,7 @@ name = "json-schema-to-pydantic"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/39/e7d190da630be2721841e8846a151a6baf2ad3415e105d3e09e711382675/json_schema_to_pydantic-0.4.6.tar.gz", hash = "sha256:5cbca5b02cb52435f5698981dc050acaf684a757434ec4393b81a402a4a9a08a", size = 47559, upload-time = "2025-10-30T21:20:06.021Z" }
 wheels = [
@@ -2566,8 +2552,7 @@ version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -2602,17 +2587,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "anyio" },
+    { name = "httpx2" },
     { name = "jsonschema" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-settings" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -2622,14 +2605,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
-[package.optional-dependencies]
-ws = [
-    { name = "websockets" },
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -3432,8 +3423,7 @@ version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/64/709dc99030f8f46ec552f0a7da73bbdcc2da58666abfec4742ccdb2e800e/ollama-0.4.8.tar.gz", hash = "sha256:1121439d49b96fa8339842965d0616eba5deb9f8c790786cdf4c0b3df4833802", size = 12972, upload-time = "2025-04-16T21:55:14.101Z" }
 wheels = [
@@ -3445,13 +3435,11 @@ name = "openai"
 version = "1.79.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "distro" },
     { name = "httpx" },
     { name = "jiter" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -4159,35 +4147,11 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540, upload-time = "2025-04-29T20:38:55.02Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900, upload-time = "2025-04-29T20:38:52.724Z" },
-]
-
-[[package]]
-name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
     { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic-core" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
@@ -4198,104 +4162,8 @@ wheels = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/92/b31726561b5dae176c2d2c2dc43a9c5bfba5d32f96f8b4c0a600dd492447/pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8", size = 2028817, upload-time = "2025-04-23T18:30:43.919Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/44/3f0b95fafdaca04a483c4e685fe437c6891001bf3ce8b2fded82b9ea3aa1/pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d", size = 1861357, upload-time = "2025-04-23T18:30:46.372Z" },
-    { url = "https://files.pythonhosted.org/packages/30/97/e8f13b55766234caae05372826e8e4b3b96e7b248be3157f53237682e43c/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d", size = 1898011, upload-time = "2025-04-23T18:30:47.591Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a3/99c48cf7bafc991cc3ee66fd544c0aae8dc907b752f1dad2d79b1b5a471f/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572", size = 1982730, upload-time = "2025-04-23T18:30:49.328Z" },
-    { url = "https://files.pythonhosted.org/packages/de/8e/a5b882ec4307010a840fb8b58bd9bf65d1840c92eae7534c7441709bf54b/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02", size = 2136178, upload-time = "2025-04-23T18:30:50.907Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/bb/71e35fc3ed05af6834e890edb75968e2802fe98778971ab5cba20a162315/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b", size = 2736462, upload-time = "2025-04-23T18:30:52.083Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/c8f7593e6bc7066289bbc366f2235701dcbebcd1ff0ef8e64f6f239fb47d/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2", size = 2005652, upload-time = "2025-04-23T18:30:53.389Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/7a/996d8bd75f3eda405e3dd219ff5ff0a283cd8e34add39d8ef9157e722867/pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a", size = 2113306, upload-time = "2025-04-23T18:30:54.661Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/84/daf2a6fb2db40ffda6578a7e8c5a6e9c8affb251a05c233ae37098118788/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac", size = 2073720, upload-time = "2025-04-23T18:30:56.11Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fb/2258da019f4825128445ae79456a5499c032b55849dbd5bed78c95ccf163/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a", size = 2244915, upload-time = "2025-04-23T18:30:57.501Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/7a/925ff73756031289468326e355b6fa8316960d0d65f8b5d6b3a3e7866de7/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b", size = 2241884, upload-time = "2025-04-23T18:30:58.867Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b0/249ee6d2646f1cdadcb813805fe76265745c4010cf20a8eba7b0e639d9b2/pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22", size = 1910496, upload-time = "2025-04-23T18:31:00.078Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ff/172ba8f12a42d4b552917aa65d1f2328990d3ccfc01d5b7c943ec084299f/pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640", size = 1955019, upload-time = "2025-04-23T18:31:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584, upload-time = "2025-04-23T18:31:03.106Z" },
-    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071, upload-time = "2025-04-23T18:31:04.621Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823, upload-time = "2025-04-23T18:31:06.377Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792, upload-time = "2025-04-23T18:31:07.93Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338, upload-time = "2025-04-23T18:31:09.283Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998, upload-time = "2025-04-23T18:31:11.7Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200, upload-time = "2025-04-23T18:31:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890, upload-time = "2025-04-23T18:31:15.011Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359, upload-time = "2025-04-23T18:31:16.393Z" },
-    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883, upload-time = "2025-04-23T18:31:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074, upload-time = "2025-04-23T18:31:19.205Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538, upload-time = "2025-04-23T18:31:20.541Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909, upload-time = "2025-04-23T18:31:22.371Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786, upload-time = "2025-04-23T18:31:24.161Z" },
-    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
-    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
-    { url = "https://files.pythonhosted.org/packages/30/68/373d55e58b7e83ce371691f6eaa7175e3a24b956c44628eb25d7da007917/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa", size = 2023982, upload-time = "2025-04-23T18:32:53.14Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/16/145f54ac08c96a63d8ed6442f9dec17b2773d19920b627b18d4f10a061ea/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29", size = 1858412, upload-time = "2025-04-23T18:32:55.52Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b1/c6dc6c3e2de4516c0bb2c46f6a373b91b5660312342a0cf5826e38ad82fa/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d", size = 1892749, upload-time = "2025-04-23T18:32:57.546Z" },
-    { url = "https://files.pythonhosted.org/packages/12/73/8cd57e20afba760b21b742106f9dbdfa6697f1570b189c7457a1af4cd8a0/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e", size = 2067527, upload-time = "2025-04-23T18:32:59.771Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/d5/0bb5d988cc019b3cba4a78f2d4b3854427fc47ee8ec8e9eaabf787da239c/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c", size = 2108225, upload-time = "2025-04-23T18:33:04.51Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/c5/00c02d1571913d496aabf146106ad8239dc132485ee22efe08085084ff7c/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec", size = 2069490, upload-time = "2025-04-23T18:33:06.391Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a8/dccc38768274d3ed3a59b5d06f59ccb845778687652daa71df0cab4040d7/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052", size = 2237525, upload-time = "2025-04-23T18:33:08.44Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e7/4f98c0b125dda7cf7ccd14ba936218397b44f50a56dd8c16a3091df116c3/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c", size = 2238446, upload-time = "2025-04-23T18:33:10.313Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/91/2ec36480fdb0b783cd9ef6795753c1dea13882f2e68e73bce76ae8c21e6a/pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808", size = 2066678, upload-time = "2025-04-23T18:33:12.224Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200, upload-time = "2025-04-23T18:33:14.199Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123, upload-time = "2025-04-23T18:33:16.555Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852, upload-time = "2025-04-23T18:33:18.513Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484, upload-time = "2025-04-23T18:33:20.475Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896, upload-time = "2025-04-23T18:33:22.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475, upload-time = "2025-04-23T18:33:24.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
-    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
-]
-
-[[package]]
-name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -4406,21 +4274,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -4821,8 +4674,7 @@ dependencies = [
     { name = "numpy" },
     { name = "portalocker" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/80/b84c4c52106b6da291829d8ec632f58a5692d2772e8d3c1d3be4f9a47a2e/qdrant_client-1.14.2.tar.gz", hash = "sha256:da5cab4d367d099d1330b6f30d45aefc8bd76f8b8f9d8fa5d4f813501b93af0d", size = 285531, upload-time = "2025-04-24T14:44:43.307Z" }
@@ -4947,8 +4799,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
-    { name = "idna", version = "3.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", version = "3.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
@@ -5516,8 +5367,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "cryptography" },
     { name = "filelock" },
-    { name = "idna", version = "3.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", version = "3.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "pyjwt" },
@@ -5557,8 +5407,7 @@ name = "snowflake-core"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -5669,8 +5518,7 @@ name = "sse-starlette"
 version = "3.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
@@ -5683,8 +5531,7 @@ name = "starlette"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
@@ -6064,6 +5911,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "twine"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6228,8 +6084,7 @@ dependencies = [
     { name = "aiolimiter" },
     { name = "numpy" },
     { name = "pillow" },
-    { name = "pydantic", version = "2.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "tenacity" },
     { name = "tokenizers" },
@@ -6429,8 +6284,7 @@ name = "yarl"
 version = "1.18.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", version = "3.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", version = "3.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
     { name = "multidict" },
     { name = "propcache" },
 ]


### PR DESCRIPTION
Migrates `MCPTool` to `mcp@2.x`. Technically a breaking change but it doesn't feel big enough to warrant a `griptape@2`

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2301.org.readthedocs.build//2301/

<!-- readthedocs-preview griptape end -->