### PR TITLE
fix(tools-mcp): use removeprefix for MCP image/audio MIME subtypes

### DIFF
--- a/griptape/tools/mcp/tool.py
+++ b/griptape/tools/mcp/tool.py
@@ -249,10 +249,14 @@ class MCPTool(BaseTool):
                 response_artifacts.append(TextArtifact(content.text))
             elif isinstance(content, types.ImageContent):
                 response_artifacts.append(
-                    ImageArtifact(value=content.data, format=content.mime_type.lstrip("image/"), width=0, height=0)
+                    ImageArtifact(
+                        value=content.data, format=content.mime_type.removeprefix("image/"), width=0, height=0
+                    )
                 )
             elif isinstance(content, types.AudioContent):
-                response_artifacts.append(AudioArtifact(value=content.data, format=content.mime_type.lstrip("audio/")))
+                response_artifacts.append(
+                    AudioArtifact(value=content.data, format=content.mime_type.removeprefix("audio/"))
+                )
             elif isinstance(content, types.EmbeddedResource):
                 if isinstance(content.resource, types.TextResourceContents):
                     response_artifacts.append(TextArtifact(content.resource.text))

--- a/tests/unit/tools/test_mcp_tool.py
+++ b/tests/unit/tools/test_mcp_tool.py
@@ -14,7 +14,7 @@ from mcp.server.lowlevel import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.shared.memory import create_client_server_memory_streams
 
-from griptape.artifacts import ErrorArtifact, ListArtifact, TextArtifact
+from griptape.artifacts import AudioArtifact, ErrorArtifact, ImageArtifact, ListArtifact, TextArtifact
 from griptape.tools.mcp.sessions import create_session
 from griptape.tools.mcp.tool import MCPTool
 
@@ -111,6 +111,23 @@ class TestMCPTool:
 
         assert isinstance(artifact, ListArtifact)
         assert artifact.value == []
