### PR TITLE
feat(drivers-vector-store): support regular inserts in BaseVectorStoreDriver

### DIFF
--- a/griptape/drivers/vector/base_vector_store_driver.py
+++ b/griptape/drivers/vector/base_vector_store_driver.py
@@ -74,7 +74,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         **kwargs,
     ) -> str:
         warnings.warn(
-            "`BaseVectorStoreDriver.upsert_text` is deprecated and will be removed in a future release. `BaseVectorStoreDriver.upsert` is a drop-in replacement.",
+            "`BaseVectorStoreDriver.upsert_text_artifacts` is deprecated and will be removed in a future release. `BaseVectorStoreDriver.upsert` is a drop-in replacement.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -138,6 +138,7 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         namespace: str | None = None,
         meta: dict | None = None,
         vector_id: str | None = None,
+        insert: bool = False,
         **kwargs,
     ) -> str:
         artifact = TextArtifact(value) if isinstance(value, str) else value
@@ -145,8 +146,15 @@ class BaseVectorStoreDriver(SerializableMixin, FuturesExecutorMixin, ABC):
         meta = {} if meta is None else meta
 
         if vector_id is None:
-            value = artifact.to_text() if artifact.reference is None else artifact.to_text() + str(artifact.reference)
-            vector_id = self._get_default_vector_id(value)
+            if insert:
+                # Bypass the content-hash dedup below so re-adding the same text creates a new entry
+                # instead of overwriting the prior one.
+                vector_id = str(uuid.uuid4())
+            else:
+                value = (
+                    artifact.to_text() if artifact.reference is None else artifact.to_text() + str(artifact.reference)
+                )
+                vector_id = self._get_default_vector_id(value)
 
         meta = {**meta, "artifact": artifact.to_json()}
 

--- a/tests/unit/drivers/vector/test_base_vector_store_driver.py
+++ b/tests/unit/drivers/vector/test_base_vector_store_driver.py
@@ -26,6 +26,13 @@ class TestBaseVectorStoreDriver(ABC):
 
         assert len(driver.entries) == 2
 
+    def test_upsert_insert(self, driver):
+        id1 = driver.upsert(TextArtifact(value="foobar"), insert=True)
+        id2 = driver.upsert(TextArtifact(value="foobar"), insert=True)
+
+        assert id1 != id2
+        assert len(driver.entries) == 2
+
     def test_upsert_multiple(self, driver):
         driver.upsert_collection({"foo": [TextArtifact("foo")], "bar": [TextArtifact("bar")]})
 


### PR DESCRIPTION
- [x] I have read and agree to the [contributing guidelines](https://github.com/griptape-ai/griptape/blob/main/CONTRIBUTING.md).

## Describe your changes

Adds an `insert: bool = False` keyword argument to `BaseVectorStoreDriver.upsert()`. When enabled without an explicit `vector_id`, it generates a fresh `uuid4()` identifier instead of the deterministic content hash, allowing identical text to be inserted without overwriting the earlier entry.

The option works through `upsert_collection()` and concrete drivers through existing keyword forwarding. A shared `test_upsert_insert` test covers the new behavior; the full vector-driver suite passes (1,022 tests).

## Issue ticket number and link

Fixes #50