### PR TITLE
fix(utils-j2): render templates in a Jinja2 sandbox

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,28 @@ This document provides instructions for migrating your codebase to accommodate b
 
 ## Next Version (Security Hardening)
 
+### Jinja templates are rendered in a sandbox.
+
+To prevent template injection, `J2` now renders with `jinja2.sandbox.SandboxedEnvironment` instead of `jinja2.Environment`. This affects everything rendered through a template, including Task input, Task context, and Tool activity descriptions.
+
+Ordinary templating is unaffected. Only access to private and dunder attributes changes: it resolves to undefined instead of the value, and raises `jinja2.exceptions.SecurityError` when chained.
+
+#### Before
+
+```python
+task = PromptTask("{{ foo._bar }}", context={"foo": Foo()})
+task.input.value  # "baz"
+```
+
+#### After
+
+Expose the value as a public attribute, or pass it through the Task context directly.
+
+```python
+task = PromptTask("{{ foo.bar }}", context={"foo": Foo()})
+task.input.value  # "baz"
+```
+
 ### `MCPTool` requires MCP Python SDK 2.x.
 
 `MCPTool` now uses [MCP Python SDK 2.x](https://github.com/modelcontextprotocol/python-sdk). Reinstall the tool's requirements (`griptape/tools/mcp/requirements.txt`) to pick up `mcp>=2,<3`.

--- a/griptape/utils/j2.py
+++ b/griptape/utils/j2.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from attrs import Factory, define, field
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment
 
 from .paths import abs_path
 
@@ -10,9 +11,11 @@ from .paths import abs_path
 class J2:
     template_name: str | None = field(default=None)
     templates_dir: str = field(default=abs_path("templates"), kw_only=True)
-    environment: Environment = field(
+    environment: SandboxedEnvironment = field(
         default=Factory(
-            lambda self: Environment(loader=FileSystemLoader(self.templates_dir), trim_blocks=True, lstrip_blocks=True),
+            lambda self: SandboxedEnvironment(
+                loader=FileSystemLoader(self.templates_dir), trim_blocks=True, lstrip_blocks=True
+            ),
             takes_self=True,
         ),
         kw_only=True,

--- a/tests/unit/utils/test_j2.py
+++ b/tests/unit/utils/test_j2.py
@@ -1,0 +1,50 @@
+import pytest
+from jinja2.exceptions import SecurityError
+
+from griptape.utils import J2
+
+
+class TestJ2:
+    def test_render_from_string(self):
+        assert J2().render_from_string("Hello {{ name }}", name="World") == "Hello World"
+
+    def test_render_from_string_expressions(self):
+        assert J2().render_from_string("{{ 1 + 1 }}") == "2"
+        assert J2().render_from_string("{% for i in items %}{{ i }}{% endfor %}", items=[1, 2, 3]) == "123"
+        assert J2().render_from_string("{{ name | upper }}", name="world") == "WORLD"
+
+    def test_render_from_string_public_attrs(self):
+        class Foo:
+            bar = "baz"
+
+            def qux(self) -> str:
+                return "quux"
+
+        assert J2().render_from_string("{{ foo.bar }} {{ foo.qux() }}", foo=Foo()) == "baz quux"
+
+    def test_render_from_string_blocks_unsafe_attrs(self):
+        class Foo:
+            _bar = "baz"
+
+        # Unsafe attribute access resolves to undefined rather than the value.
+        assert J2().render_from_string("{{ foo._bar }}", foo=Foo()) == ""
+        assert J2().render_from_string("{{ foo.__class__ }}", foo="bar") == ""
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "{{ foo.__class__.__name__ }}",
+            "{{ foo.__class__.mro()[1].__subclasses__() }}",
+            "{{ cycler.__init__.__globals__['os'].popen('id').read() }}",
+        ],
+    )
+    def test_render_from_string_blocks_code_execution(self, template):
+        with pytest.raises(SecurityError):
+            J2().render_from_string(template, foo="bar")
+
+    def test_render(self):
+        assert J2("memory/conversation/summary.j2").render(summary="foo") == "Summary of the conversation so far: foo"
+
+    def test_render_no_template_name(self):
+        with pytest.raises(ValueError, match="template_name is required."):
+            J2().render()


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

Render Jinja templates with `SandboxedEnvironment` so Task input cannot reach Python internals through template syntax. Ordinary templating is unaffected; only private and dunder attribute access changes, resolving to undefined instead of the value.

## Issue ticket number and link
