### PR TITLE
chore: enable Ruff PLW1641 rule

### DIFF
--- a/griptape/artifacts/boolean_artifact.py
+++ b/griptape/artifacts/boolean_artifact.py
@@ -34,5 +34,7 @@ class BooleanArtifact(BaseArtifact):
     def __eq__(self, value: object) -> bool:
         return self.value == value
 
+    __hash__ = None
+
     def to_text(self) -> str:
         return str(self.value).lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,6 @@ ignore = [
   "SLF001", # private-member-access
   "EM102",  # f-string-in-exception
   "PLC0415", # import-outside-top-level
-  "PLW1641", # eq-without-hash
   "A003",   # builtin-attribute-shadowing
   "FBT001", # boolean-typed-positional-argument
 ]

--- a/tests/utils/expected_spans.py
+++ b/tests/utils/expected_spans.py
@@ -84,3 +84,5 @@ class ExpectedSpans:
                 )
 
         return True
+
+    __hash__ = None


### PR DESCRIPTION
Fixes #995

## Summary

- Remove PLW1641 (eq-without-hash) from the Ruff ignore list.
- Explicitly set BooleanArtifact.__hash__ to None, matching its existing unhashable behavior and the behavior of other Artifact subclasses.
- Keep the change scoped to one Ruff rule, following the maintainer preference in #995.

## Validation

- Ruff passes.
- Pyright passes.
- All 81 relevant unit tests pass.