### PR TITLE
docs: repoint extras anchors at the renamed Installing Optional Dependencies section

### DIFF
--- a/docs/griptape-framework/data/loaders.md
+++ b/docs/griptape-framework/data/loaders.md
@@ -31,7 +31,7 @@ Loads text files into [TextArtifact](../../griptape-framework/data/artifacts.md#
 
 !!! info
 
-    This driver requires the `loaders-pdf` [extra](../index.md#extras).
+    This driver requires the `loaders-pdf` [extra](../index.md#installing-optional-dependencies).
 
 Loads PDF files into [ListArtifact](../../griptape-framework/data/artifacts.md#list)s, where each element is a [TextArtifact](../../griptape-framework/data/artifacts.md#text) containing a page of the PDF:
 
@@ -51,7 +51,7 @@ Loads CSV files into [ListArtifact](../../griptape-framework/data/artifacts.md#l
 
 !!! info
 
-    This driver requires the `loaders-image` [extra](../index.md#extras).
+    This driver requires the `loaders-image` [extra](../index.md#installing-optional-dependencies).
 
 Loads images into [ImageArtifact](../../griptape-framework/data/artifacts.md#image)s:
 
@@ -88,7 +88,7 @@ Loads JSON files into [JsonArtifact](../../griptape-framework/data/artifacts.md#
 
 !!! info
 
-    This driver requires the `loaders-web` [extra](../index.md#extras).
+    This driver requires the `loaders-web` [extra](../index.md#installing-optional-dependencies).
 
 Scrapes web pages using a [WebScraperDriver](../drivers/web-scraper-drivers.md) and loads the resulting text into [TextArtifact](../../griptape-framework/data/artifacts.md#text)s.
 
@@ -108,7 +108,7 @@ Loads data from a SQL database using a [SQLDriver](../drivers/sql-drivers.md) an
 
 !!! info
 
-    This driver requires the `loaders-email` [extra](../index.md#extras).
+    This driver requires the `loaders-email` [extra](../index.md#installing-optional-dependencies).
 
 Loads data from an imap email server into a [ListArtifact](../../reference/griptape/artifacts/list_artifact.md)s, where each element is a [TextArtifact](../../reference/griptape/artifacts/text_artifact.md) containing an email.
 

--- a/docs/griptape-framework/drivers/conversation-memory-drivers.md
+++ b/docs/griptape-framework/drivers/conversation-memory-drivers.md
@@ -45,7 +45,7 @@ The [LocalConversationMemoryDriver](../../reference/griptape/drivers/memory/conv
 
 !!! info
 
-    This driver requires the `drivers-memory-conversation-amazon-dynamodb` [extra](../index.md#extras).
+    This driver requires the `drivers-memory-conversation-amazon-dynamodb` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonDynamoDbConversationMemoryDriver](../../reference/griptape/drivers/memory/conversation/amazon_dynamodb_conversation_memory_driver.md) allows you to persist Conversation Memory in [Amazon DynamoDb](https://aws.amazon.com/dynamodb/).
 
@@ -67,7 +67,7 @@ Optional parameters `sort_key` and `sort_key_value` can be supplied for tables w
 
 !!! info
 
-    This driver requires the `drivers-memory-conversation-redis` [extra](../index.md#extras).
+    This driver requires the `drivers-memory-conversation-redis` [extra](../index.md#installing-optional-dependencies).
 
 The [RedisConversationMemoryDriver](../../reference/griptape/drivers/memory/conversation/redis_conversation_memory_driver.md) allows you to persist Conversation Memory in [Redis](https://redis.io/).
 

--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -52,7 +52,7 @@ with updated defaults.
 
 !!! info
 
-    This driver requires the `drivers-embedding-amazon-bedrock` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-amazon-bedrock` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonBedrockTitanEmbeddingDriver](../../reference/griptape/drivers/embedding/amazon_bedrock_titan_embedding_driver.md) uses the [Amazon Bedrock Embeddings API](https://docs.aws.amazon.com/bedrock/latest/userguide/embeddings.html).
 
@@ -76,7 +76,7 @@ The [AmazonBedrockTitanEmbeddingDriver](../../reference/griptape/drivers/embeddi
 
 !!! info
 
-    This driver requires the `drivers-embedding-google` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-google` [extra](../index.md#installing-optional-dependencies).
 
 The [GoogleEmbeddingDriver](../../reference/griptape/drivers/embedding/google_embedding_driver.md) uses the [Google Embeddings API](https://ai.google.dev/tutorials/python_quickstart#use_embeddings).
 
@@ -100,7 +100,7 @@ The [GoogleEmbeddingDriver](../../reference/griptape/drivers/embedding/google_em
 
 !!! info
 
-    This driver requires the `drivers-embedding-huggingface` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-huggingface` [extra](../index.md#installing-optional-dependencies).
 
 The [HuggingFaceHubEmbeddingDriver](../../reference/griptape/drivers/embedding/huggingface_hub_embedding_driver.md) connects to the [Hugging Face Hub API](https://huggingface.co/docs/hub/api). It supports models with the following tasks:
 
@@ -122,7 +122,7 @@ The [HuggingFaceHubEmbeddingDriver](../../reference/griptape/drivers/embedding/h
 
 !!! info
 
-    This driver requires the `drivers-embedding-ollama` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-ollama` [extra](../index.md#installing-optional-dependencies).
 
 The [OllamaEmbeddingDriver](../../reference/griptape/drivers/embedding/ollama_embedding_driver.md) uses the [Ollama Embeddings API](https://ollama.com/blog/embedding-models).
 
@@ -136,7 +136,7 @@ The [AmazonSageMakerJumpstartEmbeddingDriver](../../reference/griptape/drivers/e
 
 !!! info
 
-    This driver requires the `drivers-embedding-amazon-sagemaker` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-amazon-sagemaker` [extra](../index.md#installing-optional-dependencies).
 
 ```python
 --8<-- "docs/griptape-framework/drivers/src/embedding_drivers_7.py"
@@ -148,7 +148,7 @@ The [VoyageAiEmbeddingDriver](../../reference/griptape/drivers/embedding/voyagea
 
 !!! info
 
-    This driver requires the `drivers-embedding-voyageai` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-voyageai` [extra](../index.md#installing-optional-dependencies).
 
 === "Code"
 
@@ -168,7 +168,7 @@ The [CohereEmbeddingDriver](../../reference/griptape/drivers/embedding/cohere_em
 
 !!! info
 
-    This driver requires the `drivers-embedding-cohere` [extra](../index.md#extras).
+    This driver requires the `drivers-embedding-cohere` [extra](../index.md#installing-optional-dependencies).
 
 === "Code"
 

--- a/docs/griptape-framework/drivers/event-listener-drivers.md
+++ b/docs/griptape-framework/drivers/event-listener-drivers.md
@@ -35,7 +35,7 @@ Griptape offers the following Event Listener Drivers for forwarding Griptape Eve
 
 !!! info
 
-    This driver requires the `drivers-event-listener-amazon-sqs` [extra](../index.md#extras).
+    This driver requires the `drivers-event-listener-amazon-sqs` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonSqsEventListenerDriver](../../reference/griptape/drivers/event_listener/amazon_sqs_event_listener_driver.md) sends Events to an [Amazon SQS](https://aws.amazon.com/sqs/) queue.
 
@@ -55,7 +55,7 @@ The [AmazonSqsEventListenerDriver](../../reference/griptape/drivers/event_listen
 
 !!! info
 
-    This driver requires the `drivers-event-listener-amazon-iot` [extra](../index.md#extras).
+    This driver requires the `drivers-event-listener-amazon-iot` [extra](../index.md#installing-optional-dependencies).
 
 The [AwsIotCoreEventListenerDriver](../../reference/griptape/drivers/event_listener/aws_iot_core_event_listener_driver.md) sends Events to the [AWS IoT Message Broker](https://aws.amazon.com/iot-core/).
 
@@ -111,7 +111,7 @@ The [WebhookEventListenerDriver](../../reference/griptape/drivers/event_listener
 
 !!! info
 
-    This driver requires the `drivers-event-listener-pusher` [extra](../index.md#extras).
+    This driver requires the `drivers-event-listener-pusher` [extra](../index.md#installing-optional-dependencies).
 
 The [PusherEventListenerDriver](../../reference/griptape/drivers/event_listener/pusher_event_listener_driver.md) sends Events to [Pusher](https://pusher.com).
 

--- a/docs/griptape-framework/drivers/file-manager-drivers.md
+++ b/docs/griptape-framework/drivers/file-manager-drivers.md
@@ -61,7 +61,7 @@ The [LocalFileManagerDriver](../../reference/griptape/drivers/file_manager/local
 
 !!! info
 
-    This driver requires the `drivers-file-manager-amazon-s3` [extra](../index.md#extras).
+    This driver requires the `drivers-file-manager-amazon-s3` [extra](../index.md#installing-optional-dependencies).
 
 The [LocalFile ManagerDriver](../../reference/griptape/drivers/file_manager/amazon_s3_file_manager_driver.md) allows you to load and save files sourced from an Amazon S3 bucket.
 

--- a/docs/griptape-framework/drivers/image-generation-drivers.md
+++ b/docs/griptape-framework/drivers/image-generation-drivers.md
@@ -131,7 +131,7 @@ This Driver supports image generation configurations like style presets, image q
 
 !!! info
 
-    This driver requires the `drivers-image-generation-huggingface` [extra](../index.md#extras).
+    This driver requires the `drivers-image-generation-huggingface` [extra](../index.md#installing-optional-dependencies).
 
 The [HuggingFace Pipelines Image Generation Driver](../../reference/griptape/drivers/image_generation/huggingface_pipeline_image_generation_driver.md) enables image generation through locally-hosted models using the HuggingFace [Diffusers](https://huggingface.co/docs/diffusers/en/index) library. This Driver requires a [Pipeline Driver](../../reference/griptape/drivers/image_generation_pipeline/index.md) to prepare the appropriate Pipeline.
 

--- a/docs/griptape-framework/drivers/observability-drivers.md
+++ b/docs/griptape-framework/drivers/observability-drivers.md
@@ -17,7 +17,7 @@ Observability Drivers are used by [Observability](../structures/observability.md
 
 !!! info
 
-    This driver requires the `drivers-observability-griptape-cloud` [extra](../index.md#extras).
+    This driver requires the `drivers-observability-griptape-cloud` [extra](../index.md#installing-optional-dependencies).
 
 The Griptape Cloud Observability Driver instruments `@observable` functions and methods with metrics and traces for use with the Griptape Cloud.
 
@@ -36,7 +36,7 @@ Here is an example of how to use the `GriptapeCloudObservabilityDriver` with the
 
 !!! info
 
-    This driver requires the `drivers-observability-opentelemetry` [extra](../index.md#extras).
+    This driver requires the `drivers-observability-opentelemetry` [extra](../index.md#installing-optional-dependencies).
 
 The [OpenTelemetry](https://opentelemetry.io/) Observability Driver instruments `@observable` functions and methods with metrics and traces for use with OpenTelemetry. You must configure a destination for the telemetry by providing a `SpanProcessor` to the Driver.
 

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -188,7 +188,7 @@ This driver uses [Cohere tool use](https://docs.cohere.com/docs/tools) when usin
 
 !!! info
 
-    This driver requires the `drivers-prompt-cohere` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-cohere` [extra](../index.md#installing-optional-dependencies).
 
 === "Code"
 
@@ -206,7 +206,7 @@ This driver uses [Cohere tool use](https://docs.cohere.com/docs/tools) when usin
 
 !!! info
 
-    This driver requires the `drivers-prompt-anthropic` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-anthropic` [extra](../index.md#installing-optional-dependencies).
 
 The [AnthropicPromptDriver](../../reference/griptape/drivers/prompt/anthropic_prompt_driver.md) connects to the Anthropic [Messages](https://docs.anthropic.com/claude/reference/messages_post) API.
 This driver uses [Anthropic tool use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) when using [Tools](../tools/index.md).
@@ -227,7 +227,7 @@ This driver uses [Anthropic tool use](https://docs.anthropic.com/en/docs/build-w
 
 !!! info
 
-    This driver requires the `drivers-prompt-google` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-google` [extra](../index.md#installing-optional-dependencies).
 
 The [GooglePromptDriver](../../reference/griptape/drivers/prompt/google_prompt_driver.md) connects to the [Google Generative AI](https://ai.google.dev/tutorials/python_quickstart#generate_text_from_text_inputs) API.
 This driver uses [Gemini function calling](https://ai.google.dev/gemini-api/docs/function-calling) when using [Tools](../tools/index.md).
@@ -248,7 +248,7 @@ This driver uses [Gemini function calling](https://ai.google.dev/gemini-api/docs
 
 !!! info
 
-    This driver requires the `drivers-prompt-amazon-bedrock` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-amazon-bedrock` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonBedrockPromptDriver](../../reference/griptape/drivers/prompt/amazon_bedrock_prompt_driver.md) uses [Amazon Bedrock](https://aws.amazon.com/bedrock/)'s [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html).
 This driver uses [Bedrock tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html) when using [Tools](../tools/index.md).
@@ -271,7 +271,7 @@ All models supported by the Converse API are available for use with this driver.
 
 !!! info
 
-    This driver requires the `drivers-prompt-ollama` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-ollama` [extra](../index.md#installing-optional-dependencies).
 
 The [OllamaPromptDriver](../../reference/griptape/drivers/prompt/ollama_prompt_driver.md) connects to the [Ollama Chat Completion API](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion).
 This driver uses [Ollama tool calling](https://ollama.com/blog/tool-support) when using [Tools](../tools/index.md).
@@ -284,7 +284,7 @@ This driver uses [Ollama tool calling](https://ollama.com/blog/tool-support) whe
 
 !!! info
 
-    This driver requires the `drivers-prompt-huggingface` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-huggingface` [extra](../index.md#installing-optional-dependencies).
 
 The [HuggingFaceHubPromptDriver](../../reference/griptape/drivers/prompt/huggingface_hub_prompt_driver.md) connects to the [Hugging Face Hub API](https://huggingface.co/docs/hub/api).
 
@@ -318,7 +318,7 @@ The [HuggingFaceHubPromptDriver](#hugging-face-hub) also supports [Text Generati
 
 !!! info
 
-    This driver requires the `drivers-prompt-huggingface-pipeline` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-huggingface-pipeline` [extra](../index.md#installing-optional-dependencies).
 
 The [HuggingFacePipelinePromptDriver](../../reference/griptape/drivers/prompt/huggingface_pipeline_prompt_driver.md) uses [Hugging Face Pipelines](https://huggingface.co/docs/transformers/main_classes/pipelines) for inference locally.
 
@@ -342,7 +342,7 @@ The [HuggingFacePipelinePromptDriver](../../reference/griptape/drivers/prompt/hu
 
 !!! info
 
-    This driver requires the `drivers-prompt-amazon-sagemaker` [extra](../index.md#extras).
+    This driver requires the `drivers-prompt-amazon-sagemaker` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonSageMakerJumpstartPromptDriver](../../reference/griptape/drivers/prompt/amazon_sagemaker_jumpstart_prompt_driver.md) uses [Amazon SageMaker Jumpstart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) for inference on AWS.
 

--- a/docs/griptape-framework/drivers/rerank-drivers.md
+++ b/docs/griptape-framework/drivers/rerank-drivers.md
@@ -49,7 +49,7 @@ The [CohereRerankDriver](../../reference/griptape/drivers/rerank/cohere_rerank_d
 
 !!! info
 
-    This driver requires the `drivers-rerank-amazon-bedrock` [extra](../index.md#extras).
+    This driver requires the `drivers-rerank-amazon-bedrock` [extra](../index.md#installing-optional-dependencies).
 
 The [AmazonBedrockRerankDriver](../../reference/griptape/drivers/rerank/amazon_bedrock_rerank_driver.md) uses [Amazon Bedrock](https://aws.amazon.com/bedrock/)'s Rerank API.
 
@@ -73,7 +73,7 @@ The [NvidiaNimRerankDriver](../../reference/griptape/drivers/rerank/nvidia_nim_r
 
 !!! info
 
-    This driver requires the `drivers-rerank-voyageai` [extra](../index.md#extras).
+    This driver requires the `drivers-rerank-voyageai` [extra](../index.md#installing-optional-dependencies).
 
 The [VoyageAiRerankDriver](../../reference/griptape/drivers/rerank/voyageai_rerank_driver.md) uses [Voyage AI's Rerank](https://docs.voyageai.com/docs/reranker) API.
 

--- a/docs/griptape-framework/drivers/sql-drivers.md
+++ b/docs/griptape-framework/drivers/sql-drivers.md
@@ -17,7 +17,7 @@ SQL drivers can be used to make SQL queries and load table schemas. They are use
 
 !!! info
 
-    This driver requires the `drivers-sql` [extra](../index.md#extras).
+    This driver requires the `drivers-sql` [extra](../index.md#installing-optional-dependencies).
 
 Note that you may need to install the appropriate database driver for your SQL database.
 For example, to use the `psycopg2` driver for PostgreSQL, you can install it with `pip install psycopg2-binary`.
@@ -32,7 +32,7 @@ This is a basic SQL loader based on [SQLAlchemy 2.0](https://docs.sqlalchemy.org
 
 !!! info
 
-    This driver requires the `drivers-sql-amazon-redshift` [extra](../index.md#extras).
+    This driver requires the `drivers-sql-amazon-redshift` [extra](../index.md#installing-optional-dependencies).
 
 This is a SQL driver for interacting with the [Amazon Redshift Data API](https://docs.aws.amazon.com/redshift-data/latest/APIReference/Welcome.html)
 to execute statements. Here is an example of how to use it for Redshift Serverless:
@@ -45,7 +45,7 @@ to execute statements. Here is an example of how to use it for Redshift Serverle
 
 !!! info
 
-    This driver requires the `drivers-sql-snowflake` [extra](../index.md#extras).
+    This driver requires the `drivers-sql-snowflake` [extra](../index.md#installing-optional-dependencies).
 
 This is a SQL driver based on the [Snowflake SQLAlchemy Toolkit](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy) which runs on top of the Snowflake Connector for Python. Here is an example of how to use it:
 

--- a/docs/griptape-framework/drivers/text-to-speech-drivers.md
+++ b/docs/griptape-framework/drivers/text-to-speech-drivers.md
@@ -17,7 +17,7 @@ The [Eleven Labs Text to Speech Driver](../../reference/griptape/drivers/text_to
 
 !!! info
 
-    This driver requires the `drivers-text-to-speech-elevenlabs` [extra](../index.md#extras).
+    This driver requires the `drivers-text-to-speech-elevenlabs` [extra](../index.md#installing-optional-dependencies).
 
 === "Code"
 

--- a/docs/griptape-framework/drivers/vector-store-drivers.md
+++ b/docs/griptape-framework/drivers/vector-store-drivers.md
@@ -60,7 +60,7 @@ The [GriptapeCloudVectorStoreDriver](../../reference/griptape/drivers/vector/gri
 
 !!! info
 
-    This Driver requires the `drivers-vector-pinecone` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-pinecone` [extra](../index.md#installing-optional-dependencies).
 
 The [PineconeVectorStoreDriver](../../reference/griptape/drivers/vector/pinecone_vector_store_driver.md) supports the [Pinecone vector database](https://www.pinecone.io/).
 
@@ -82,7 +82,7 @@ Here is an example of how the Driver can be used to load and query information i
 
 !!! info
 
-    This Driver requires the `drivers-vector-marqo` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-marqo` [extra](../index.md#installing-optional-dependencies).
 
 The [MarqoVectorStoreDriver](../../reference/griptape/drivers/vector/marqo_vector_store_driver.md) supports the Marqo vector database.
 
@@ -104,7 +104,7 @@ Here is an example of how the Driver can be used to load and query information i
 
 !!! info
 
-    This Driver requires the `drivers-vector-mongodb` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-mongodb` [extra](../index.md#installing-optional-dependencies).
 
 The [MongodbAtlasVectorStoreDriver](../../reference/griptape/drivers/vector/mongodb_atlas_vector_store_driver.md) provides support for storing vector data in a MongoDB Atlas database.
 
@@ -147,7 +147,7 @@ Replace `path_to_vector` with the expected field name where the vector content w
 
 !!! info
 
-    This Driver requires the `drivers-vector-mongodb` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-mongodb` [extra](../index.md#installing-optional-dependencies).
 
 The [AzureMongoDbVectorStoreDriver](../../reference/griptape/drivers/vector/azure_mongodb_vector_store_driver.md) provides support for storing vector data in an Azure CosmosDb database account using the MongoDb vCore API
 
@@ -169,7 +169,7 @@ Here is an example of how the Driver can be used to load and query information i
 
 !!! info
 
-    This Driver requires the `drivers-vector-redis` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-redis` [extra](../index.md#installing-optional-dependencies).
 
 The [RedisVectorStoreDriver](../../reference/griptape/drivers/vector/redis_vector_store_driver.md) integrates with the Redis vector storage system.
 
@@ -197,7 +197,7 @@ FT.CREATE idx:griptape ON hash PREFIX 1 "griptape:" SCHEMA namespace TAG vector 
 
 !!! info
 
-    This Driver requires the `drivers-vector-opensearch` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-opensearch` [extra](../index.md#installing-optional-dependencies).
 
 The [OpenSearchVectorStoreDriver](../../reference/griptape/drivers/vector/opensearch_vector_store_driver.md) integrates with the OpenSearch platform, allowing for storage, retrieval, and querying of vector data.
 
@@ -233,7 +233,7 @@ The body mappings for creating a vector index should look similar to the followi
 
 !!! info
 
-    This Driver requires the `drivers-vector-pgvector` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-pgvector` [extra](../index.md#installing-optional-dependencies).
 
 The [PGVectorVectorStoreDriver](../../reference/griptape/drivers/vector/pgvector_vector_store_driver.md) integrates with PGVector, a vector storage and search extension for Postgres. While Griptape will handle enabling the extension, PGVector must be installed and ready for use in your Postgres instance before using this Vector Store Driver.
 
@@ -255,7 +255,7 @@ Here is an example of how the Driver can be used to load and query information i
 
 !!! info
 
-    This Driver requires the `drivers-vector-qdrant` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-qdrant` [extra](../index.md#installing-optional-dependencies).
 
 The QdrantVectorStoreDriver supports the [Qdrant vector database](https://qdrant.tech/).
 
@@ -277,7 +277,7 @@ Here is an example of how the Driver can be used to query information in a Qdran
 
 !!! info
 
-    This Driver requires the `drivers-vector-astra-db` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-astra-db` [extra](../index.md#installing-optional-dependencies).
 
 The AstraDbVectorStoreDriver supports [DataStax Astra DB](https://www.datastax.com/products/datastax-astra).
 
@@ -299,7 +299,7 @@ The following example shows how to store vector entries and query the informatio
 
 !!! info
 
-    This Driver requires the `drivers-vector-pgai` [extra](../index.md#extras).
+    This Driver requires the `drivers-vector-pgai` [extra](../index.md#installing-optional-dependencies).
 
 The PgAiKnowledgeBaseVectorStoreDriver integrates with PG.AI, a managed postgres platform from [EnterpriseDB](https://www.enterprisedb.com/).
 

--- a/docs/griptape-framework/drivers/web-scraper-drivers.md
+++ b/docs/griptape-framework/drivers/web-scraper-drivers.md
@@ -25,7 +25,7 @@ Example using `ProxyWebScraperDriver` directly:
 
 !!! info
 
-    This driver requires the `drivers-web-scraper-markdownify` [extra](../index.md#extras) and the
+    This driver requires the `drivers-web-scraper-markdownify` [extra](../index.md#installing-optional-dependencies) and the
     playwright browsers to be installed.
 
     To install the playwright browsers, run `playwright install` in your terminal. If you are using
@@ -74,7 +74,7 @@ Example of using `MarkdownifyWebScraperDriver` with an agent:
 
 !!! info
 
-    This driver requires the `drivers-web-scraper-trafilatura` [extra](../index.md#extras).
+    This driver requires the `drivers-web-scraper-trafilatura` [extra](../index.md#installing-optional-dependencies).
 
 The [TrafilaturaWebScraperDriver](../../reference/griptape/drivers/web_scraper/trafilatura_web_scraper_driver.md) scrapes text from a webpage using the [Trafilatura](https://trafilatura.readthedocs.io) library.
 

--- a/docs/griptape-framework/drivers/web-search-drivers.md
+++ b/docs/griptape-framework/drivers/web-search-drivers.md
@@ -73,7 +73,7 @@ The [GoogleWebSearchDriver](../../reference/griptape/drivers/web_search/google_w
 
 !!! info
 
-    This driver requires the `drivers-web-search-duckduckgo` [extra](../index.md#extras).
+    This driver requires the `drivers-web-search-duckduckgo` [extra](../index.md#installing-optional-dependencies).
 
 The [DuckDuckGoWebSearchDriver](../../reference/griptape/drivers/web_search/duck_duck_go_web_search_driver.md) uses the [ddgs](https://github.com/deedy5/ddgs) SDK for web searching.
 
@@ -85,7 +85,7 @@ The [DuckDuckGoWebSearchDriver](../../reference/griptape/drivers/web_search/duck
 
 !!! info
 
-    This driver requires the `drivers-web-search-tavily` [extra](../index.md#extras), and a Tavily [api key](https://app.tavily.com).
+    This driver requires the `drivers-web-search-tavily` [extra](../index.md#installing-optional-dependencies), and a Tavily [api key](https://app.tavily.com).
 
 ```python
 --8<-- "docs/griptape-framework/drivers/src/web_search_drivers_4.py"
@@ -95,7 +95,7 @@ The [DuckDuckGoWebSearchDriver](../../reference/griptape/drivers/web_search/duck
 
 !!! info
 
-    This driver requires the `drivers-web-search-exa` [extra](../index.md#extras),
+    This driver requires the `drivers-web-search-exa` [extra](../index.md#installing-optional-dependencies),
     and an Exa [api key](https://dashboard.exa.ai/api-keys)
 
 ```python


### PR DESCRIPTION
Heading `#### Installing Extras` in `docs/griptape-framework/index.md` was renamed to `#### Installing Optional Dependencies` in bc195530 (#1871), but the 49 inbound anchors across the framework's driver/data docs still linked `index.md#extras` — every one scrolls nowhere on the rendered docs. Repointed all of them to `#installing-optional-dependencies` (14 files, mechanical rename; zero remaining `index.md#extras` references).

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2304.org.readthedocs.build//2304/

<!-- readthedocs-preview griptape end -->