+
+    @pytest.mark.parametrize(
+        ("content", "artifact_type", "expected_format"),
+        [
+            ({"type": "image", "data": "aGk=", "mimeType": "image/gif"}, ImageArtifact, "gif"),
+            ({"type": "image", "data": "aGk=", "mimeType": "image/apng"}, ImageArtifact, "apng"),
+            ({"type": "image", "data": "aGk=", "mimeType": "image/png"}, ImageArtifact, "png"),
+            ({"type": "audio", "data": "aGk=", "mimeType": "audio/aac"}, AudioArtifact, "aac"),
+            ({"type": "audio", "data": "aGk=", "mimeType": "audio/wav"}, AudioArtifact, "wav"),
+        ],
+    )
+    def test_media_subtype_removes_only_the_media_prefix(self, tool, content, artifact_type, expected_format):
+        """Keep subtype characters that overlap a MIME prefix."""
+        artifact = tool._convert_call_tool_result_to_artifact(call_tool_result(content=[content]))
+
+        assert isinstance(artifact.value[0], artifact_type)
+        assert artifact.value[0].format == expected_format
 
 
 SERVER_TOOLS = [


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

> One caveat on that box, stated plainly: CONTRIBUTING.md says "Pull requests should be associated with a previously accepted issue." The linked issue below was filed shortly before this PR and, at the time of writing, has **not** been triaged by a maintainer. If you would rather accept the issue first and leave this stale until then, or convert it to a Discussion, that is fine — please just say which and I will follow it.

## Describe your changes

### The symptom

If an MCP server hands back an image or audio block whose MIME subtype starts with a letter that also appears in the `image/` or `audio/` prefix, the artifact's `format` is silently mangled:

| MIME type from the MCP server | `format` you get today | `format` you should get |
| --- | --- | --- |
| `image/gif` | `'f'` | `'gif'` |
| `image/apng` | `'png'` | `'apng'` |
| `audio/aac` | `'c'` | `'aac'` |
| `image/png` | `'png'` | `'png'` (unaffected) |
| `audio/wav` | `'wav'` | `'wav'` (unaffected) |

The `image/apng` row is the nastiest: the result is a plausible-looking but wrong format rather than an obviously broken one. The common types (`image/png`, `image/jpeg`, `audio/wav`, `audio/mpeg`) happen to survive intact, which is presumably why this has not been noticed.

Anything downstream that branches on `ImageArtifact.format` or `AudioArtifact.format` — file naming, MIME reconstruction, provider uploads — receives the corrupted value.

### The root cause

`griptape/tools/mcp/tool.py`, lines 250-255 at `e825448bee212745aa58aa09f628caa5f8a0f9ef`:

```python
elif isinstance(content, types.ImageContent):
    response_artifacts.append(
        ImageArtifact(value=content.data, format=content.mime_type.lstrip("image/"), width=0, height=0)
    )
elif isinstance(content, types.AudioContent):
    response_artifacts.append(AudioArtifact(value=content.data, format=content.mime_type.lstrip("audio/")))
```

`str.lstrip` takes a **set of characters**, not a prefix. It strips any leading character in `{i, m, a, g, e, /}` (or `{a, u, d, i, o, /}`), so it runs past the `/` and eats into the subtype:

```
'image/gif'    lstrip -> 'f'      removeprefix -> 'gif'
'image/apng'   lstrip -> 'png'    removeprefix -> 'apng'
'image/png'    lstrip -> 'png'    removeprefix -> 'png'
'audio/aac'    lstrip -> 'c'      removeprefix -> 'aac'
'audio/wav'    lstrip -> 'wav'    removeprefix -> 'wav'
```

### What this change does

Replaces both calls with `str.removeprefix`, which removes exactly one literal prefix and leaves the string untouched when the prefix is absent. Behaviour for non-overlapping subtypes is byte-identical. `removeprefix` is available on every supported interpreter (`requires-python = ">=3.10, <4"`, `pyproject.toml:6`).

Full diff: **2 files changed, 24 insertions(+), 3 deletions(-)** — one source file and one test file.

### The one trade-off worth a reviewer's attention

Both call sites are re-wrapped onto multiple lines, which makes the source diff look larger than a two-token change. That is forced, not cosmetic. Measured at the base commit:

```
252: 115 chars   ->  121 chars with removeprefix
255: 119 chars   ->  125 chars with removeprefix
```

against `line-length = 120` (`pyproject.toml:220`). The wrapping is exactly what `ruff format` produces; `ruff format --check` reports both files already formatted after the change. If you would rather take the overflow and add a `# noqa`, say so and I will change it.

## Issue ticket number and link

Closes #2332 (https://github.com/griptape-ai/griptape/issues/2332)

## Testing

Python 3.12.12, ruff 0.16.6, run from a clean checkout of this branch on top of `e825448`.

**Targeted unit tests** — 15 passed on the base commit, 20 on this branch (5 new parameterized cases):

```
$ .venv/bin/python -m pytest -q tests/unit/tools/test_mcp_tool.py
....................                                                     [100%]
20 passed in 1.12s
```

**Revert proof.** Restoring *only* `griptape/tools/mcp/tool.py` to its state at `e825448` while keeping the new test:

```
$ git checkout e825448 -- griptape/tools/mcp/tool.py
$ .venv/bin/python -m pytest -q tests/unit/tools/test_mcp_tool.py
E       AssertionError: assert 'c' == 'aac'
E         
E         - aac
E         + c

tests/unit/tools/test_mcp_tool.py:130: AssertionError
=========================== short test summary info ============================
FAILED tests/unit/tools/test_mcp_tool.py::TestMCPTool::test_media_subtype_removes_only_the_media_prefix[content0-ImageArtifact-gif]
FAILED tests/unit/tools/test_mcp_tool.py::TestMCPTool::test_media_subtype_removes_only_the_media_prefix[content1-ImageArtifact-apng]
FAILED tests/unit/tools/test_mcp_tool.py::TestMCPTool::test_media_subtype_removes_only_the_media_prefix[content3-AudioArtifact-aac]
3 failed, 17 passed in 0.87s
```

Restoring the fix returns it to `20 passed in 0.73s`.

Being precise about what those 5 new nodes are: **3 of them are regression tests** (`image/gif`, `image/apng`, `audio/aac`) — they fail against the unpatched source, as shown above. The other **2 (`image/png`, `audio/wav`) pass with or without the fix**. They are not regression tests; they are guards that pin the behaviour this change must *not* alter. I am listing them separately rather than counting all 5 as proof of the fix.

**End-to-end symptom check**, same script as in the linked issue, run on both refs:

```
### base e825448
ImageArtifact.format = 'f'
ImageArtifact.format = 'png'
AudioArtifact.format = 'c'
ImageArtifact.format = 'png'

### this branch
ImageArtifact.format = 'gif'
ImageArtifact.format = 'apng'
AudioArtifact.format = 'aac'
ImageArtifact.format = 'png'
```

**Formatting:**

```
$ .venv/bin/ruff format --check griptape/tools/mcp/tool.py tests/unit/tools/test_mcp_tool.py
2 files already formatted
```

**Lint** — 2 findings, both `CPY001`, and the base commit reports the same 2 for the same 2 files. No new findings:

```
$ .venv/bin/ruff check griptape/tools/mcp/tool.py tests/unit/tools/test_mcp_tool.py
CPY001 Missing copyright notice at top of file
--> griptape/tools/mcp/tool.py:1:1

CPY001 Missing copyright notice at top of file
--> tests/unit/tools/test_mcp_tool.py:1:1

Found 2 errors.
```

**Whitespace:** `git diff --check e825448` is clean (exit 0).

**Full unit suite**, to show nothing else moved. `--continue-on-collection-errors` is needed in my environment because 29 test modules fail to import for lack of optional extras (`boto3`, `pypdf`, and similar), which would otherwise abort the run before a single test executed:

```
$ .venv/bin/python -m pytest -q --continue-on-collection-errors tests/unit
this branch : 82 failed, 3234 passed, 1 skipped, 32 warnings, 248 errors
base e825448: 82 failed, 3229 passed, 1 skipped, 32 warnings, 248 errors
```

(Wall-clock times are omitted from those two lines because they swing with machine load and prove nothing.)

Those 82 failures and 248 errors are pre-existing on `e825448` in my environment (missing optional extras), not caused by this branch. To prove nothing was traded, I sorted the `FAILED`/`ERROR` node-id lines from both runs — 330 lines each — and diffed them: **identical**. The only delta is +5 passing nodes, which are the 5 new test cases.

## What was not verified

Stated plainly, because understating is safer than overstating:

- **No live MCP server.** The transport was not exercised. The test and the repro call `MCPTool._convert_call_tool_result_to_artifact` directly on a `CallToolResult`, using the existing `MCPTool.__new__(MCPTool)` fixture already present in `tests/unit/tools/test_mcp_tool.py` (which skips `__attrs_post_init__` precisely because it would open a server session).
- **`make check` was run, but with drifting tool versions.** All four legs — `check/format`, `check/lint`, `check/types` (pyright), `check/spell` (typos) — were run repo-wide on `e825448` and on this branch. Each of the four outputs is **byte-identical between the two refs**:

  ```
                        base e825448                                   this branch
  pyright               189 errors, 5 warnings, 0 informations         identical
  typos                 exit 0                                         identical
  ruff format --check   55 files would be reformatted, 1271 already    identical
  ruff check            Found 1236 errors.                             identical
  ```

  Those absolute counts are large because my local tools are newer than the versions `uv.lock` pins (ruff 0.16.6 vs 0.15.15, pyright 1.1.413 vs 1.1.410, typos 1.50.1 vs 1.47.0), so they are **not** what CI will report — the pre-existing findings are an artifact of that drift. The load-bearing part is the base-to-branch delta, which is zero, and neither file this PR touches is in the 55-file "would reformat" set. `make check/format` also runs `mdformat --check .github/ docs/`; `mdformat` is not installed here, but this branch touches neither directory.
- **One interpreter, one OS.** Python 3.12.12 on macOS only. The `>=3.10, <4` matrix and Windows were not exercised. `str.removeprefix` is 3.9+, so I do not expect version sensitivity, but I did not run it.
- **The full unit suite is not green to begin with** in this environment, so "no regressions" here means "the failure set is byte-identical to base", not "everything passes".
- **No integration tests.** `make test/integration` runs `tests/integration/test_code_blocks.py`, which executes documentation code blocks and needs live provider credentials. Not run.
