### PR TITLE
docs: fix prompttask anchor and remove stale Attributes from base file manager driver docstring

### DIFF
--- a/docs/griptape-framework/index.md
+++ b/docs/griptape-framework/index.md
@@ -320,7 +320,7 @@ The LLM response is not only formatted correctly, but automatically parsed into 
 
 !!! info
 
-    If your chosen model provider doesn’t natively support structured output, Griptape employs multiple [fallback strategies](./drivers/prompt-drivers.md#prompttask). The final fallback is the `JsonSchemaRule`, which you saw earlier.
+    If your chosen model provider doesn’t natively support structured output, Griptape employs multiple [fallback strategies](./drivers/prompt-drivers.md#prompt-task). The final fallback is the `JsonSchemaRule`, which you saw earlier.
 
 Now that we can generate structured responses, let’s make our Task more conversational using Griptape’s memory features.
 

--- a/griptape/drivers/file_manager/base_file_manager_driver.py
+++ b/griptape/drivers/file_manager/base_file_manager_driver.py
@@ -11,9 +11,6 @@ from griptape.artifacts import BaseArtifact, BlobArtifact, InfoArtifact, TextArt
 class BaseFileManagerDriver(ABC):
     """BaseFileManagerDriver can be used to list, load, and save files.
 
-    Attributes:
-        default_loader: The default loader to use for loading file contents into artifacts.
-        loaders: Dictionary of file extension specific loaders to use for loading file contents into artifacts.
     """
 
     _workdir: str = field(kw_only=True, alias="workdir")

--- a/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
+++ b/griptape/drivers/prompt/huggingface_hub_prompt_driver.py
@@ -28,7 +28,6 @@ class HuggingFaceHubPromptDriver(BasePromptDriver):
 
     Attributes:
         api_token: Hugging Face Hub API token.
-        use_gpu: Use GPU during model run.
         model: Hugging Face Hub model name.
         client: Custom `InferenceApi`.
         tokenizer: Custom `HuggingFaceTokenizer`.


### PR DESCRIPTION
Three small doc fixes:

1. `docs/griptape-framework/index.md`: the fallback-strategies link used `#prompttask`; the heading in `prompt-drivers.md` is `### Prompt Task` → `#prompt-task`
2. `HuggingFaceHubPromptDriver`: the Attributes section documented `use_gpu`, which exists on neither the class, its parents, nor anywhere else in the package (stale from the old HF-pipeline implementation) — removed the line
3. `BaseFileManagerDriver`: the Attributes section documented `default_loader`/`loaders`, which live on the loader classes rather than on this `@define` driver (fields: `workdir`, `encoding`) — removed the stale section

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--2305.org.readthedocs.build//2305/

<!-- readthedocs-preview griptape end -->