### PR TITLE
fix(drivers-vector-redis): escape namespace metacharacters in queries

### DIFF
--- a/griptape/drivers/vector/redis_vector_store_driver.py
+++ b/griptape/drivers/vector/redis_vector_store_driver.py
@@ -37,6 +37,11 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
     index: str = field(kw_only=True, metadata={"serializable": True})
     _client: Redis | None = field(default=None, kw_only=True, alias="client", metadata={"serializable": False})
 
+    # Characters that alter the structure of a RediSearch TAG query rather than the value matched.
+    TAG_QUERY_METACHARACTERS = frozenset("\\|{}")
+    # Characters that alter the structure of a Redis key glob pattern.
+    GLOB_METACHARACTERS = frozenset("\\*?[]")
+
     @lazy_property()
     def client(self) -> Redis:
         return import_optional_dependency("redis").Redis(
@@ -102,7 +107,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
         Returns:
             A list of `BaseVectorStoreDriver.Entry` objects.
         """
-        pattern = f"{namespace}:*" if namespace else "*"
+        pattern = f"{self._escape_glob_pattern(namespace)}:*" if namespace else "*"
         keys = self.client.keys(pattern)
 
         entries = []
@@ -133,7 +138,7 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
 
         search_query = import_optional_dependency("redis.commands.search.query")
 
-        filter_expression = f"(@namespace:{{{namespace}}})" if namespace else "*"
+        filter_expression = f"(@namespace:{{{self._escape_tag_value(namespace)}}})" if namespace else "*"
         query_expression = (
             search_query.Query(f"{filter_expression}=>[KNN {count or 10} @vector $vector as score]")
             .sort_by("score")
@@ -162,6 +167,18 @@ class RedisVectorStoreDriver(BaseVectorStoreDriver):
                 ),
             )
         return query_results
+
+    def _escape_tag_value(self, value: str) -> str:
+        """Escapes characters that would otherwise be parsed as RediSearch TAG query syntax.
+
+        Without this, a value such as `foo|bar` widens an exact tag filter into a union,
+        and a `}` closes the tag set so that arbitrary query clauses can be appended.
+        """
+        return "".join(f"\\{char}" if char in self.TAG_QUERY_METACHARACTERS else char for char in value)
+
+    def _escape_glob_pattern(self, value: str) -> str:
+        """Escapes characters that would otherwise be parsed as Redis key glob syntax."""
+        return "".join(f"\\{char}" if char in self.GLOB_METACHARACTERS else char for char in value)
 
     def _generate_key(self, vector_id: str, namespace: str | None = None) -> str:
         """Generates a Redis key using the provided vector ID and optionally a namespace."""

--- a/tests/unit/drivers/vector/test_redis_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_redis_vector_store_driver.py
@@ -117,3 +117,42 @@ class TestRedisVectorStorageDriver:
         assert results[0].score == 0.456198036671
         assert results[0].meta == {"foo": "bar"}
         assert results[0].vector == [1.0, 2.0, 3.0]
+
+    @pytest.mark.parametrize(
+        "namespace",
+        ["some_namespace", "tenant-a", "a.b.c", "9f3c-4d1e-88ab", "user 12", "ns:sub"],
+    )
+    def test_query_vector_leaves_ordinary_namespaces_intact(self, driver, mock_search, namespace):
+        driver.query_vector([0.0, 0.5], namespace=namespace)
+
+        assert mock_search.call_args[0][0].query_string().startswith(f"(@namespace:{{{namespace}}})")
+
+    @pytest.mark.parametrize(
+        ("namespace", "expected"),
+        [
+            ("tenant-a|tenant-b", "(@namespace:{tenant-a\\|tenant-b})"),
+            ("x} | (@namespace:{y}", "(@namespace:{x\\} \\| (@namespace:\\{y\\}})"),
+            ("a\\|b", "(@namespace:{a\\\\\\|b})"),
+        ],
+    )
+    def test_query_vector_escapes_namespace_tag_metacharacters(self, driver, mock_search, namespace, expected):
+        driver.query_vector([0.0, 0.5], namespace=namespace)
+
+        assert mock_search.call_args[0][0].query_string().startswith(expected)
+
+    @pytest.mark.parametrize(
+        ("namespace", "expected"),
+        [
+            ("some_namespace", "some_namespace:*"),
+            ("tenant-a", "tenant-a:*"),
+            ("tenant*", "tenant\\*:*"),
+            ("tenant[ab]", "tenant\\[ab\\]:*"),
+            ("tenant?", "tenant\\?:*"),
+        ],
+    )
+    def test_load_entries_escapes_namespace_glob_metacharacters(
+        self, driver, mock_keys, mock_hgetall, namespace, expected
+    ):
+        driver.load_entries(namespace=namespace)
+
+        mock_keys.assert_called_once_with(expected)


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

Escape the characters that alter RediSearch TAG query and Redis key glob structure before interpolating `namespace`, so a namespace cannot widen a filter beyond its own tag.

## Issue ticket number and link
